### PR TITLE
Automatically close stale issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,31 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before a stale Issue or Pull Request is closed
+daysUntilClose: 30
+
+# Issues or Pull Requests with these labels will never be considered stale
+exemptLabels:
+  - bug
+  - Announcement
+  - help wanted
+  - To investigate
+  - pinned
+  - security
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed after 30 days if no further activity 
+  occurs, but feel free to re-open a closed issue if needed.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
Stalebot will automatically mark 3-month-old issues as stale.  If there is no further activity for 30 more days, the issue will be automatically closed. 