### PR TITLE
Add "fgbg" as transform key.

### DIFF
--- a/deepcell/image_generators.py
+++ b/deepcell/image_generators.py
@@ -102,7 +102,7 @@ def _transform_masks(y, transform, data_format=None, **kwargs):
             y_transform = np.zeros((y.shape[0], *y.shape[2:]))
         else:
             y_transform = np.zeros(y.shape[0:-1])
-        
+
         if y.ndim == 5:
             _distance_transform = distance_transform_3d
         else:
@@ -136,7 +136,7 @@ def _transform_masks(y, transform, data_format=None, **kwargs):
         if data_format == 'channels_first':
             y_transform = np.rollaxis(y_transform, y.ndim - 1, 1)
 
-    elif transform is None: 
+    elif transform is None:
         y_transform = to_categorical(y.squeeze(channel_axis))
         if data_format == 'channels_first':
             y_transform = np.rollaxis(y_transform, y.ndim - 1, 1)

--- a/deepcell/image_generators.py
+++ b/deepcell/image_generators.py
@@ -127,12 +127,17 @@ def _transform_masks(y, transform, data_format=None, **kwargs):
         if data_format == 'channels_first':
             y_transform = np.rollaxis(y_transform, y.ndim - 1, 1)
 
-    elif transform is None:
+    elif transform == 'fgbg':
         y_transform = np.where(y > 1, 1, y)
         # convert to one hot notation
         if data_format == 'channels_first':
             y_transform = np.rollaxis(y_transform, 1, y.ndim)
         y_transform = to_categorical(y_transform)
+        if data_format == 'channels_first':
+            y_transform = np.rollaxis(y_transform, y.ndim - 1, 1)
+
+    elif transform is None: 
+        y_transform = to_categorical(y.squeeze(channel_axis))
         if data_format == 'channels_first':
             y_transform = np.rollaxis(y_transform, y.ndim - 1, 1)
 

--- a/deepcell/image_generators.py
+++ b/deepcell/image_generators.py
@@ -73,6 +73,8 @@ def _transform_masks(y, transform, data_format=None, **kwargs):
     # Returns:
         y_transform: the output of the given transform function on y
     """
+    valid_transforms = {'deepcell', 'disc', 'watershed', 'centroid', 'fgbg'}
+
     if data_format is None:
         data_format = K.image_data_format()
 
@@ -87,7 +89,7 @@ def _transform_masks(y, transform, data_format=None, **kwargs):
 
     if isinstance(transform, str):
         transform = transform.lower()
-        if transform not in {'deepcell', 'disc', 'watershed', 'centroid'}:
+        if transform not in valid_transforms:
             raise ValueError('`{}` is not a valid transform'.format(transform))
 
     if transform == 'deepcell':

--- a/scripts/deepcell/DeepCell Transform 3D Fully Convolutional.ipynb
+++ b/scripts/deepcell/DeepCell Transform 3D Fully Convolutional.ipynb
@@ -490,7 +490,7 @@
     "    dataset=DATA_FILE,\n",
     "    optimizer=optimizer,\n",
     "    batch_size=batch_size,\n",
-    "    transform=None,  # fg/bg separation\n",
+    "    transform='fgbg',\n",
     "    n_epoch=n_epoch,\n",
     "    frames_per_batch=frames_per_batch,\n",
     "    direc_save=MODEL_DIR,\n",

--- a/scripts/watershed/Watershed Transform 2D Fully Convolutional.ipynb
+++ b/scripts/watershed/Watershed Transform 2D Fully Convolutional.ipynb
@@ -259,7 +259,7 @@
     "    dataset=DATA_FILE,\n",
     "    optimizer=optimizer,\n",
     "    batch_size=batch_size,\n",
-    "    transform=None,  # fg/bg separation\n",
+    "    transform='fgbg',\n",
     "    n_epoch=n_epoch,\n",
     "    direc_save=os.path.join(MODEL_DIR, PREFIX),\n",
     "    direc_data=os.path.join(NPZ_DIR, PREFIX),\n",

--- a/scripts/watershed/Watershed Transform 2D Sample Based.ipynb
+++ b/scripts/watershed/Watershed Transform 2D Sample Based.ipynb
@@ -228,7 +228,7 @@
     "    optimizer=optimizer,\n",
     "    window_size=(WIN_X, WIN_Y),\n",
     "    batch_size=batch_size,\n",
-    "    transform=None,  # fg/bg separation\n",
+    "    transform='fgbg',\n",
     "    n_epoch=n_epoch,\n",
     "    balance_classes=True,\n",
     "    max_class_samples=None,\n",

--- a/scripts/watershed/Watershed Transform 3D Fully Convolutional.ipynb
+++ b/scripts/watershed/Watershed Transform 3D Fully Convolutional.ipynb
@@ -233,7 +233,7 @@
     "train_model_conv(\n",
     "    model=fgbg_model,\n",
     "    expt='conv_fgbg',\n",
-    "    transform=None,\n",
+    "    transform='fgbg',\n",
     "    skip=2,\n",
     "    dataset=DATA_FILE,\n",
     "    optimizer=optimizer,\n",

--- a/scripts/watershed/Watershed Transform 3D Sample Based.ipynb
+++ b/scripts/watershed/Watershed Transform 3D Sample Based.ipynb
@@ -248,7 +248,7 @@
     "    batch_size=batch_size,\n",
     "    balance_classes=False,\n",
     "    max_class_samples=1e5,\n",
-    "    transform=None,\n",
+    "    transform='fgbg',\n",
     "    n_epoch=n_epoch,\n",
     "    direc_save=os.path.join(MODEL_DIR, PREFIX),\n",
     "    direc_data=os.path.join(NPZ_DIR, PREFIX),\n",

--- a/tests/deepcell/image_generators_test.py
+++ b/tests/deepcell/image_generators_test.py
@@ -120,6 +120,7 @@ class TestTransformMasks(test.TestCase):
             data_format='channels_last')
         self.assertEqual(mask_transform.shape, (5, 30, 30, distance_bins))
 
+        distance_bins = 6
         mask = np.random.randint(3, size=(5, 1, 30, 30))
         mask_transform = image_generators._transform_masks(
             mask,
@@ -130,6 +131,7 @@ class TestTransformMasks(test.TestCase):
         self.assertEqual(mask_transform.shape, (5, distance_bins, 30, 30))
 
         # test 3D masks
+        distance_bins = 5
         mask = np.random.randint(3, size=(5, 10, 30, 30, 1))
         mask_transform = image_generators._transform_masks(
             mask,
@@ -139,6 +141,7 @@ class TestTransformMasks(test.TestCase):
             data_format='channels_last')
         self.assertEqual(mask_transform.shape, (5, 10, 30, 30, distance_bins))
 
+        distance_bins = 4
         mask = np.random.randint(3, size=(5, 1, 10, 30, 30))
         mask_transform = image_generators._transform_masks(
             mask,

--- a/tests/deepcell/image_generators_test.py
+++ b/tests/deepcell/image_generators_test.py
@@ -61,27 +61,29 @@ def _generate_test_images():
 class TestTransformMasks(test.TestCase):
 
     def test_no_transform(self):
+        num_classes = np.random.randint(5, size=1)[0]
         # test 2D masks
-        mask = np.random.randint(3, size=(5, 30, 30, 1))
+        mask = np.random.randint(num_classes, size=(5, 30, 30, 1))
         mask_transform = image_generators._transform_masks(
             mask, transform=None, data_format='channels_last')
-        self.assertEqual(mask_transform.shape, (5, 30, 30, 2))
+        self.assertEqual(mask_transform.shape, (5, 30, 30, num_classes))
 
-        mask = np.random.randint(3, size=(5, 1, 30, 30))
+        mask = np.random.randint(num_classes, size=(5, 1, 30, 30))
         mask_transform = image_generators._transform_masks(
             mask, transform=None, data_format='channels_first')
-        self.assertEqual(mask_transform.shape, (5, 2, 30, 30))
+        self.assertEqual(mask_transform.shape, (5, num_classes, 30, 30))
 
         # test 3D masks
-        mask = np.random.randint(3, size=(5, 10, 30, 30, 1))
+        mask = np.random.randint(num_classes, size=(5, 10, 30, 30, 1))
         mask_transform = image_generators._transform_masks(
             mask, transform=None, data_format='channels_last')
-        self.assertEqual(mask_transform.shape, (5, 10, 30, 30, 2))
+        self.assertEqual(mask_transform.shape, (5, 10, 30, 30, num_classes))
 
-        mask = np.random.randint(3, size=(5, 1, 10, 30, 30))
+        mask = np.random.randint(num_classes, size=(5, 1, 10, 30, 30))
         mask_transform = image_generators._transform_masks(
             mask, transform=None, data_format='channels_first')
-        self.assertEqual(mask_transform.shape, (5, 2, 10, 30, 30))
+        self.assertEqual(mask_transform.shape, (5, num_classes, 10, 30, 30))
+
 
     def test_deepcell_transform(self):
         num_classes = 4

--- a/tests/deepcell/image_generators_test.py
+++ b/tests/deepcell/image_generators_test.py
@@ -84,27 +84,28 @@ class TestTransformMasks(test.TestCase):
         self.assertEqual(mask_transform.shape, (5, 2, 10, 30, 30))
 
     def test_deepcell_transform(self):
+        num_classes = 4
         # test 2D masks
         mask = np.random.randint(3, size=(5, 30, 30, 1))
         mask_transform = image_generators._transform_masks(
             mask, transform='deepcell', data_format='channels_last')
-        self.assertEqual(mask_transform.shape, (5, 30, 30, 4))
+        self.assertEqual(mask_transform.shape, (5, 30, 30, num_classes))
 
         mask = np.random.randint(3, size=(5, 1, 30, 30))
         mask_transform = image_generators._transform_masks(
             mask, transform='deepcell', data_format='channels_first')
-        self.assertEqual(mask_transform.shape, (5, 4, 30, 30))
+        self.assertEqual(mask_transform.shape, (5, num_classes, 30, 30))
 
         # test 3D masks
         mask = np.random.randint(3, size=(5, 10, 30, 30, 1))
         mask_transform = image_generators._transform_masks(
             mask, transform='deepcell', data_format='channels_last')
-        self.assertEqual(mask_transform.shape, (5, 10, 30, 30, 4))
+        self.assertEqual(mask_transform.shape, (5, 10, 30, 30, num_classes))
 
         mask = np.random.randint(3, size=(5, 1, 10, 30, 30))
         mask_transform = image_generators._transform_masks(
             mask, transform='deepcell', data_format='channels_first')
-        self.assertEqual(mask_transform.shape, (5, 4, 10, 30, 30))
+        self.assertEqual(mask_transform.shape, (5, num_classes, 10, 30, 30))
 
     def test_watershed_transform(self):
         distance_bins = 4

--- a/tests/deepcell/image_generators_test.py
+++ b/tests/deepcell/image_generators_test.py
@@ -84,6 +84,29 @@ class TestTransformMasks(test.TestCase):
             mask, transform=None, data_format='channels_first')
         self.assertEqual(mask_transform.shape, (5, num_classes, 10, 30, 30))
 
+    def test_fgbg_transform(self):
+        num_classes = 2  # always 2 for fg and bg
+        # test 2D masks
+        mask = np.random.randint(3, size=(5, 30, 30, 1))
+        mask_transform = image_generators._transform_masks(
+            mask, transform='fgbg', data_format='channels_last')
+        self.assertEqual(mask_transform.shape, (5, 30, 30, num_classes))
+
+        mask = np.random.randint(3, size=(5, 1, 30, 30))
+        mask_transform = image_generators._transform_masks(
+            mask, transform='fgbg', data_format='channels_first')
+        self.assertEqual(mask_transform.shape, (5, num_classes, 30, 30))
+
+        # test 3D masks
+        mask = np.random.randint(3, size=(5, 10, 30, 30, 1))
+        mask_transform = image_generators._transform_masks(
+            mask, transform='fgbg', data_format='channels_last')
+        self.assertEqual(mask_transform.shape, (5, 10, 30, 30, num_classes))
+
+        mask = np.random.randint(3, size=(5, 1, 10, 30, 30))
+        mask_transform = image_generators._transform_masks(
+            mask, transform='fgbg', data_format='channels_first')
+        self.assertEqual(mask_transform.shape, (5, num_classes, 10, 30, 30))
 
     def test_deepcell_transform(self):
         num_classes = 4


### PR DESCRIPTION
Instead of a None transform changing data to `fgbg` (background, not background), None will just call `to_categorical` on the data provided.  This is a good catch-all for new data that will be semantically segmented, but likely not instance segmented.

Meanwhile, `"fgbg"`  has been added as a distinct transform key.  It behaves as before, and all notebooks have been updated to use the "fgbg" key instead of None.