### PR TITLE
enable training on multiple GPUs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,6 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/* && \
     /usr/local/bin/pip install --upgrade pip
 
-# Install Mask R-CNN
-RUN git clone https://www.github.com/vanvalenlab/Mask_RCNN /opt/Mask_RCNN && \
-    cd /opt/Mask_RCNN && \
-    pip install -r requirements.txt && \
-    python setup.py install
-
 # Set working directory
 WORKDIR /deepcell-tf
 

--- a/deepcell/layers/padding.py
+++ b/deepcell/layers/padding.py
@@ -42,63 +42,145 @@ except ImportError:
 
 class ReflectionPadding2D(Layer):
     def __init__(self, padding=(1, 1), data_format=None, **kwargs):
-        self.padding = conv_utils.normalize_tuple(padding, 2, 'padding')
-        self.input_spec = [InputSpec(ndim=4)]
-        self.data_format = conv_utils.normalize_data_format(data_format)
+        # self.padding = conv_utils.normalize_tuple(padding, 2, 'padding')
+        # self.input_spec = [InputSpec(ndim=4)]
+        # self.data_format = conv_utils.normalize_data_format(data_format)
         super(ReflectionPadding2D, self).__init__(**kwargs)
+        self.data_format = conv_utils.normalize_data_format(data_format)
+        if isinstance(padding, int):
+            self.padding = ((padding, padding), (padding, padding))
+        elif hasattr(padding, '__len__'):
+            if len(padding) != 2:
+                raise ValueError('`padding` should have two elements. '
+                                 'Found: ' + str(padding))
+            height_padding = conv_utils.normalize_tuple(padding[0], 2,
+                                                        '1st entry of padding')
+            width_padding = conv_utils.normalize_tuple(padding[1], 2,
+                                                       '2nd entry of padding')
+            self.padding = (height_padding, width_padding)
+        else:
+            raise ValueError('`padding` should be either an int, '
+                             'a tuple of 2 ints '
+                             '(symmetric_height_pad, symmetric_width_pad), '
+                             'or a tuple of 2 tuples of 2 ints '
+                             '((top_pad, bottom_pad), (left_pad, right_pad)). '
+                             'Found: ' + str(padding))
+        self.input_spec = [InputSpec(ndim=4)]
 
     def compute_output_shape(self, input_shape):
         input_shape = tensor_shape.TensorShape(input_shape).as_list()
         if self.data_format == 'channels_first':
-            output_shape = (input_shape[0],
-                            input_shape[1],
-                            input_shape[2] + 2 * self.padding[0],
-                            input_shape[3] + 2 * self.padding[1])
+            if input_shape[2] is not None:
+                rows = input_shape[2] + self.padding[0][0] + self.padding[0][1]
+            else:
+                rows = None
+            if input_shape[3] is not None:
+                cols = input_shape[3] + self.padding[1][0] + self.padding[1][1]
+            else:
+                cols = None
+            return tensor_shape.TensorShape(
+                [input_shape[0], input_shape[1], rows, cols])
         else:
-            output_shape = (input_shape[0],
-                            input_shape[1] + 2 * self.padding[0],
-                            input_shape[2] + 2 * self.padding[1],
-                            input_shape[3])
+            if input_shape[1] is not None:
+                rows = input_shape[1] + self.padding[0][0] + self.padding[0][1]
+            else:
+                rows = None
+            if input_shape[2] is not None:
+                cols = input_shape[2] + self.padding[1][0] + self.padding[1][1]
+            else:
+                cols = None
+            return tensor_shape.TensorShape(
+                [input_shape[0], rows, cols, input_shape[3]])
 
-        return tensor_shape.TensorShape(output_shape)
-
-    def call(self, x, mask=None):
+    def call(self, inputs):
         w_pad, h_pad = self.padding
         if self.data_format == 'channels_first':
-            paddings = [[0, 0], [0, 0], [h_pad, h_pad], [w_pad, w_pad]]
+            paddings = ((0, 0), (0, 0), h_pad, w_pad)
         else:
-            paddings = [[0, 0], [h_pad, h_pad], [w_pad, w_pad], [0, 0]]
-        return tf.pad(x, paddings, 'REFLECT')
+            paddings = ((0, 0), h_pad, w_pad, (0, 0))
+        return tf.pad(inputs, paddings, 'REFLECT')
+
+    def get_config(self):
+        config = {'padding': self.padding, 'data_format': self.data_format}
+        base_config = super(ReflectionPadding2D, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
 
 
 class ReflectionPadding3D(Layer):
     def __init__(self, padding=(1, 1, 1), data_format=None, **kwargs):
-        self.padding = conv_utils.normalize_tuple(padding, 3, 'padding')
-        self.input_spec = [InputSpec(ndim=4)]
-        self.data_format = conv_utils.normalize_data_format(data_format)
         super(ReflectionPadding3D, self).__init__(**kwargs)
+        self.data_format = conv_utils.normalize_data_format(data_format)
+        if isinstance(padding, int):
+            self.padding = ((padding, padding),
+                            (padding, padding),
+                            (padding, padding))
+
+        elif hasattr(padding, '__len__'):
+            if len(padding) != 3:
+                raise ValueError('`padding` should have 3 elements. '
+                                 'Found: ' + str(padding))
+            dim1_padding = conv_utils.normalize_tuple(padding[0], 2,
+                                                      '1st entry of padding')
+            dim2_padding = conv_utils.normalize_tuple(padding[1], 2,
+                                                      '2nd entry of padding')
+            dim3_padding = conv_utils.normalize_tuple(padding[2], 2,
+                                                      '3rd entry of padding')
+            self.padding = (dim1_padding, dim2_padding, dim3_padding)
+        else:
+            raise ValueError(
+                '`padding` should be either an int, '
+                'a tuple of 3 ints '
+                '(symmetric_dim1_pad, symmetric_dim2_pad, symmetric_dim3_pad), '
+                'or a tuple of 3 tuples of 2 ints '
+                '((left_dim1_pad, right_dim1_pad),'
+                ' (left_dim2_pad, right_dim2_pad),'
+                ' (left_dim3_pad, right_dim2_pad)). '
+                'Found: ' + str(padding))
+
+        self.input_spec = [InputSpec(ndim=5)]
 
     def compute_output_shape(self, input_shape):
         input_shape = tensor_shape.TensorShape(input_shape).as_list()
         if self.data_format == 'channels_first':
-            output_shape = (input_shape[0],
-                            input_shape[1],
-                            input_shape[2] + 2 * self.padding[0],
-                            input_shape[3] + 2 * self.padding[1],
-                            input_shape[4] + 2 * self.padding[2])
+            if input_shape[2] is not None:
+                dim1 = input_shape[2] + 2 * self.padding[0][0]
+            else:
+                dim1 = None
+            if input_shape[3] is not None:
+                dim2 = input_shape[3] + 2 * self.padding[1][0]
+            else:
+                dim2 = None
+            if input_shape[4] is not None:
+                dim3 = input_shape[4] + 2 * self.padding[2][0]
+            else:
+                dim3 = None
+            return tensor_shape.TensorShape(
+                [input_shape[0], input_shape[1], dim1, dim2, dim3])
         else:
-            output_shape = (input_shape[0],
-                            input_shape[1] + 2 * self.padding[0],
-                            input_shape[2] + 2 * self.padding[1],
-                            input_shape[3] + 2 * self.padding[2],
-                            input_shape[4])
-
-        return tensor_shape.TensorShape(output_shape)
+            if input_shape[1] is not None:
+                dim1 = input_shape[1] + 2 * self.padding[0][1]
+            else:
+                dim1 = None
+            if input_shape[2] is not None:
+                dim2 = input_shape[2] + 2 * self.padding[1][1]
+            else:
+                dim2 = None
+            if input_shape[3] is not None:
+                dim3 = input_shape[3] + 2 * self.padding[2][1]
+            else:
+                dim3 = None
+            return tensor_shape.TensorShape(
+                [input_shape[0], dim1, dim2, dim3, input_shape[4]])
 
     def call(self, x, mask=None):
         z_pad, w_pad, h_pad = self.padding
         if self.data_format == 'channels_first':
-            paddings = [[0, 0], [0, 0], [z_pad, z_pad], [h_pad, h_pad], [w_pad, w_pad]]
+            paddings = ((0, 0), (0, 0), z_pad, h_pad, w_pad)
         else:
-            paddings = [[0, 0], [z_pad, z_pad], [h_pad, h_pad], [w_pad, w_pad], [0, 0]]
+            paddings = ((0, 0), z_pad, h_pad, w_pad, (0, 0))
         return tf.pad(x, paddings, 'REFLECT')
+
+    def get_config(self):
+        config = {'padding': self.padding, 'data_format': self.data_format}
+        base_config = super(ReflectionPadding3D, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/deepcell/layers/padding.py
+++ b/deepcell/layers/padding.py
@@ -65,7 +65,7 @@ class ReflectionPadding2D(Layer):
                              'or a tuple of 2 tuples of 2 ints '
                              '((top_pad, bottom_pad), (left_pad, right_pad)). '
                              'Found: ' + str(padding))
-        self.input_spec = [InputSpec(ndim=4)]
+        self.input_spec = InputSpec(ndim=4)
 
     def compute_output_shape(self, input_shape):
         input_shape = tensor_shape.TensorShape(input_shape).as_list()
@@ -137,7 +137,7 @@ class ReflectionPadding3D(Layer):
                 ' (left_dim3_pad, right_dim2_pad)). '
                 'Found: ' + str(padding))
 
-        self.input_spec = [InputSpec(ndim=5)]
+        self.input_spec = InputSpec(ndim=5)
 
     def compute_output_shape(self, input_shape):
         input_shape = tensor_shape.TensorShape(input_shape).as_list()

--- a/deepcell/training.py
+++ b/deepcell/training.py
@@ -37,6 +37,7 @@ import numpy as np
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.callbacks import ModelCheckpoint, LearningRateScheduler
 from tensorflow.python.keras.optimizers import SGD
+from tensorflow.python.keras.utils import multi_gpu_model
 
 from deepcell import losses
 from deepcell import image_generators as generators
@@ -49,6 +50,7 @@ def train_model_sample(model,
                        expt='',
                        n_epoch=10,
                        batch_size=32,
+                       num_gpus=1,
                        transform=None,
                        window_size=None,
                        balance_classes=True,
@@ -92,6 +94,9 @@ def train_model_sample(model,
                 y_true, y_pred, gamma=gamma, n_classes=n_classes)
         return losses.weighted_categorical_crossentropy(
             y_true, y_pred, n_classes=n_classes)
+    
+    if num_gpus >= 2:
+        model = multi_gpu_model(model, num_gpus)
 
     model.compile(loss=loss_function, optimizer=optimizer, metrics=['accuracy'])
 
@@ -161,6 +166,7 @@ def train_model_conv(model,
                      expt='',
                      n_epoch=10,
                      batch_size=1,
+                     num_gpus=1,
                      frames_per_batch=5,
                      transform=None,
                      optimizer=SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True),
@@ -201,6 +207,9 @@ def train_model_conv(model,
                 y_true, y_pred, gamma=gamma, n_classes=n_classes)
         return losses.weighted_categorical_crossentropy(
             y_true, y_pred, n_classes=n_classes)
+        
+    if num_gpus >= 2:
+        model = multi_gpu_model(model, num_gpus)
 
     model.compile(loss=loss_function, optimizer=optimizer, metrics=['accuracy'])
 

--- a/deepcell/training.py
+++ b/deepcell/training.py
@@ -102,6 +102,7 @@ def train_model_sample(model,
         num_gpus = len(gpus)
 
     if num_gpus >= 2:
+        batch_size = batch_size * num_gpus
         model = multi_gpu_model(model, num_gpus)
 
     model.compile(loss=loss_function, optimizer=optimizer, metrics=['accuracy'])
@@ -220,6 +221,7 @@ def train_model_conv(model,
         num_gpus = len(gpus)
 
     if num_gpus >= 2:
+        batch_size = batch_size * num_gpus
         model = multi_gpu_model(model, num_gpus)
 
     model.compile(loss=loss_function, optimizer=optimizer, metrics=['accuracy'])

--- a/deepcell/training.py
+++ b/deepcell/training.py
@@ -34,16 +34,15 @@ import datetime
 import os
 
 import numpy as np
+from tensorflow.keras import backend as K
+from tensorflow.keras.callbacks import ModelCheckpoint, LearningRateScheduler
+from tensorflow.keras.optimizers import SGD
 from tensorflow.python.client import device_lib
-from tensorflow.python.keras import backend as K
-from tensorflow.python.keras.callbacks import ModelCheckpoint, LearningRateScheduler
-from tensorflow.python.keras.optimizers import SGD
-from tensorflow.python.keras.utils import multi_gpu_model
 
 from deepcell import losses
 from deepcell import image_generators as generators
 from deepcell.utils.data_utils import get_data
-from deepcell.utils.train_utils import rate_scheduler
+from deepcell.utils.train_utils import rate_scheduler, ModelMGPU
 
 
 def train_model_sample(model,
@@ -103,7 +102,7 @@ def train_model_sample(model,
 
     if num_gpus >= 2:
         batch_size = batch_size * num_gpus
-        model = multi_gpu_model(model, num_gpus)
+        model = ModelMGPU(model, num_gpus)
 
     print('Training on {} GPUs'.format(num_gpus))
 
@@ -224,7 +223,7 @@ def train_model_conv(model,
 
     if num_gpus >= 2:
         batch_size = batch_size * num_gpus
-        model = multi_gpu_model(model, num_gpus)
+        model = ModelMGPU(model, num_gpus)
 
     print('Training on {} GPUs'.format(num_gpus))
 

--- a/deepcell/training.py
+++ b/deepcell/training.py
@@ -105,6 +105,8 @@ def train_model_sample(model,
         batch_size = batch_size * num_gpus
         model = multi_gpu_model(model, num_gpus)
 
+    print('Training on {} GPUs'.format(num_gpus))
+
     model.compile(loss=loss_function, optimizer=optimizer, metrics=['accuracy'])
 
     if train_dict['X'].ndim == 4:
@@ -223,6 +225,8 @@ def train_model_conv(model,
     if num_gpus >= 2:
         batch_size = batch_size * num_gpus
         model = multi_gpu_model(model, num_gpus)
+
+    print('Training on {} GPUs'.format(num_gpus))
 
     model.compile(loss=loss_function, optimizer=optimizer, metrics=['accuracy'])
 

--- a/deepcell/training.py
+++ b/deepcell/training.py
@@ -160,7 +160,7 @@ def train_model_sample(model,
         validation_data=val_data,
         validation_steps=val_data.y.shape[0] // batch_size,
         callbacks=[
-            ModelCheckpoint(file_name_save, monitor='val_loss', verbose=1, save_best_only=True),
+            ModelCheckpoint(file_name_save, monitor='val_loss', verbose=1, save_best_only=True, save_weights_only=num_gpus >= 2),
             LearningRateScheduler(lr_sched)
         ])
 
@@ -296,7 +296,7 @@ def train_model_conv(model,
         validation_data=val_data,
         validation_steps=val_data.y.shape[0] // batch_size,
         callbacks=[
-            ModelCheckpoint(file_name_save, monitor='val_loss', verbose=1, save_best_only=True),
+            ModelCheckpoint(file_name_save, monitor='val_loss', verbose=1, save_best_only=True, save_weights_only=num_gpus >= 2),
             LearningRateScheduler(lr_sched)
         ])
 

--- a/deepcell/training.py
+++ b/deepcell/training.py
@@ -94,7 +94,7 @@ def train_model_sample(model,
                 y_true, y_pred, gamma=gamma, n_classes=n_classes)
         return losses.weighted_categorical_crossentropy(
             y_true, y_pred, n_classes=n_classes)
-    
+
     if num_gpus >= 2:
         model = multi_gpu_model(model, num_gpus)
 
@@ -207,7 +207,7 @@ def train_model_conv(model,
                 y_true, y_pred, gamma=gamma, n_classes=n_classes)
         return losses.weighted_categorical_crossentropy(
             y_true, y_pred, n_classes=n_classes)
-        
+
     if num_gpus >= 2:
         model = multi_gpu_model(model, num_gpus)
 

--- a/deepcell/training.py
+++ b/deepcell/training.py
@@ -34,6 +34,7 @@ import datetime
 import os
 
 import numpy as np
+from tensorflow.python.client import device_lib
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.callbacks import ModelCheckpoint, LearningRateScheduler
 from tensorflow.python.keras.optimizers import SGD
@@ -50,7 +51,7 @@ def train_model_sample(model,
                        expt='',
                        n_epoch=10,
                        batch_size=32,
-                       num_gpus=1,
+                       num_gpus=None,
                        transform=None,
                        window_size=None,
                        balance_classes=True,
@@ -94,6 +95,11 @@ def train_model_sample(model,
                 y_true, y_pred, gamma=gamma, n_classes=n_classes)
         return losses.weighted_categorical_crossentropy(
             y_true, y_pred, n_classes=n_classes)
+
+    if num_gpus is None:
+        devices = device_lib.list_local_devices()
+        gpus = [d for d in devices if d.name.lower().startswith('/device:gpu')]
+        num_gpus = len(gpus)
 
     if num_gpus >= 2:
         model = multi_gpu_model(model, num_gpus)
@@ -166,7 +172,7 @@ def train_model_conv(model,
                      expt='',
                      n_epoch=10,
                      batch_size=1,
-                     num_gpus=1,
+                     num_gpus=None,
                      frames_per_batch=5,
                      transform=None,
                      optimizer=SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True),
@@ -207,6 +213,11 @@ def train_model_conv(model,
                 y_true, y_pred, gamma=gamma, n_classes=n_classes)
         return losses.weighted_categorical_crossentropy(
             y_true, y_pred, n_classes=n_classes)
+
+    if num_gpus is None:
+        devices = device_lib.list_local_devices()
+        gpus = [d for d in devices if d.name.lower().startswith('/device:gpu')]
+        num_gpus = len(gpus)
 
     if num_gpus >= 2:
         model = multi_gpu_model(model, num_gpus)

--- a/deepcell/training.py
+++ b/deepcell/training.py
@@ -264,7 +264,7 @@ def train_model_conv(model,
             frames_per_batch=frames_per_batch)
 
         val_data = datagen_val.flow(
-            train_dict,
+            test_dict,
             skip=skip,
             batch_size=batch_size,
             transform=transform,
@@ -279,7 +279,7 @@ def train_model_conv(model,
             transform_kwargs=kwargs)
 
         val_data = datagen_val.flow(
-            train_dict,
+            test_dict,
             skip=skip,
             batch_size=batch_size,
             transform=transform,

--- a/deepcell/training.py
+++ b/deepcell/training.py
@@ -42,7 +42,7 @@ from tensorflow.python.client import device_lib
 from deepcell import losses
 from deepcell import image_generators as generators
 from deepcell.utils.data_utils import get_data
-from deepcell.utils.train_utils import rate_scheduler, ModelMGPU
+from deepcell.utils.train_utils import rate_scheduler, MultiGpuModel
 
 
 def train_model_sample(model,
@@ -102,7 +102,7 @@ def train_model_sample(model,
 
     if num_gpus >= 2:
         batch_size = batch_size * num_gpus
-        model = ModelMGPU(model, num_gpus)
+        model = MultiGpuModel(model, num_gpus)
 
     print('Training on {} GPUs'.format(num_gpus))
 
@@ -223,7 +223,7 @@ def train_model_conv(model,
 
     if num_gpus >= 2:
         batch_size = batch_size * num_gpus
-        model = ModelMGPU(model, num_gpus)
+        model = MultiGpuModel(model, num_gpus)
 
     print('Training on {} GPUs'.format(num_gpus))
 

--- a/deepcell/training.py
+++ b/deepcell/training.py
@@ -48,6 +48,7 @@ from deepcell.utils.train_utils import rate_scheduler, MultiGpuModel
 def train_model_sample(model,
                        dataset,
                        expt='',
+                       test_size=.1,
                        n_epoch=10,
                        batch_size=32,
                        num_gpus=None,
@@ -74,7 +75,7 @@ def train_model_sample(model,
     file_name_save_loss = os.path.join(direc_save, '{}.npz'.format(basename))
 
     training_data_file_name = os.path.join(direc_data, dataset + '.npz')
-    train_dict, test_dict = get_data(training_data_file_name, mode='sample')
+    train_dict, test_dict = get_data(training_data_file_name, mode='sample', test_size=test_size)
 
     n_classes = model.layers[-1].output_shape[1 if is_channels_first else -1]
 
@@ -172,6 +173,7 @@ def train_model_sample(model,
 def train_model_conv(model,
                      dataset,
                      expt='',
+                     test_size=.1,
                      n_epoch=10,
                      batch_size=1,
                      num_gpus=None,
@@ -196,7 +198,7 @@ def train_model_conv(model,
     file_name_save_loss = os.path.join(direc_save, '{}.npz'.format(basename))
 
     training_data_file_name = os.path.join(direc_data, dataset + '.npz')
-    train_dict, test_dict = get_data(training_data_file_name, mode='conv')
+    train_dict, test_dict = get_data(training_data_file_name, mode='conv', test_size=test_size)
 
     n_classes = model.layers[-1].output_shape[1 if is_channels_first else -1]
     # the data, shuffled and split between train and test sets

--- a/deepcell/utils/train_utils.py
+++ b/deepcell/utils/train_utils.py
@@ -43,7 +43,9 @@ def rate_scheduler(lr=.001, decay=0.95):
     return output_fn
 
 
-class ModelMGPU(Model):
+class MultiGpuModel(Model):
+    """Wrapper Model class to enable multi-gpu saving/loading
+    """
     def __init__(self, ser_model, gpus):
         pmodel = multi_gpu_model(ser_model, gpus)
         self.__dict__.update(pmodel.__dict__)
@@ -57,4 +59,4 @@ class ModelMGPU(Model):
         if 'load' in attrname or 'save' in attrname:
             return getattr(self._smodel, attrname)
 
-        return super(ModelMGPU, self).__getattribute__(attrname)
+        return super(MultiGpuModel, self).__getattribute__(attrname)

--- a/deepcell/utils/train_utils.py
+++ b/deepcell/utils/train_utils.py
@@ -31,6 +31,8 @@ from __future__ import print_function
 from __future__ import division
 
 import numpy as np
+from tensorflow.keras.utils import multi_gpu_model
+from tensorflow.keras.models import Model
 
 
 def rate_scheduler(lr=.001, decay=0.95):
@@ -39,3 +41,20 @@ def rate_scheduler(lr=.001, decay=0.95):
         new_lr = lr * (decay ** epoch)
         return new_lr
     return output_fn
+
+
+class ModelMGPU(Model):
+    def __init__(self, ser_model, gpus):
+        pmodel = multi_gpu_model(ser_model, gpus)
+        self.__dict__.update(pmodel.__dict__)
+        self._smodel = ser_model
+
+    def __getattribute__(self, attrname):
+        """Override load and save methods to be used from the serial-model. The
+        serial-model holds references to the weights in the multi-gpu model.
+        """
+        # return Model.__getattribute__(self, attrname)
+        if 'load' in attrname or 'save' in attrname:
+            return getattr(self._smodel, attrname)
+
+        return super(ModelMGPU, self).__getattribute__(attrname)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ numpy>=1.11.0,<2
 scipy>=1.1.0,<2
 scikit-image>=0.14.0,<1
 scikit-learn>=0.19.2,<1
-tensorflow==1.9.0
 tensorflow-gpu==1.9.0
+jupyter>=1.0.0
 nbformat>=4.4.0
 
 # requirements for fizyr's retinanet and maskrcnn implmentations


### PR DESCRIPTION
Using tf.keras `multi_gpu_model` to enable multiple GPU training when available.  To enable saving (and loading) of models using `multi_gpu_model`, it is wrapped in a parent class that holds the original series model as an attribute, which it uses to save and load models.

Additionally, there are some small requirements for using `skip_connections` with multi_gpu_models.  Namely 1) the training data must be divisible by the number of GPUs, and 2) the validation data must be bigger than the number of GPUs.  this PR silently shaves off any training data that is uneven, but if the validation data is too small, a descriptive error is thrown.