### PR TITLE
Travis builds and pushes both CPU and GPU based docker images.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: false
-dist: trusty
+sudo: true
+dist: xenial
 
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ jobs:
       - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
       - docker push "$TRAVIS_REPO_SLUG"
       # edit the requirements and Dockerfile to build the GPU TensorFlow base image
-      - sed -i -e "s/tensorflow/tensorflow-gpu/" requirements.txt
       - docker build --build-arg TF_VERSION=$TF_VERSION-gpu -t "$TRAVIS_REPO_SLUG" .
       - docker images
       - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,18 +21,9 @@ env:
 cache: pip
 
 install:
-  - pip install cython
-  - pip install matplotlib
-  - pip install nbformat
-  - pip install scipy
-  - pip install numpy
-  - pip install pandas
-  - pip install networkx
-  - pip install scikit-learn
-  - pip install scikit-image
-  - pip install opencv-python
-  - pip install pathlib
-  - pip install keras_preprocessing>=1.0.6
+  # remove tensorflow from requirements.txt
+  - sed -i "" -n "/tensorflow/!p" requirements.txt
+  - pip install -r requirements.txt
   # install TensorFlow (CPU version).
   - pip install tensorflow==$TF_VERSION
   # install testing requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       # build an image with the CPU TensorFlow base image
-      - docker build --build-arg TF_VERSION=$TF_VERSION -t "$TRAVIS_REPO_SLUG" -f .
+      - docker build --build-arg TF_VERSION=$TF_VERSION -t "$TRAVIS_REPO_SLUG" .
       - docker images
       - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":latest
       # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
@@ -56,7 +56,7 @@ jobs:
       - docker rm "$TRAVIS_REPO_SLUG"
       # edit the requirements and Dockerfile to build the GPU TensorFlow base image
       - sed -i -e "s/tensorflow/tensorflow-gpu/" requirements.txt
-      - docker build --build-arg TF_VERSION=$TF_VERSION-gpu -t "$TRAVIS_REPO_SLUG" -f .
+      - docker build --build-arg TF_VERSION=$TF_VERSION-gpu -t "$TRAVIS_REPO_SLUG" .
       - docker images
       # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"
       - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":test-gpu

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache: pip
 
 install:
   # remove tensorflow from requirements.txt
-  - sed -ri "/tensorflow/!p" requirements.txt
+  - sed -i "/tensorflow/d" requirements.txt
   - pip install -r requirements.txt
   # install TensorFlow (CPU version).
   - pip install tensorflow==$TF_VERSION
@@ -55,7 +55,7 @@ jobs:
       - docker push "$TRAVIS_REPO_SLUG"
       - docker rm "$TRAVIS_REPO_SLUG"
       # edit the requirements and Dockerfile to build the GPU TensorFlow base image
-      - sed -i "" -e "s/tensorflow/tensorflow-gpu/" requirements.txt
+      - sed -i -e "s/tensorflow/tensorflow-gpu/" requirements.txt
       - docker build --build-arg TF_TAG=-gpu-py3 --build-arg TF_VERSION=$TF_VERSION -t "$TRAVIS_REPO_SLUG" -f .
       - docker images
       # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - python setup.py build_ext --inplace
 
 script:
-  - pytest --cov=deepcell --pep8
+  # - pytest --cov=deepcell --pep8
   - sphinx-build -nT -b dummy ./docs/source build/html
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
       - docker rm "$TRAVIS_REPO_SLUG"
       # edit the requirements and Dockerfile to build the GPU TensorFlow base image
       - sed -i -e "s/tensorflow/tensorflow-gpu/" requirements.txt
-      - docker build --build-arg TF_TAG=-gpu-py3 --build-arg TF_VERSION=$TF_VERSION -t "$TRAVIS_REPO_SLUG" -f .
+      - docker build --build-arg TF_VERSION=$TF_VERSION-gpu -t "$TRAVIS_REPO_SLUG" -f .
       - docker images
       # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"
       - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":test-gpu

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,13 +50,15 @@ jobs:
       - docker build --build-arg TF_VERSION=$TF_VERSION -t "$TRAVIS_REPO_SLUG" .
       - docker images
       - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":latest
-      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
+      # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
+      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":test
       - docker push "$TRAVIS_REPO_SLUG"
       # edit the requirements and Dockerfile to build the GPU TensorFlow base image
       - sed -i -e "s/tensorflow/tensorflow-gpu/" requirements.txt
       - docker build --build-arg TF_VERSION=$TF_VERSION-gpu -t "$TRAVIS_REPO_SLUG" .
       - docker images
-      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"
+      # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"
+      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"test-gpu"
       - docker push "$TRAVIS_REPO_SLUG"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache: pip
 
 install:
   # remove tensorflow from requirements.txt
-  - sed -i '' -n '/tensorflow/!p' requirements.txt
+  - sed -ri "/tensorflow/!p" requirements.txt
   - pip install -r requirements.txt
   # install TensorFlow (CPU version).
   - pip install tensorflow==$TF_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
 jobs:
   include:
     - stage: deploy
-      if: (branch = master OR branch =~ ^r[0-9]+.[0-9]+) AND type != pull_request
+      if: tag IS present
       env: TF_VERSION=1.12.0
       python: 3.5
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ git:
 language: python
 
 python:
-  # - 2.7
-  # - 3.5
+  - 2.7
+  - 3.5
   - 3.6
 
 env:
-  # - TF_VERSION=1.8.0
-  # - TF_VERSION=1.9.0
-  # - TF_VERSION=1.10.0
-  # - TF_VERSION=1.11.0
+  - TF_VERSION=1.8.0
+  - TF_VERSION=1.9.0
+  - TF_VERSION=1.10.0
+  - TF_VERSION=1.11.0
   - TF_VERSION=1.12.0
 
 cache: pip
@@ -24,10 +24,10 @@ install:
   # remove tensorflow from requirements.txt
   - sed -i "/tensorflow/d" requirements.txt
   - pip install -r requirements.txt
-  # # install TensorFlow (CPU version).
+  # install TensorFlow (CPU version).
   - pip install tensorflow==$TF_VERSION
-  # # install testing requirements
-  # - pip install pytest pytest-cov==2.5.1 pytest-pep8 coveralls
+  # install testing requirements
+  - pip install pytest pytest-cov==2.5.1 pytest-pep8 coveralls
   # Install sphinx to check documentation build
   - pip install sphinx m2r
   # install deepcell with setup.py
@@ -35,13 +35,13 @@ install:
   - python setup.py build_ext --inplace
 
 script:
-  # - pytest --cov=deepcell --pep8
+  - pytest --cov=deepcell --pep8
   - sphinx-build -nT -b dummy ./docs/source build/html
 
 jobs:
   include:
     - stage: deploy
-      # if: tag IS present
+      if: tag IS present
       env: TF_VERSION=1.12.0
       python: 3.5
       script:
@@ -50,14 +50,12 @@ jobs:
       - docker build --build-arg TF_VERSION=$TF_VERSION -t "$TRAVIS_REPO_SLUG" .
       - docker images
       - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":latest
-      # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
-      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":test
+      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
       - docker push "$TRAVIS_REPO_SLUG"
       # edit the requirements and Dockerfile to build the GPU TensorFlow base image
       - docker build --build-arg TF_VERSION=$TF_VERSION-gpu -t "$TRAVIS_REPO_SLUG" .
       - docker images
-      # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"
-      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":test-gpu
+      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"
       - docker push "$TRAVIS_REPO_SLUG"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
       - docker push "$TRAVIS_REPO_SLUG"
       - docker rm "$TRAVIS_REPO_SLUG"
       # edit the requirements and Dockerfile to build the GPU TensorFlow base image
-      - sed -i "" -e "s/tensorflow==/tensorflow-gpu==/" requirements.txt
+      - sed -i "" -e "s/tensorflow/tensorflow-gpu/" requirements.txt
       - docker build --build-arg TF_TAG=-gpu-py3 --build-arg TF_VERSION=$TF_VERSION -t "$TRAVIS_REPO_SLUG" -f .
       - docker images
       # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,18 @@ jobs:
       python: 3.5
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-      - docker build -t "$TRAVIS_REPO_SLUG" .
+      # build an image with the CPU TensorFlow base image
+      - docker build --build-arg TF_VERSION=$TF_VERSION -t "$TRAVIS_REPO_SLUG" -f .
       - docker images
       - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":latest
-      - if [[ "$TRAVIS_BRANCH" != "master" ]] ; then docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_BRANCH#r}" ; fi
+      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
+      - docker push "$TRAVIS_REPO_SLUG"
+      - docker rm "$TRAVIS_REPO_SLUG"
+      # edit the requirements and Dockerfile to build the GPU TensorFlow base image
+      - sed -i "" -e "s/tensorflow==/tensorflow-gpu==/" requirements.txt
+      - docker build --build-arg TF_TAG=-gpu-py3 --build-arg TF_VERSION=$TF_VERSION -t "$TRAVIS_REPO_SLUG" -f .
+      - docker images
+      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"
       - docker push "$TRAVIS_REPO_SLUG"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,27 +7,27 @@ git:
 language: python
 
 python:
-  - 2.7
-  - 3.5
+  # - 2.7
+  # - 3.5
   - 3.6
 
 env:
-  - TF_VERSION=1.8.0
-  - TF_VERSION=1.9.0
-  - TF_VERSION=1.10.0
-  - TF_VERSION=1.11.0
+  # - TF_VERSION=1.8.0
+  # - TF_VERSION=1.9.0
+  # - TF_VERSION=1.10.0
+  # - TF_VERSION=1.11.0
   - TF_VERSION=1.12.0
 
 cache: pip
 
 install:
   # remove tensorflow from requirements.txt
-  - sed -i "/tensorflow/d" requirements.txt
-  - pip install -r requirements.txt
-  # install TensorFlow (CPU version).
-  - pip install tensorflow==$TF_VERSION
-  # install testing requirements
-  - pip install pytest pytest-cov==2.5.1 pytest-pep8 coveralls
+  # - sed -i "/tensorflow/d" requirements.txt
+  # - pip install -r requirements.txt
+  # # install TensorFlow (CPU version).
+  # - pip install tensorflow==$TF_VERSION
+  # # install testing requirements
+  # - pip install pytest pytest-cov==2.5.1 pytest-pep8 coveralls
   # Install sphinx to check documentation build
   - pip install sphinx m2r
   # install deepcell with setup.py
@@ -35,13 +35,13 @@ install:
   - python setup.py build_ext --inplace
 
 script:
-  - pytest --cov=deepcell --pep8
+  # - pytest --cov=deepcell --pep8
   - sphinx-build -nT -b dummy ./docs/source build/html
 
 jobs:
   include:
     - stage: deploy
-      if: tag IS present
+      # if: tag IS present
       env: TF_VERSION=1.12.0
       python: 3.5
       script:
@@ -50,12 +50,14 @@ jobs:
       - docker build --build-arg TF_VERSION=$TF_VERSION -t "$TRAVIS_REPO_SLUG" .
       - docker images
       - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":latest
-      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
+      # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
+      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":test
       - docker push "$TRAVIS_REPO_SLUG"
       # edit the requirements and Dockerfile to build the GPU TensorFlow base image
       - docker build --build-arg TF_VERSION=$TF_VERSION-gpu -t "$TRAVIS_REPO_SLUG" .
       - docker images
-      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"
+      # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"
+      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":test-gpu
       - docker push "$TRAVIS_REPO_SLUG"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: true
-dist: xenial
+sudo: false
+dist: trusty
 
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,15 @@ language: python
 
 python:
   - 2.7
-  # - 3.5
-  # - 3.6
+  - 3.5
+  - 3.6
 
 env:
   - TF_VERSION=1.8.0
-  # - TF_VERSION=1.9.0
-  # - TF_VERSION=1.10.0
-  # - TF_VERSION=1.11.0
-  # - TF_VERSION=1.12.0
+  - TF_VERSION=1.9.0
+  - TF_VERSION=1.10.0
+  - TF_VERSION=1.11.0
+  - TF_VERSION=1.12.0
 
 cache: pip
 
@@ -35,13 +35,13 @@ install:
   - python setup.py build_ext --inplace
 
 script:
-  # - pytest --cov=deepcell --pep8
+  - pytest --cov=deepcell --pep8
   - sphinx-build -nT -b dummy ./docs/source build/html
 
 jobs:
   include:
     - stage: deploy
-      # if: tag IS present
+      if: tag IS present
       env: TF_VERSION=1.12.0
       python: 3.5
       script:
@@ -50,15 +50,13 @@ jobs:
       - docker build --build-arg TF_VERSION=$TF_VERSION -t "$TRAVIS_REPO_SLUG" .
       - docker images
       - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":latest
-      # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
-      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":test
+      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
       - docker push "$TRAVIS_REPO_SLUG"
       # edit the requirements and Dockerfile to build the GPU TensorFlow base image
       - sed -i -e "s/tensorflow/tensorflow-gpu/" requirements.txt
       - docker build --build-arg TF_VERSION=$TF_VERSION-gpu -t "$TRAVIS_REPO_SLUG" .
       - docker images
-      # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"
-      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"test-gpu"
+      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"
       - docker push "$TRAVIS_REPO_SLUG"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ cache: pip
 
 install:
   # remove tensorflow from requirements.txt
-  # - sed -i "/tensorflow/d" requirements.txt
-  # - pip install -r requirements.txt
+  - sed -i "/tensorflow/d" requirements.txt
+  - pip install -r requirements.txt
   # # install TensorFlow (CPU version).
-  # - pip install tensorflow==$TF_VERSION
+  - pip install tensorflow==$TF_VERSION
   # # install testing requirements
   # - pip install pytest pytest-cov==2.5.1 pytest-pep8 coveralls
   # Install sphinx to check documentation build

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,13 @@ install:
   - python setup.py build_ext --inplace
 
 script:
-  # - pytest --cov=deepcell --pep8
+  - pytest --cov=deepcell --pep8
   - sphinx-build -nT -b dummy ./docs/source build/html
 
 jobs:
   include:
     - stage: deploy
-      # if: tag IS present
+      if: tag IS present
       env: TF_VERSION=1.12.0
       python: 3.5
       script:
@@ -50,16 +50,13 @@ jobs:
       - docker build --build-arg TF_VERSION=$TF_VERSION -t "$TRAVIS_REPO_SLUG" .
       - docker images
       - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":latest
-      # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
-      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":test
+      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
       - docker push "$TRAVIS_REPO_SLUG"
-      - docker rm "$TRAVIS_REPO_SLUG"
       # edit the requirements and Dockerfile to build the GPU TensorFlow base image
       - sed -i -e "s/tensorflow/tensorflow-gpu/" requirements.txt
       - docker build --build-arg TF_VERSION=$TF_VERSION-gpu -t "$TRAVIS_REPO_SLUG" .
       - docker images
-      # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"
-      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":test-gpu
+      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"
       - docker push "$TRAVIS_REPO_SLUG"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,15 @@ language: python
 
 python:
   - 2.7
-  - 3.5
-  - 3.6
+  # - 3.5
+  # - 3.6
 
 env:
   - TF_VERSION=1.8.0
-  - TF_VERSION=1.9.0
-  - TF_VERSION=1.10.0
-  - TF_VERSION=1.11.0
-  - TF_VERSION=1.12.0
+  # - TF_VERSION=1.9.0
+  # - TF_VERSION=1.10.0
+  # - TF_VERSION=1.11.0
+  # - TF_VERSION=1.12.0
 
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
 jobs:
   include:
     - stage: deploy
-      if: tag IS present
+      # if: tag IS present
       env: TF_VERSION=1.12.0
       python: 3.5
       script:
@@ -50,14 +50,16 @@ jobs:
       - docker build --build-arg TF_VERSION=$TF_VERSION -t "$TRAVIS_REPO_SLUG" -f .
       - docker images
       - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":latest
-      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
+      # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}"
+      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":test
       - docker push "$TRAVIS_REPO_SLUG"
       - docker rm "$TRAVIS_REPO_SLUG"
       # edit the requirements and Dockerfile to build the GPU TensorFlow base image
       - sed -i "" -e "s/tensorflow==/tensorflow-gpu==/" requirements.txt
       - docker build --build-arg TF_TAG=-gpu-py3 --build-arg TF_VERSION=$TF_VERSION -t "$TRAVIS_REPO_SLUG" -f .
       - docker images
-      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"
+      # - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":"${TRAVIS_TAG}-gpu"
+      - docker tag "$TRAVIS_REPO_SLUG" "$TRAVIS_REPO_SLUG":test-gpu
       - docker push "$TRAVIS_REPO_SLUG"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,13 @@ install:
   - python setup.py build_ext --inplace
 
 script:
-  - pytest --cov=deepcell --pep8
+  # - pytest --cov=deepcell --pep8
   - sphinx-build -nT -b dummy ./docs/source build/html
 
 jobs:
   include:
     - stage: deploy
-      if: tag IS present
+      # if: tag IS present
       env: TF_VERSION=1.12.0
       python: 3.5
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache: pip
 
 install:
   # remove tensorflow from requirements.txt
-  - sed -i "" -n "/tensorflow/!p" requirements.txt
+  - sed -i '' -n '/tensorflow/!p' requirements.txt
   - pip install -r requirements.txt
   # install TensorFlow (CPU version).
   - pip install tensorflow==$TF_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,10 @@ WORKDIR /notebooks
 
 # Copy the setup.py and requirements.txt and install the deepcell-tf dependencies
 COPY setup.py requirements.txt /opt/deepcell-tf/
-RUN pip install -r /opt/deepcell-tf/requirements.txt
+
+# Prevent reinstallation of tensorflow and install all other requirements.
+RUN sed -i "/tensorflow/d" requirements.txt && \
+    pip install -r /opt/deepcell-tf/requirements.txt
 
 # Copy the rest of the package code and its scripts
 COPY deepcell /opt/deepcell-tf/deepcell

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 
 WORKDIR /notebooks
 
-# Older versions of TensorFlow have notebooks, but they may not exist
-RUN if [ -n "$(find /notebooks/ -prune -empty)" ] ; \
-    then \
-      mkdir -p /notebooks/intro_to_tensorflow && \
-      ls /notebooks | grep -v intro_to_tensorflow | \
-      xargs -r mv -t /notebooks/intro_to_tensorflow ; \
-    fi
-
 # Copy the setup.py and requirements.txt and install the deepcell-tf dependencies
 COPY setup.py requirements.txt /opt/deepcell-tf/
 RUN pip install -r /opt/deepcell-tf/requirements.txt
@@ -34,6 +26,13 @@ COPY deepcell /opt/deepcell-tf/deepcell
 RUN pip install /opt/deepcell-tf && \
     cd /opt/deepcell-tf && \
     python setup.py build_ext --inplace
+
+# Older versions of TensorFlow have notebooks, but they may not exist
+RUN if [ -n "$(find /notebooks/ -prune)" ] ; then \
+      mkdir -p /notebooks/intro_to_tensorflow && \
+      ls -d /notebooks/* | grep -v intro_to_tensorflow | \
+      xargs -r mv -t /notebooks/intro_to_tensorflow ; \
+    fi
 
 # Copy over deepcell notebooks
 COPY scripts/ /notebooks/

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,4 @@ RUN pip install /opt/deepcell-tf && \
 # Copy over deepcell notebooks
 COPY scripts/ /notebooks/
 
+ENTRYPOINT ['jupyter', 'notebook', '--ip=0.0.0.0', '--allow-root']

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ RUN pip install /opt/deepcell-tf && \
 # Copy over deepcell notebooks
 COPY scripts/ /notebooks/
 
-ENTRYPOINT ['jupyter', 'notebook', '--ip=0.0.0.0', '--allow-root']
+CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--allow-root"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ARG TF_TAG=-py3
 
 FROM tensorflow/tensorflow:${TF_VERSION}${TF_TAG}
 
+WORKDIR /notebooks
+
 # Older versions of TensorFlow have notebooks, but they may not exist
 RUN mkdir -p /notebooks/intro_to_tensorflow && \
     ls /notebooks | grep -v intro_to_tensorflow | \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,8 @@
 # Change the build arg to edit the tensorflow version.
 # Only supporting python3.
 ARG TF_VERSION=1.11.0
-ARG TF_TAG=-py3
 
-FROM tensorflow/tensorflow:${TF_VERSION}${TF_TAG}
+FROM tensorflow/tensorflow:${TF_VERSION}-py3
 
 # System maintenance
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /notebooks
 COPY setup.py requirements.txt /opt/deepcell-tf/
 
 # Prevent reinstallation of tensorflow and install all other requirements.
-RUN sed -i "/tensorflow/d" requirements.txt && \
+RUN sed -i "/tensorflow/d" /opt/deepcell-tf/requirements.txt && \
     pip install -r /opt/deepcell-tf/requirements.txt
 
 # Copy the rest of the package code and its scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,13 @@ ARG TF_TAG=-py3
 
 FROM tensorflow/tensorflow:${TF_VERSION}${TF_TAG}
 
+# System maintenance
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    python3-tk \
+    libsm6 && \
+    rm -rf /var/lib/apt/lists/* && \
+    /usr/local/bin/pip install --upgrade pip
+
 WORKDIR /notebooks
 
 # Older versions of TensorFlow have notebooks, but they may not exist
@@ -15,13 +22,6 @@ RUN if [ -n "$(find /notebooks/ -prune -empty)" ] ; \
       ls /notebooks | grep -v intro_to_tensorflow | \
       xargs -r mv -t /notebooks/intro_to_tensorflow ; \
     fi
-
-# System maintenance
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    python3-tk \
-    libsm6 && \
-    rm -rf /var/lib/apt/lists/* && \
-    /usr/local/bin/pip install --upgrade pip
 
 # Copy the setup.py and requirements.txt and install the deepcell-tf dependencies
 COPY setup.py requirements.txt /opt/deepcell-tf/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN mkdir /notebooks/intro_to_tensorflow && \
 
 # System maintenance
 RUN apt-get update && apt-get install -y \
-    git \
     python3-tk \
     libsm6 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,11 @@ ARG TF_TAG=-py3
 
 FROM tensorflow/tensorflow:${TF_VERSION}${TF_TAG}
 
-RUN mkdir /notebooks/intro_to_tensorflow && \
-    mv BUILD LICENSE /notebooks/*.ipynb intro_to_tensorflow/
+# Older versions of TensorFlow have notebooks, but they may not exist
+RUN mkdir -p /notebooks/intro_to_tensorflow && \
+    ls /notebooks | grep -v intro_to_tensorflow | \
+    xargs mv -t /notebooks/intro_to_tensorflow  \
+    || true
 
 # System maintenance
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,12 @@ FROM tensorflow/tensorflow:${TF_VERSION}${TF_TAG}
 WORKDIR /notebooks
 
 # Older versions of TensorFlow have notebooks, but they may not exist
-RUN mkdir -p /notebooks/intro_to_tensorflow && \
-    ls /notebooks | grep -v intro_to_tensorflow | \
-    xargs mv -t /notebooks/intro_to_tensorflow  \
-    || true
+RUN if [ -n "$(find /notebooks/ -prune -empty)" ] ; \
+    then \
+      mkdir -p /notebooks/intro_to_tensorflow && \
+      ls /notebooks | grep -v intro_to_tensorflow | \
+      xargs -r mv -t /notebooks/intro_to_tensorflow ; \
+    fi
 
 # System maintenance
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,3 @@ RUN pip install /opt/deepcell-tf && \
 # Copy over deepcell notebooks
 COPY scripts/ /notebooks/
 
-# Change matplotlibrc file to use the Agg backend
-RUN echo "backend : Agg" > /usr/local/lib/python3.5/dist-packages/matplotlib/mpl-data/matplotlibrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # Use tensorflow/tensorflow as the base image
 # Change the build arg to edit the tensorflow version.
 # Only supporting python3.
-ARG TF_VERSION=1.11.0-gpu
-FROM tensorflow/tensorflow:${TF_VERSION}-py3
+ARG TF_VERSION=1.11.0
+ARG TF_TAG=-py3
+
+FROM tensorflow/tensorflow:${TF_VERSION}${TF_TAG}
 
 RUN mkdir /notebooks/intro_to_tensorflow && \
     mv BUILD LICENSE /notebooks/*.ipynb intro_to_tensorflow/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /notebooks/intro_to_tensorflow && \
     || true
 
 # System maintenance
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3-tk \
     libsm6 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.14.5,<2
 scipy>=1.1.0,<2
 scikit-image>=0.14.1,<1
 scikit-learn>=0.19.1,<1
-tensorflow==1.11.0
+tensorflow>=1.8.0,<2
 jupyter>=1.0.0,<2
 nbformat>=4.4.0,<5
 keras-preprocessing==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scikit-learn>=0.19.1,<1
 tensorflow==1.11.0
 jupyter>=1.0.0,<2
 nbformat>=4.4.0,<5
-keras-preprocessing==1.0.6
+keras-preprocessing==1.1.0
 networkx>=2.1,<3
 opencv-python>=3.4.2.17,<4
 cython>=0.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.14.5,<2
 scipy>=1.1.0,<2
 scikit-image>=0.14.1,<1
 scikit-learn>=0.19.1,<1
-tensorflow-gpu==1.11.0
+tensorflow==1.11.0
 jupyter>=1.0.0,<2
 nbformat>=4.4.0,<5
 keras-preprocessing==1.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scikit-learn>=0.19.1,<1
 tensorflow>=1.8.0,<2
 jupyter>=1.0.0,<2
 nbformat>=4.4.0,<5
-keras-preprocessing==1.1.0
+keras-preprocessing==1.0.6
 networkx>=2.1,<3
 opencv-python>=3.4.2.17,<4
 cython>=0.28


### PR DESCRIPTION
Use `sed` to change the prevent installation of tensorflow in the travis tests and Dockerfile build stages.  Travis will push an image for both GPU and CPU once tests complete.

The Dockerfile has also been updated to support the newer base images of tensorflow that no longer use `jupyter` by default.

Fixes #107 