### PR TITLE
removed pytest tests in favor of tf.python.platform.test

### DIFF
--- a/tests/deepcell/utils/io_utils_test.py
+++ b/tests/deepcell/utils/io_utils_test.py
@@ -1,9 +1,16 @@
+"""
+Tests for io_utils
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import os
 import shutil
 
-import pytest
 import numpy as np
 from skimage.io import imread
+from tensorflow.python.platform import test
 
 from deepcell.utils.io_utils import get_immediate_subdirs
 from deepcell.utils.io_utils import get_image
@@ -15,48 +22,50 @@ TEST_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 RES_DIR = os.path.join(TEST_DIR, 'resources')
 TEST_IMG = imread(os.path.join(RES_DIR, 'phase.tif'))
 
-def test_get_immediate_subdirs():
-    dirs = []
-    tmp_dir = os.path.join(RES_DIR, 'tmp')
-    for x in range(2, -1, -1): # iterate backwards to test sorting
-        sub_dir = os.path.join(tmp_dir, str(x))
-        try:
-            os.makedirs(sub_dir)
-        except OSError as err:
-            if err.errno != os.errno.EEXIST:
-                raise
-        dirs.append(str(x))
+class TestIOUtils(test.TestCase):
 
-    assert get_immediate_subdirs(tmp_dir) == list(reversed(dirs))
-    shutil.rmtree(tmp_dir)
-    # now tmp_dir is removed, so RES_DIR should have no subdirs
-    assert get_immediate_subdirs(RES_DIR) == []
+    def test_get_immediate_subdirs(self):
+        dirs = []
+        tmp_dir = os.path.join(RES_DIR, 'tmp')
+        for x in range(2, -1, -1): # iterate backwards to test sorting
+            sub_dir = os.path.join(tmp_dir, str(x))
+            try:
+                os.makedirs(sub_dir)
+            except OSError as err:
+                if err.errno != os.errno.EEXIST:
+                    raise
+            dirs.append(str(x))
 
-def test_get_image():
-    test_img_path = os.path.join(RES_DIR, 'phase.tif')
-    test_img = get_image(test_img_path)
-    assert np.asarray(test_img).shape == (300, 300)
+        assert get_immediate_subdirs(tmp_dir) == list(reversed(dirs))
+        shutil.rmtree(tmp_dir)
+        # now tmp_dir is removed, so RES_DIR should have no subdirs
+        assert get_immediate_subdirs(RES_DIR) == []
 
-def test_nikon_getfiles():
-    images = nikon_getfiles(RES_DIR, 'phase')
-    assert images == ['phase.tif']
-    rotated_images = nikon_getfiles(RES_DIR, 'rotated')
-    assert rotated_images == ['rotated_90.tif', 'rotated_180.tif', 'rotated_270.tif']
-    no_images = nikon_getfiles(RES_DIR, 'bad_channel_name')
-    assert no_images == []
+    def test_get_image(self):
+        test_img_path = os.path.join(RES_DIR, 'phase.tif')
+        test_img = get_image(test_img_path)
+        assert np.asarray(test_img).shape == (300, 300)
 
-def test_get_image_sizes():
-    # test with single channel name
-    size = get_image_sizes(RES_DIR, ['phase'])
-    assert size == (300, 300)
-    # test with multiple channel names
-    sizes = get_image_sizes(RES_DIR, ['phase', 'rotated'])
-    assert sizes == (300, 300)
+    def test_nikon_getfiles(self):
+        images = nikon_getfiles(RES_DIR, 'phase')
+        assert images == ['phase.tif']
+        rotated_images = nikon_getfiles(RES_DIR, 'rotated')
+        assert rotated_images == ['rotated_90.tif', 'rotated_180.tif', 'rotated_270.tif']
+        no_images = nikon_getfiles(RES_DIR, 'bad_channel_name')
+        assert no_images == []
 
-def test_get_images_from_directory():
-    img = get_images_from_directory(RES_DIR, ['phase'])
-    assert isinstance(img, list) and len(img) == 1
-    assert img[0].shape == (1, 300, 300, 1)
+    def test_get_image_sizes(self):
+        # test with single channel name
+        size = get_image_sizes(RES_DIR, ['phase'])
+        assert size == (300, 300)
+        # test with multiple channel names
+        sizes = get_image_sizes(RES_DIR, ['phase', 'rotated'])
+        assert sizes == (300, 300)
+
+    def test_get_images_from_directory(self):
+        img = get_images_from_directory(RES_DIR, ['phase'])
+        assert isinstance(img, list) and len(img) == 1
+        assert img[0].shape == (1, 300, 300, 1)
 
 if __name__ == '__main__':
-    pytest.main([__file__])
+    test.main()

--- a/tests/deepcell/utils/misc_utils_test.py
+++ b/tests/deepcell/utils/misc_utils_test.py
@@ -1,17 +1,25 @@
-import pytest
+"""
+Tests for misc_utils
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.platform import test
 
 from deepcell.utils.misc_utils import sorted_nicely
 
 
-def test_sorted_nicely():
-    # test image file sorting
-    expected = ['test_image_001_dapi', 'test_image_002_dapi', 'test_image_003_dapi']
-    unsorted = ['test_image_003_dapi', 'test_image_001_dapi', 'test_image_002_dapi']
-    assert expected == sorted_nicely(unsorted)
-    # test montage folder sorting
-    expected = ['test_image_0_0', 'test_image_1_0', 'test_image_1_1']
-    unsorted = ['test_image_1_1', 'test_image_0_0', 'test_image_1_0']
-    assert expected == sorted_nicely(unsorted)
+class MiscUtilsTest(test.TestCase):
+    def test_sorted_nicely(self):
+        # test image file sorting
+        expected = ['test_image_001_dapi', 'test_image_002_dapi', 'test_image_003_dapi']
+        unsorted = ['test_image_003_dapi', 'test_image_001_dapi', 'test_image_002_dapi']
+        assert expected == sorted_nicely(unsorted)
+        # test montage folder sorting
+        expected = ['test_image_0_0', 'test_image_1_0', 'test_image_1_1']
+        unsorted = ['test_image_1_1', 'test_image_0_0', 'test_image_1_0']
+        assert expected == sorted_nicely(unsorted)
 
 if __name__ == '__main__':
-    pytest.main([__file__])
+    test.main()

--- a/tests/deepcell/utils/plot_utils_test.py
+++ b/tests/deepcell/utils/plot_utils_test.py
@@ -1,7 +1,14 @@
+"""
+Tests for io_utils
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import os
 
-import pytest
 from skimage.io import imread
+from tensorflow.python.platform import test
 
 from deepcell.utils.plot_utils import cf
 
@@ -9,14 +16,15 @@ TEST_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 RES_DIR = os.path.join(TEST_DIR, 'resources')
 TEST_IMG = imread(os.path.join(RES_DIR, 'phase.tif'))
 
-def test_cf():
-    # values are hard-coded for test image
-    shape = TEST_IMG.shape
-    # test coordinates outside of test_img dimensions
-    assert cf(shape[0] + 1, shape[1] + 1, TEST_IMG) == 'x=301.0000, y=301.0000'
-    assert cf(-1 * shape[0], -1 * shape[1], TEST_IMG) == 'x=-300.0000, y=-300.0000'
-    # test coordinates inside test_img dimensions
-    assert cf(shape[0] / 2, shape[1] / 2, TEST_IMG) == 'x=150.0000, y=150.0000, z=7771.0000'
+class PlotUtilsTest(test.TestCase):
+    def test_cf(self):
+        # values are hard-coded for test image
+        shape = TEST_IMG.shape
+        # test coordinates outside of test_img dimensions
+        assert cf(shape[0] + 1, shape[1] + 1, TEST_IMG) == 'x=301.0000, y=301.0000'
+        assert cf(-1 * shape[0], -1 * shape[1], TEST_IMG) == 'x=-300.0000, y=-300.0000'
+        # test coordinates inside test_img dimensions
+        assert cf(shape[0] / 2, shape[1] / 2, TEST_IMG) == 'x=150.0000, y=150.0000, z=7771.0000'
 
 if __name__ == '__main__':
-    pytest.main([__file__])
+    test.main()

--- a/tests/deepcell/utils/train_utils_test.py
+++ b/tests/deepcell/utils/train_utils_test.py
@@ -1,10 +1,16 @@
+"""
+Tests for train_utils
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import os
 
-import pytest
 import numpy as np
 from skimage.io import imread
 from tensorflow.python import keras
-from tensorflow.python.platform.test import TestCase
+from tensorflow.python.platform import test
 
 from deepcell.utils.train_utils import axis_softmax
 
@@ -12,38 +18,37 @@ TEST_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 RES_DIR = os.path.join(TEST_DIR, 'resources')
 TEST_IMG = imread(os.path.join(RES_DIR, 'phase.tif'))
 
-def test_axis_softmax():
-    """
-    Adapted from the Tensorflow test for the softmax layer.
-    """
+class TrainUtilsTest(test.TestCase):
+    def test_axis_softmax(self):
+        """
+        Adapted from the Tensorflow test for the softmax layer.
+        """
 
-    def _ref_softmax(values):
-        m = np.max(values)
-        e = np.exp(values - m)
-        return e / np.sum(e)
+        def _ref_softmax(values):
+            m = np.max(values)
+            e = np.exp(values - m)
+            return e / np.sum(e)
 
-    test_case = TestCase()
+        with self.test_session():
+            x = keras.backend.placeholder(ndim=2)
+            f = keras.backend.function([x], [keras.activations.softmax(x)])
+            test_values = np.random.random((2, 5))
 
-    with test_case.test_session():
-        x = keras.backend.placeholder(ndim=2)
-        f = keras.backend.function([x], [keras.activations.softmax(x)])
-        test_values = np.random.random((2, 5))
+            result = f([test_values])[0]
+        expected = _ref_softmax(test_values[0])
+        self.assertAllClose(result[0], expected, rtol=1e-05)
 
-        result = f([test_values])[0]
-    expected = _ref_softmax(test_values[0])
-    test_case.assertAllClose(result[0], expected, rtol=1e-05)
+        with self.assertRaises(ValueError):
+            x = keras.backend.placeholder(ndim=1)
+            keras.activations.softmax(x)
 
-    with test_case.assertRaises(ValueError):
-        x = keras.backend.placeholder(ndim=1)
-        keras.activations.softmax(x)
-
-    # Testing that the axis_softmax function fails when passed a NumPy array.
-    with pytest.raises(AttributeError) as e_info:
-        axis_softmax(TEST_IMG, 0)
-    with pytest.raises(AttributeError) as e_info:
-        axis_softmax(TEST_IMG, 1)
-    with pytest.raises(AttributeError) as e_info:
-        axis_softmax(TEST_IMG)
+        # Testing that the axis_softmax function fails when passed a NumPy array.
+        with self.assertRaises(AttributeError):
+            axis_softmax(TEST_IMG, 0)
+        with self.assertRaises(AttributeError):
+            axis_softmax(TEST_IMG, 1)
+        with self.assertRaises(AttributeError):
+            axis_softmax(TEST_IMG)
 
 if __name__ == '__main__':
-    pytest.main([__file__])
+    test.main()

--- a/tests/deepcell/utils/transform_utils_test.py
+++ b/tests/deepcell/utils/transform_utils_test.py
@@ -1,11 +1,16 @@
+"""
+Tests for transform_utils
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import os
 
-import pytest
 import numpy as np
 import numpy.testing as np_test
 from skimage.io import imread
-from tensorflow.python import keras
-from tensorflow.python.platform.test import TestCase
+from tensorflow.python.platform import test
 
 from deepcell.utils.transform_utils import to_categorical
 from deepcell.utils.transform_utils import rotate_array_0
@@ -22,49 +27,50 @@ TEST_IMG_90 = imread(os.path.join(RES_DIR, 'rotated_90.tif'))
 TEST_IMG_180 = imread(os.path.join(RES_DIR, 'rotated_180.tif'))
 TEST_IMG_270 = imread(os.path.join(RES_DIR, 'rotated_270.tif'))
 
-def test_to_categorical():
-    num_classes = 5
-    shapes = [(1,), (3,), (4, 3), (5, 4, 3), (3, 1), (3, 2, 1)]
-    expected_shapes = [(1, num_classes),
-                       (3, num_classes),
-                       (12, num_classes),
-                       (60, num_classes),
-                       (3, num_classes),
-                       (6, num_classes)]
-    labels = [np.random.randint(0, num_classes, shape) for shape in shapes]
-    one_hots = [to_categorical(label, num_classes) for label in labels]
-    for label, one_hot, expected_shape in zip(labels, one_hots, expected_shapes):
-        # Check shape
-        assert one_hot.shape == expected_shape
-        # Make sure there are only 0s and 1s
-        assert np.array_equal(one_hot, one_hot.astype(bool))
-        # Make sure there is exactly one 1 in a row
-        assert np.all(one_hot.sum(axis=-1) == 1)
-        # Get original labels back from one hots
-        assert np.all(np.argmax(one_hot, -1).reshape(label.shape) == label)
+class TransformUtilsTest(test.TestCase):
+    def test_to_categorical(self):
+        num_classes = 5
+        shapes = [(1,), (3,), (4, 3), (5, 4, 3), (3, 1), (3, 2, 1)]
+        expected_shapes = [(1, num_classes),
+                           (3, num_classes),
+                           (12, num_classes),
+                           (60, num_classes),
+                           (3, num_classes),
+                           (6, num_classes)]
+        labels = [np.random.randint(0, num_classes, shape) for shape in shapes]
+        one_hots = [to_categorical(label, num_classes) for label in labels]
+        for label, one_hot, expected_shape in zip(labels, one_hots, expected_shapes):
+            # Check shape
+            assert one_hot.shape == expected_shape
+            # Make sure there are only 0s and 1s
+            assert np.array_equal(one_hot, one_hot.astype(bool))
+            # Make sure there is exactly one 1 in a row
+            assert np.all(one_hot.sum(axis=-1) == 1)
+            # Get original labels back from one hots
+            assert np.all(np.argmax(one_hot, -1).reshape(label.shape) == label)
 
 
-def test_rotate_array_0():
-    unrotated_image = rotate_array_0(TEST_IMG)
-    np_test.assert_array_equal(unrotated_image, TEST_IMG)
+    def test_rotate_array_0(self):
+        unrotated_image = rotate_array_0(TEST_IMG)
+        np_test.assert_array_equal(unrotated_image, TEST_IMG)
 
-# def test_rotate_array_90():
-#     rotated_image = rotate_array_90(TEST_IMG)
-#     np_test.assert_array_equal(rotated_image, TEST_IMG_90)
-#
-# def test_rotate_array_180():
-#     rotated_image = rotate_array_180(TEST_IMG)
-#     np_test.assert_array_equal(rotated_image, TEST_IMG_180)
-#
-# def test_rotate_array_270():
-#     rotated_image = rotate_array_270(TEST_IMG)
-#     np_test.assert_array_equal(rotated_image, TEST_IMG_270)
+    # def test_rotate_array_90(self):
+    #     rotated_image = rotate_array_90(TEST_IMG)
+    #     np_test.assert_array_equal(rotated_image, TEST_IMG_90)
+    #
+    # def test_rotate_array_180(self):
+    #     rotated_image = rotate_array_180(TEST_IMG)
+    #     np_test.assert_array_equal(rotated_image, TEST_IMG_180)
+    #
+    # def test_rotate_array_270(self):
+    #     rotated_image = rotate_array_270(TEST_IMG)
+    #     np_test.assert_array_equal(rotated_image, TEST_IMG_270)
 
-def test_rotate_array_90_and_180():
-    rotated_image1 = rotate_array_90(TEST_IMG)
-    rotated_image1 = rotate_array_90(rotated_image1)
-    rotated_image2 = rotate_array_180(TEST_IMG)
-    np_test.assert_array_equal(rotated_image1, rotated_image2)
+    def test_rotate_array_90_and_180(self):
+        rotated_image1 = rotate_array_90(TEST_IMG)
+        rotated_image1 = rotate_array_90(rotated_image1)
+        rotated_image2 = rotate_array_180(TEST_IMG)
+        np_test.assert_array_equal(rotated_image1, rotated_image2)
 
 if __name__ == '__main__':
-    pytest.main([__file__])
+    test.main()


### PR DESCRIPTION
Changed format of tests in tests/deepcell/utils to use the tensorflow.python.platform.test framework rather than using vanilla pytest.  Hopefully this will also eliminate the pytest dependency, though I am not sure how to run these tests without pytest.

TF testing provides a more consistent testing framework across all files.