### PR TITLE
pinned tensorflow-gpu package to version 1.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scikit-image>=0.13.1,<1
 scikit-learn>=0.19.1,<1
 scipy>=1.1.0,<2
-tensorflow-gpu>=1.8.0,<2
+tensorflow-gpu==1.8.0


### PR DESCRIPTION
`tensorflow-gpu` 1.9.0 was giving weird errors (see branch `_impl-deprecated` for some preliminary work in this vein), so we're just going to use 1.8.0 for the foreseeable future.