### PR TITLE
Use tensorflow/tensorflow as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-# Use the nvidia tensorflow:18.08-py3 image as the parent image
-FROM nvcr.io/nvidia/tensorflow:18.08-py3
+# Use tensorflow/tensorflow as the base image
+# Change the build arg to edit the tensorflow version.
+# Only supporting python3.
+ARG TF_VERSION=1.9.0-gpu
+FROM tensorflow/tensorflow:${TF_VERSION}-py3
 
 # System maintenance
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM tensorflow/tensorflow:${TF_VERSION}-py3
 
 # System maintenance
 RUN apt-get update && apt-get install -y \
+        git \
         python3-tk \
         libsm6 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@
 ARG TF_VERSION=1.9.0-gpu
 FROM tensorflow/tensorflow:${TF_VERSION}-py3
 
+RUN mkdir /notebooks/intro_to_tensorflow && \
+    mv BUILD LICENSE /notebooks/*.ipynb intro_to_tensorflow/
+
 # System maintenance
 RUN apt-get update && apt-get install -y \
         git \
@@ -12,19 +15,18 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/* && \
     /usr/local/bin/pip install --upgrade pip
 
-# Set working directory
-WORKDIR /deepcell-tf
-
 # Copy the setup.py and requirements.txt and install the deepcell-tf dependencies
 COPY setup.py requirements.txt /opt/deepcell-tf/
 RUN pip install -r /opt/deepcell-tf/requirements.txt
 
 # Copy the rest of the package code and its scripts
 COPY deepcell /opt/deepcell-tf/deepcell
-COPY scripts /deepcell-tf/scripts
 
 # Install deepcell via setup.py
 RUN pip install /opt/deepcell-tf
+
+# Copy over deepcell notebooks
+COPY scripts/ /notebooks/
 
 # Change matplotlibrc file to use the Agg backend
 RUN echo "backend : Agg" > /usr/local/lib/python3.5/dist-packages/matplotlib/mpl-data/matplotlibrc

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There are several notebooks with various training methods that can be used as ex
 
 ## Using DeepCell with Docker
 
-DeepCell uses `nvcr.io/nvidia/tensorflow` as a base image and `nvidia-docker` to enable GPU processing.
+DeepCell uses `tensorflow/tensorflow` as a base image and `nvidia-docker` to enable GPU processing.
 
 Below are some helpful commands to get started:
 
@@ -70,4 +70,3 @@ NV_GPU='0' nvidia-docker run -it \
   $USER/deepcell-tf:latest \
   notebook --allow-root --ip=0.0.0.0
 ```
-> **_Note_**: You will need to authenticate with NGC to pull the DeepCell base image.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # deepcell-tf
-DeepCell is neural network API for single cell analysis, built using [TensorFlow](https://github.com/tensorflow/tensorflow) and [Keras](https://github.com/keras-team/keras).
+DeepCell is neural network library for single cell analysis, built using [TensorFlow](https://github.com/tensorflow/tensorflow) and [Keras](https://github.com/keras-team/keras).
 
 ## Getting Started
 
-There are several notebooks with various training methods that can be used as examples:
+The fastest way to get started with DeepCell is to run the latest docker image:
 
-#### Cell Edge and Cell Interior Segmentation
+```bash
+nvidia-docker run -it --rm -p 8888:8888 vanvalenlab/deepcell-tf:latest
+```
+
+This will start a jupyter session, with several example notebooks detailing various training methods:
+
+### Cell Edge and Cell Interior Segmentation
 
 * [2D DeepCell Transform - Fully Convolutional.ipynb](scripts/deepcell/DeepCell%20Transform%202D%20Fully%20Convolutional.ipynb)
 
@@ -15,7 +21,7 @@ There are several notebooks with various training methods that can be used as ex
 
 * [3D DeepCell Transform - Sample Based.ipynb](scripts/deepcell/DeepCell%20Transfrom%203D%20Sample%20Based.ipynb)
 
-#### Deep Watershed Instance Segmentation
+### Deep Watershed Instance Segmentation
 
 * [2D Watershed - Fully Convolutional.ipynb](scripts/watershed/Watershed%20Transform%202D%20Fully%20Convolutional.ipynb)
 
@@ -25,20 +31,26 @@ There are several notebooks with various training methods that can be used as ex
 
 * [3D Watershed - Sample Based.ipynb](scripts/watershed/Watershed%20Transform%203D%20Sample%20Based.ipynb)
 
-## Using DeepCell with Docker
+## DeepCell for Developers
 
-DeepCell uses `tensorflow/tensorflow` as a base image and `nvidia-docker` to enable GPU processing.
+DeepCell uses `nvidia-docker` and `tensorflow` to enable GPU processing.  
 
-Below are some helpful commands to get started:
-
-##### Build a docker image based on your local copy of deepcell-tf
+### Build a local docker container
 
 ```bash
-# Build a docker image based on the local copy of deepcell-tf
+git clone https://github.com/vanvalenlab/deepcell-tf.git
+cd deepcell-tf
 docker build -t $USER/deepcell-tf .
+
 ```
 
-##### Run the new docker image
+The tensorflow version can be overridden with the build-arg `TF_VERSION`.
+
+```bash
+docker build --build-arg TF_VERSION=1.9.0-gpu -t $USER/deepcell-tf .
+```
+
+### Run the new docker image
 
 ```bash
 # NV_GPU refers to the specific GPU to run DeepCell on, and is not required
@@ -47,26 +59,17 @@ docker build -t $USER/deepcell-tf .
 # but can be handy for local development
 
 NV_GPU='0' nvidia-docker run -it \
-  -v $PWD/deepcell:/usr/local/lib/python3.5/dist-packages/deepcell/ \
-  -v $PWD/scripts:/deepcell-tf/scripts \
-  -v /data:/data \
+  -p 8888:8888 \
   $USER/deepcell-tf:latest
 ```
 
-##### Run the docker image as a Jupyter notebook
+It can also be helpful to mount the local copy of the repository and the scripts to speed up local development.
 
 ```bash
-# Alternatively, run a jupyter notebook as the container entrypoint
-
-# Note that the --entrypoint flag is before the image name,
-# but the options passed to jupyter come after the image name
-
 NV_GPU='0' nvidia-docker run -it \
   -p 8888:8888 \
   -v $PWD/deepcell:/usr/local/lib/python3.5/dist-packages/deepcell/ \
   -v $PWD/scripts:/deepcell-tf/scripts \
   -v /data:/data \
-  --entrypoint /usr/local/bin/jupyter \
-  $USER/deepcell-tf:latest \
-  notebook --allow-root --ip=0.0.0.0
+  $USER/deepcell-tf:latest
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.14.5,<2
 scipy>=1.1.0,<2
 scikit-image>=0.14.1,<1
 scikit-learn>=0.19.1,<1
-tensorflow==1.9.0
+tensorflow-gpu==1.9.0
 jupyter>=1.0.0,<2
 nbformat>=4.4.0,<5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-pandas>=0.23.0,<1
-numpy>=1.11.0,<2
+pandas>=0.23.3,<1
+numpy>=1.14.5,<2
 scipy>=1.1.0,<2
-scikit-image>=0.14.0,<1
-scikit-learn>=0.19.2,<1
-tensorflow-gpu==1.9.0
-jupyter>=1.0.0
-nbformat>=4.4.0
+scikit-image>=0.14.1,<1
+scikit-learn>=0.19.1,<1
+tensorflow==1.9.0
+jupyter>=1.0.0,<2
+nbformat>=4.4.0,<5
 
 # requirements for fizyr's retinanet and maskrcnn implmentations
 opencv-python>=3.4.2.17,<4


### PR DESCRIPTION
Deprecating the nvidia base image, as users will need to make an account in order to use this.  Additionally, `tensorflow/tensorflow` has base images that compile for both CPU and GPU, which we can leverage in creating builds for `deepcell` for both CPU and GPU as well.  This base image is a required step in getting CPU and GPU builds, but these will likely need to be automatically generated, or the user will be told what version to use.

Fixes #115 
Related to #107 
Related to #105 

