### PR TITLE
Refreshed the example datasets

### DIFF
--- a/deepcell/datasets/hek293.py
+++ b/deepcell/datasets/hek293.py
@@ -61,7 +61,7 @@ def load_data(path='HEK293.npz', test_size=.2, seed=0):
 
     path = get_file(path,
                     origin='https://deepcell-data.s3.amazonaws.com/nuclei/HEK293.npz',
-                    file_hash='c0bbfba54b90e63a2010133a198e6e63')
+                    file_hash='6221fa459350cd1e45ce6c9145264329')
 
     train_dict, test_dict = get_data(path, test_size=test_size, seed=seed)
 

--- a/deepcell/datasets/nih_3t3.py
+++ b/deepcell/datasets/nih_3t3.py
@@ -61,7 +61,7 @@ def load_data(path='3T3_NIH.npz', test_size=.2, seed=0):
 
     path = get_file(path,
                     origin='https://deepcell-data.s3.amazonaws.com/nuclei/3T3_NIH.npz',
-                    file_hash='954b6f4ad6a71435b84c40726837e4ba')
+                    file_hash='f6520df218847fa56be2de0d3552c8a2')
 
     train_dict, test_dict = get_data(path, test_size=test_size, seed=seed)
 

--- a/deepcell/datasets/tracked/hek293.py
+++ b/deepcell/datasets/tracked/hek293.py
@@ -61,7 +61,7 @@ def load_tracked_data(path='HEK293.trks', test_size=.2, seed=0):
 
     path = get_file(path,
                     origin='https://deepcell-data.s3.amazonaws.com/tracked/HEK293.trks',
-                    file_hash='d19e0fe144633a08d41cf6695e11f72b')
+                    file_hash='d5c563ab5866403836f2dcbe249c640f')
 
     train_dict, test_dict = get_data(path, mode='siamese_daughters',
                                      test_size=test_size, seed=seed)


### PR DESCRIPTION
The datasets have been updated to remove errors.  This changes the hash in the `get_file` call inside `deepcell.datasets`.