### PR TITLE
Pin PyWaveletts to 1.0.3 in requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
-  - travis_retry bash miniconda.sh -b -p $HOME/miniconda
+  - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - source activate test-environment
 
   # install TensorFlow (CPU version).
-  - travis_retry pip install tensorflow==$TF_VERSION
+  - travis_retry pip install tensorflow==$TF_VERSION --progress-bar off
 
   # remove tensorflow an requirements.txt
   - sed -i "/tensorflow/d" requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
-  - bash miniconda.sh -b -p $HOME/miniconda
+  - travis_retry bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no

--- a/deepcell/applications/label_detection_test.py
+++ b/deepcell/applications/label_detection_test.py
@@ -49,7 +49,7 @@ class TestLabelDetectionModel(test.TestCase):
         X = np.random.random(batch_shape)
 
         for backbone in valid_backbones:
-            with self.test_session(use_gpu=True):
+            with self.test_session():
                 inputs = Input(shape=input_shape)
                 model = LabelDetectionModel(
                     inputs=inputs,
@@ -61,7 +61,7 @@ class TestLabelDetectionModel(test.TestCase):
                 assert y.shape[0] == X.shape[0]
                 assert len(y.shape) == 2
 
-            with self.test_session(use_gpu=True):
+            with self.test_session():
                 model = LabelDetectionModel(
                     input_shape=input_shape,
                     backbone=backbone,

--- a/deepcell/applications/nuclear_segmentation_test.py
+++ b/deepcell/applications/nuclear_segmentation_test.py
@@ -54,7 +54,7 @@ class TestNuclearSegmentationModel(test.TestCase):
                 # retinanet backbones do not work with versions < 1.10.0
                 continue
 
-            with self.test_session(use_gpu=True):
+            with self.test_session():
                 model = NuclearSegmentationModel(
                     input_shape=input_shape,
                     backbone=backbone,

--- a/deepcell/applications/phase_segmentation_test.py
+++ b/deepcell/applications/phase_segmentation_test.py
@@ -54,7 +54,7 @@ class TestPhaseSegmentationModel(test.TestCase):
                 # retinanet backbones do not work with versions < 1.10.0
                 continue
 
-            with self.test_session(use_gpu=True):
+            with self.test_session():
                 model = PhaseSegmentationModel(
                     input_shape=input_shape,
                     backbone=backbone,

--- a/deepcell/applications/scale_detection_test.py
+++ b/deepcell/applications/scale_detection_test.py
@@ -49,7 +49,7 @@ class TestScaleDetectionModel(test.TestCase):
         X = np.random.random(batch_shape)
 
         for backbone in valid_backbones:
-            with self.test_session(use_gpu=True):
+            with self.test_session():
                 inputs = Input(shape=input_shape)
                 model = ScaleDetectionModel(
                     inputs=inputs,
@@ -61,7 +61,7 @@ class TestScaleDetectionModel(test.TestCase):
                 assert y.shape[0] == X.shape[0]
                 assert len(y.shape) == 2
 
-            with self.test_session(use_gpu=True):
+            with self.test_session():
                 model = ScaleDetectionModel(
                     input_shape=input_shape,
                     backbone=backbone,

--- a/deepcell/layers/filter_detections_test.py
+++ b/deepcell/layers/filter_detections_test.py
@@ -40,7 +40,7 @@ class TestFilterDetections(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
-        with self.test_session(use_gpu=True):
+        with self.test_session():
             # create simple FilterDetections layer
             layer = layers.FilterDetections()
 
@@ -81,7 +81,7 @@ class TestFilterDetections(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple_3d(self):
-        with self.test_session(use_gpu=True):
+        with self.test_session():
             # create simple FilterDetections layer
             layer = layers.FilterDetections()
 
@@ -124,7 +124,7 @@ class TestFilterDetections(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple_with_other(self):
-        with self.test_session(use_gpu=True):
+        with self.test_session():
             # create simple FilterDetections layer
             layer = layers.FilterDetections()
 
@@ -185,7 +185,7 @@ class TestFilterDetections(test.TestCase):
 
     # @tf_test_util.run_in_graph_and_eager_modes()
     # def test_mini_batch(self):
-    #     with self.test_session(use_gpu=True):
+    #     with self.test_session():
     #         # create simple FilterDetections layer
     #         layer = layers.FilterDetections()
     #

--- a/deepcell/layers/location_test.py
+++ b/deepcell/layers/location_test.py
@@ -39,7 +39,7 @@ class LocationTest(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_location_2d(self):
-        with self.test_session(use_gpu=True):
+        with self.test_session():
             testing_utils.layer_test(
                 layers.Location2D,
                 kwargs={'in_shape': (5, 6, 4),
@@ -55,7 +55,7 @@ class LocationTest(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_location_3d(self):
-        with self.test_session(use_gpu=True):
+        with self.test_session():
             testing_utils.layer_test(
                 layers.Location3D,
                 kwargs={'in_shape': (11, 12, 10, 4),

--- a/deepcell/layers/normalization_test.py
+++ b/deepcell/layers/normalization_test.py
@@ -43,7 +43,7 @@ class ImageNormalizationTest(test.TestCase):
     def test_normalize_2d(self):
         custom_objects = {'ImageNormalization2D': layers.ImageNormalization2D}
         norm_methods = [None, 'std', 'max', 'whole_image']
-        with self.test_session(use_gpu=True):
+        with self.test_session():
             # test each norm method
             for norm_method in norm_methods:
                 testing_utils.layer_test(
@@ -86,7 +86,7 @@ class ImageNormalizationTest(test.TestCase):
     def test_normalize_3d(self):
         custom_objects = {'ImageNormalization3D': layers.ImageNormalization3D}
         norm_methods = [None, 'std', 'max', 'whole_image']
-        with self.test_session(use_gpu=True):
+        with self.test_session():
             # test each norm method
             for norm_method in norm_methods:
                 testing_utils.layer_test(

--- a/deepcell/layers/padding_test.py
+++ b/deepcell/layers/padding_test.py
@@ -60,7 +60,7 @@ class ReflectionPaddingTest(test.TestCase):
         data_formats = ['channels_first', 'channels_last']
         for data_format, inputs in zip(data_formats, [ins2, ins1]):
             # basic test
-            with self.test_session(use_gpu=True):
+            with self.test_session():
                 testing_utils.layer_test(
                     layers.ReflectionPadding2D,
                     kwargs={'padding': (2, 2),
@@ -75,7 +75,7 @@ class ReflectionPaddingTest(test.TestCase):
                     input_shape=inputs.shape)
 
             # correctness test
-            # with self.test_session(use_gpu=True):
+            # with self.test_session():
             #     layer = layers.ReflectionPadding2D(
             #         padding=(2, 2), data_format=data_format)
             #     layer.build(inputs.shape)
@@ -146,7 +146,7 @@ class ReflectionPaddingTest(test.TestCase):
         data_formats = ['channels_first', 'channels_last']
         for data_format, inputs in zip(data_formats, [inputs2, inputs1]):
             # basic test
-            with self.test_session(use_gpu=True):
+            with self.test_session():
                 testing_utils.layer_test(
                     layers.ReflectionPadding3D,
                     kwargs={'padding': (2, 2, 2),
@@ -155,7 +155,7 @@ class ReflectionPaddingTest(test.TestCase):
                     input_shape=inputs.shape)
 
         # correctness test
-        # with self.test_session(use_gpu=True):
+        # with self.test_session():
         #     layer = layers.ReflectionPadding3D(padding=(2, 2, 2))
         #     layer.build(inputs.shape)
         #     output = layer(keras.backend.variable(inputs))

--- a/deepcell/layers/pooling_test.py
+++ b/deepcell/layers/pooling_test.py
@@ -44,7 +44,7 @@ class DilatedMaxPoolingTest(test.TestCase):
         for strides in [(1, 1), (2, 2), None]:
             for dilation_rate in [1, 2, (1, 2)]:
                 for padding in ['valid', 'same']:
-                    with self.test_session(use_gpu=True):
+                    with self.test_session():
                         testing_utils.layer_test(
                             layers.DilatedMaxPool2D,
                             kwargs={'strides': strides,
@@ -71,7 +71,7 @@ class DilatedMaxPoolingTest(test.TestCase):
         for strides in [1, 2, None]:
             for dilation_rate in [1, 2, (1, 2, 2)]:
                 for padding in ['valid', 'same']:
-                    with self.test_session(use_gpu=True):
+                    with self.test_session():
                         testing_utils.layer_test(
                             layers.DilatedMaxPool3D,
                             kwargs={'strides': strides,

--- a/deepcell/layers/resize_test.py
+++ b/deepcell/layers/resize_test.py
@@ -39,7 +39,7 @@ class ResizeTest(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_resize_2d(self):
-        with self.test_session(use_gpu=True):
+        with self.test_session():
             testing_utils.layer_test(
                 layers.Resize2D,
                 kwargs={'scale': 2},

--- a/deepcell/layers/retinanet_test.py
+++ b/deepcell/layers/retinanet_test.py
@@ -41,7 +41,7 @@ class TestAnchors(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_anchors_2d(self):
-        with self.test_session(use_gpu=True):
+        with self.test_session():
             testing_utils.layer_test(
                 layers.Anchors,
                 kwargs={'size': 1, 'stride': 1,

--- a/deepcell/model_zoo/featurenet_test.py
+++ b/deepcell/model_zoo/featurenet_test.py
@@ -120,7 +120,7 @@ class FeatureNetTest(test.TestCase, parameterized.TestCase):
         # BAD: dilated=True, include_top=False
         # BAD: inputs != None
 
-        with self.test_session(use_gpu=True):
+        with self.test_session():
             K.set_image_data_format(data_format)
             model = featurenet.bn_feature_net_2D(
                 include_top=include_top,
@@ -147,7 +147,7 @@ class FeatureNetTest(test.TestCase, parameterized.TestCase):
         n_skips = 1
 
         for data_format in ('channels_first', 'channels_last'):
-            with self.test_session(use_gpu=True):
+            with self.test_session():
                 K.set_image_data_format(data_format)
                 axis = 1 if data_format == 'channels_first' else -1
 
@@ -249,7 +249,7 @@ class FeatureNetTest(test.TestCase, parameterized.TestCase):
         n_frames = 5
         # input_shape = (10, 32, 32, 1)
 
-        with self.test_session(use_gpu=True):
+        with self.test_session():
             K.set_image_data_format(data_format)
             model = featurenet.bn_feature_net_3D(
                 include_top=include_top,
@@ -276,7 +276,7 @@ class FeatureNetTest(test.TestCase, parameterized.TestCase):
         n_skips = 1
 
         for data_format in ('channels_first', 'channels_last'):
-            with self.test_session(use_gpu=True):
+            with self.test_session():
                 K.set_image_data_format(data_format)
                 axis = 1 if data_format == 'channels_first' else -1
 

--- a/deepcell/model_zoo/maskrcnn_test.py
+++ b/deepcell/model_zoo/maskrcnn_test.py
@@ -150,7 +150,7 @@ class RetinaMaskTest(test.TestCase, parameterized.TestCase):
 
         # TODO: RetinaMask fails with channels_first
         for data_format in ('channels_last',):  # 'channels_first'):
-            with self.test_session(use_gpu=True):
+            with self.test_session():
                 K.set_image_data_format(data_format)
                 if data_format == 'channels_first':
                     axis = 1

--- a/deepcell/model_zoo/retinanet_test.py
+++ b/deepcell/model_zoo/retinanet_test.py
@@ -124,7 +124,7 @@ class RetinaNetTest(test.TestCase, parameterized.TestCase):
         backbone = 'featurenet'
 
         for data_format in ('channels_last', 'channels_first'):
-            with self.test_session(use_gpu=True):
+            with self.test_session():
                 K.set_image_data_format(data_format)
                 if data_format == 'channels_first':
                     axis = 1

--- a/deepcell/utils/backbone_utils_test.py
+++ b/deepcell/utils/backbone_utils_test.py
@@ -96,20 +96,20 @@ class TestBackboneUtils(test.TestCase, parameterized.TestCase):
     ])
     def test_get_backbone(self, backbone):
         # some backbones seem to not play well with python2.7
-        bad_backbones = {
-            'resnext50', 'resnext101',
-            'resnet50v2', 'resnet101v2', 'resnet152v2'
-        }
-
-        if sys.version_info[0] != 2 or backbone not in bad_backbones:
-            with self.test_session():
-                K.set_image_data_format('channels_last')
-                inputs = Input(shape=(256, 256, 3))
-                model, output_dict = backbone_utils.get_backbone(
-                    backbone, inputs, return_dict=True)
-                assert isinstance(output_dict, dict)
-                assert all(k.startswith('C') for k in output_dict)
-                assert isinstance(model, Model)
+        # bad_backbones = {
+        #     'resnext50', 'resnext101',
+        #     'resnet50v2', 'resnet101v2', 'resnet152v2'
+        # }
+        #
+        # if sys.version_info[0] != 2 or backbone not in bad_backbones:
+        with self.test_session():
+            K.set_image_data_format('channels_last')
+            inputs = Input(shape=(256, 256, 3))
+            model, output_dict = backbone_utils.get_backbone(
+                backbone, inputs, return_dict=True)
+            assert isinstance(output_dict, dict)
+            assert all(k.startswith('C') for k in output_dict)
+            assert isinstance(model, Model)
 
     def test_invalid_backbone(self):
         inputs = Input(shape=(4, 2, 3))

--- a/deepcell/utils/backbone_utils_test.py
+++ b/deepcell/utils/backbone_utils_test.py
@@ -95,13 +95,6 @@ class TestBackboneUtils(test.TestCase, parameterized.TestCase):
         ('nasnet_mobile',) * 2,
     ])
     def test_get_backbone(self, backbone):
-        # some backbones seem to not play well with python2.7
-        # bad_backbones = {
-        #     'resnext50', 'resnext101',
-        #     'resnet50v2', 'resnet101v2', 'resnet152v2'
-        # }
-        #
-        # if sys.version_info[0] != 2 or backbone not in bad_backbones:
         with self.test_session():
             K.set_image_data_format('channels_last')
             inputs = Input(shape=(256, 256, 3))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pandas>=0.23.3,<1
 numpy>=1.14.5,<2
 scipy>=1.1.0,<2
-scikit-image>=0.14.1,<1
+scikit-image==0.14.4
 scikit-learn>=0.19.1,<1
 tensorflow>=1.10.0,<2
 jupyter>=1.0.0,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ networkx>=2.1,<2.4
 opencv-python>=3.4.2.17,<4
 cython>=0.28
 pathlib==1.0.1
+pywt=>1.0,<1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ networkx>=2.1,<2.4
 opencv-python>=3.4.2.17,<4
 cython>=0.28
 pathlib==1.0.1
-pywt==1.0.3
+PyWavelets==1.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pandas>=0.23.3,<1
 numpy>=1.14.5,<2
 scipy>=1.1.0,<2
-scikit-image==0.14.4
+scikit-image>=0.14.1,<1
 scikit-learn>=0.19.1,<1
 tensorflow>=1.10.0,<2
 jupyter>=1.0.0,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ networkx>=2.1,<2.4
 opencv-python>=3.4.2.17,<4
 cython>=0.28
 pathlib==1.0.1
-pywt>=1.0.0,<1.1.0
+pywt==1.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ networkx>=2.1,<2.4
 opencv-python>=3.4.2.17,<4
 cython>=0.28
 pathlib==1.0.1
-pywt=>1.0,<1.1.0
+pywt>=1.0.0,<1.1.0


### PR DESCRIPTION
`scikit-image` has a dependency on `PyWaveletts` which was just re-released today. This new vesion of PyWavelets does not support python2.7.  Pin the version of pywavelets to 1.0.3 to resolve this issue.

`test_session(use_gpu=True)` has been replaced with `test_session`.

Python2 tests all backbones, as get_backbone bug was resolved in #239 