### PR TITLE
remove PyWavelets from requirements as python2.7 skimage bug is resolved.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ networkx>=2.1,<2.4
 opencv-python>=3.4.2.17,<4
 cython>=0.28
 pathlib==1.0.1
-PyWavelets==1.0.3


### PR DESCRIPTION
the PyWavelets tarball for 1.1.0 was incompatible with python2.7 but was installed by default in skimage's setup.py.  PyWavelets was upgaded to 1.1.1 (1.1.0 deleted) and the issue is resolved.