### PR TITLE
Removed tifffile as dependency, using skimage.external.tifffile instead

### DIFF
--- a/deepcell/running.py
+++ b/deepcell/running.py
@@ -13,7 +13,7 @@ import os
 import warnings
 
 import numpy as np
-import tifffile as tiff
+from skimage.external import tifffile as tiff
 from tensorflow.python.keras import backend as K
 
 from .utils.io_utils import get_images_from_directory

--- a/deepcell/training.py
+++ b/deepcell/training.py
@@ -13,7 +13,7 @@ import datetime
 import os
 
 import numpy as np
-import tifffile as tiff
+from skimage.external import tifffile as tiff
 from sklearn.utils.class_weight import compute_class_weight
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.utils import to_categorical as keras_to_categorical

--- a/deepcell/utils/export_utils.py
+++ b/deepcell/utils/export_utils.py
@@ -11,9 +11,7 @@ from __future__ import division
 
 import os
 
-import tifffile as tiff
 import tensorflow as tf
-
 from tensorflow.python.keras import backend as K
 from tensorflow.python.saved_model import tag_constants
 from tensorflow.python.saved_model import signature_constants

--- a/deepcell/utils/io_utils.py
+++ b/deepcell/utils/io_utils.py
@@ -13,7 +13,7 @@ import os
 
 import numpy as np
 from skimage.io import imread
-from tifffile import TiffFile
+from skimage.external.tifffile import TiffFile
 from tensorflow.python.keras import backend as K
 
 from .misc_utils import sorted_nicely

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ scikit-image>=0.13.1,<1
 scikit-learn>=0.19.1,<1
 scipy>=1.1.0,<2
 tensorflow-gpu>=1.8.0,<2
-tifffile>=0.14.0,<1


### PR DESCRIPTION
tifffile is a part of skimage.external.  This PR removes the dependency on tifffile explicitly and instead uses skimage.external.tifffile instead. Ultimately reduces dependencies, sticking to the typical python data science stack.