### PR TITLE
Pin test dependencies to resolve TravisCI testing issues.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
     - stage: deploy
       if: tag IS present
       env: TF_VERSION=1.12.0
-      python: 3.5
+      python: 3.6
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       # build an image with the CPU TensorFlow base image

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,7 @@ install:
   # install all other requirements
   - pip install -r requirements.txt
   # install testing requirements
-  - pip install pytest pytest-cov==2.5.1 pytest-pep8 coveralls
-  # Install sphinx to check documentation build
-  - pip install sphinx m2r
+  - pip install -r requirements-test.txt
   # install deepcell with setup.py
   # - python setup.py install
   - python setup.py build_ext --inplace

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,9 @@
+# Running tests
 pytest==4.6.5
 pytest-cov==2.5.1
-pytest-pep8==1.0.6
-coveralls==1.8.2
-sphinx==2.1.2
-m2r==0.2.1
+pytest-pep8>=1.0.6,<2.0.0
+coveralls>=1.8.2,<2.0.0
+
+# Documentation dependencies
+sphinx>=1.8.5
+m2r>=0.2.1,<1.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,6 @@
+pytest==4.6.5
+pytest-cov==2.5.1
+pytest-pep8==1.0.6
+coveralls==1.8.2
+sphinx==2.1.2
+m2r==0.2.1


### PR DESCRIPTION
Travis seems to install different/incompatible versions with `pip` that lead to some tests failing due to `pytest`.  This PR pins all the testing dependencies and moves them to a `requirements-test.txt` file, so that they can be directly installed with `pip install -r requirements-test.txt`.