### PR TITLE
Add `separate_edge_classes` switch to deepcell transform

### DIFF
--- a/deepcell/image_generators.py
+++ b/deepcell/image_generators.py
@@ -111,7 +111,9 @@ def _transform_masks(y, transform, data_format=None, **kwargs):
 
     if transform == 'deepcell':
         dilation_radius = kwargs.pop('dilation_radius', None)
-        y_transform = deepcell_transform(y, dilation_radius, data_format=data_format)
+        separate_edge_classes = kwargs.pop('separate_edge_classes', False)
+        y_transform = deepcell_transform(y, dilation_radius, data_format=data_format,
+                                         separate_edge_classes=separate_edge_classes)
 
     elif transform == 'watershed':
         distance_bins = kwargs.pop('distance_bins', 4)

--- a/tests/deepcell/image_generators_test.py
+++ b/tests/deepcell/image_generators_test.py
@@ -108,28 +108,32 @@ class TestTransformMasks(test.TestCase):
         self.assertEqual(mask_transform.shape, (5, num_classes, 10, 30, 30))
 
     def test_deepcell_transform(self):
-        num_classes = 4
+        num_classes = 3
         # test 2D masks
         mask = np.random.randint(3, size=(5, 30, 30, 1))
         mask_transform = image_generators._transform_masks(
-            mask, transform='deepcell', data_format='channels_last')
-        self.assertEqual(mask_transform.shape, (5, 30, 30, num_classes))
+            mask, transform='deepcell', data_format='channels_last',
+            separate_edge_classes=True)
+        self.assertEqual(mask_transform.shape, (5, 30, 30, 4))
 
         mask = np.random.randint(3, size=(5, 1, 30, 30))
         mask_transform = image_generators._transform_masks(
-            mask, transform='deepcell', data_format='channels_first')
-        self.assertEqual(mask_transform.shape, (5, num_classes, 30, 30))
+            mask, transform='deepcell', data_format='channels_first',
+            separate_edge_classes=False)
+        self.assertEqual(mask_transform.shape, (5, 3, 30, 30))
 
         # test 3D masks
         mask = np.random.randint(3, size=(5, 10, 30, 30, 1))
         mask_transform = image_generators._transform_masks(
-            mask, transform='deepcell', data_format='channels_last')
-        self.assertEqual(mask_transform.shape, (5, 10, 30, 30, num_classes))
+            mask, transform='deepcell', data_format='channels_last',
+            separate_edge_classes=False)
+        self.assertEqual(mask_transform.shape, (5, 10, 30, 30, 3))
 
         mask = np.random.randint(3, size=(5, 1, 10, 30, 30))
         mask_transform = image_generators._transform_masks(
-            mask, transform='deepcell', data_format='channels_first')
-        self.assertEqual(mask_transform.shape, (5, num_classes, 10, 30, 30))
+            mask, transform='deepcell', data_format='channels_first',
+            separate_edge_classes=True)
+        self.assertEqual(mask_transform.shape, (5, 4, 10, 30, 30))
 
     def test_watershed_transform(self):
         distance_bins = 4

--- a/tests/deepcell/utils/transform_utils_test.py
+++ b/tests/deepcell/utils/transform_utils_test.py
@@ -54,11 +54,29 @@ def _generate_test_masks():
 
 class TransformUtilsTest(test.TestCase):
     def test_deepcell_transform_2d(self):
+        # test single edge class
         maskstack = np.array([label(i) for i in _generate_test_masks()])
         dc_maskstack = transform_utils.deepcell_transform(
-            maskstack, data_format=None)
+            maskstack, data_format=None, separate_edge_classes=False)
         dc_maskstack_dil = transform_utils.deepcell_transform(
-            maskstack, dilation_radius=1, data_format='channels_last')
+            maskstack, dilation_radius=1,
+            data_format='channels_last',
+            separate_edge_classes=False)
+
+        self.assertEqual(dc_maskstack.shape[-1], 3)
+        self.assertEqual(dc_maskstack_dil.shape[-1], 3)
+        self.assertGreater(
+            dc_maskstack_dil[..., 0].sum() + dc_maskstack_dil[..., 1].sum(),
+            dc_maskstack[..., 0].sum() + dc_maskstack[..., 1].sum())
+
+        # test separate edge classes
+        maskstack = np.array([label(i) for i in _generate_test_masks()])
+        dc_maskstack = transform_utils.deepcell_transform(
+            maskstack, data_format=None, separate_edge_classes=True)
+        dc_maskstack_dil = transform_utils.deepcell_transform(
+            maskstack, dilation_radius=1,
+            data_format='channels_last',
+            separate_edge_classes=True)
 
         self.assertEqual(dc_maskstack.shape[-1], 4)
         self.assertEqual(dc_maskstack_dil.shape[-1], 4)
@@ -76,14 +94,34 @@ class TransformUtilsTest(test.TestCase):
             img_stack = np.array(frame_list)
             img_list.append(img_stack)
 
+        # test single edge class
         maskstack = np.vstack(img_list)
         batch_count = maskstack.shape[0] // frames
         new_shape = (batch_count, frames, *maskstack.shape[1:])
         maskstack = np.reshape(maskstack, new_shape)
         dc_maskstack = transform_utils.deepcell_transform(
-            maskstack, data_format=None)
+            maskstack, data_format=None, separate_edge_classes=False)
         dc_maskstack_dil = transform_utils.deepcell_transform(
-            maskstack, dilation_radius=2, data_format='channels_last')
+            maskstack, dilation_radius=2,
+            data_format='channels_last',
+            separate_edge_classes=False)
+        self.assertEqual(dc_maskstack.shape[-1], 3)
+        self.assertEqual(dc_maskstack_dil.shape[-1], 3)
+        self.assertGreater(
+            dc_maskstack_dil[..., 0].sum() + dc_maskstack_dil[..., 1].sum(),
+            dc_maskstack[..., 0].sum() + dc_maskstack[..., 1].sum())
+
+        # test separate edge classes
+        maskstack = np.vstack(img_list)
+        batch_count = maskstack.shape[0] // frames
+        new_shape = (batch_count, frames, *maskstack.shape[1:])
+        maskstack = np.reshape(maskstack, new_shape)
+        dc_maskstack = transform_utils.deepcell_transform(
+            maskstack, data_format=None, separate_edge_classes=True)
+        dc_maskstack_dil = transform_utils.deepcell_transform(
+            maskstack, dilation_radius=2,
+            data_format='channels_last',
+            separate_edge_classes=True)
         self.assertEqual(dc_maskstack.shape[-1], 4)
         self.assertEqual(dc_maskstack_dil.shape[-1], 4)
         self.assertGreater(


### PR DESCRIPTION
Allow the `deepcell` transform to separate edges into cell-cell and cell-background edges with the `separate_edge_classes` boolean flag.

This PR resolves #168 