### PR TITLE
Jupyterlab implementation with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,3 +30,5 @@ COPY scripts/ /notebooks/
 
 # Change matplotlibrc file to use the Agg backend
 RUN echo "backend : Agg" > /usr/local/lib/python3.5/dist-packages/matplotlib/mpl-data/matplotlibrc
+
+ENTRYPOINT ["jupyter","lab","--ip=0.0.0.0","--allow-root"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ scipy>=1.1.0,<2
 scikit-image>=0.14.1,<1
 scikit-learn>=0.19.1,<1
 tensorflow-gpu==1.9.0
-jupyter>=1.0.0,<2
+jupyter
 nbformat>=4.4.0,<5
 jupyterlab
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ scikit-learn>=0.19.1,<1
 tensorflow-gpu==1.9.0
 jupyter>=1.0.0,<2
 nbformat>=4.4.0,<5
+jupyterlab
 
 # requirements for fizyr's retinanet and maskrcnn implmentations
 opencv-python>=3.4.2.17,<4


### PR DESCRIPTION
I modified the Dockerfile to launch jupyter lab instead of jupyter notebooks when running a container. Jupyterlab needed to be added to requirements.txt for deepcell. When jupyter notebook was pinned to `jupyter>=1.0.0,<2`, it appeared to cause an error when shutting down jupyter where it seemed to get stuck midway through the shutdown process. When this happened, I ended up needing to kill the container. After releasing the version requirement for jupyter, this error seems to have disappeared and I was able to shutdown jupyter from various different states without a problem.