### PR TITLE
Upgrade to TensorFlow >= 1.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,12 @@ language: python
 
 python:
   - 2.7
-  - 3.5
   - 3.6
+  - 3.7
 
 env:
-  - TF_VERSION=1.10.0
-  - TF_VERSION=1.11.0
-  - TF_VERSION=1.12.3
-  # - TF_VERSION=1.13.2  # tf 1.13.x times out on all model tests
   - TF_VERSION=1.14.0
+  - TF_VERSION=1.15.0
 
 install:
   # code below is taken from https://github.com/keras-team/keras/blob/master/.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
   include:
     - stage: deploy
       if: tag IS present
-      env: TF_VERSION=1.12.0
+      env: TF_VERSION=1.14.0
       python: 3.6
       script:
       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use tensorflow/tensorflow as the base image
 # Change the build arg to edit the tensorflow version.
 # Only supporting python3.
-ARG TF_VERSION=1.11.0
+ARG TF_VERSION=1.14.0
 
 FROM tensorflow/tensorflow:${TF_VERSION}-py3
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker build -t $USER/deepcell-tf .
 The tensorflow version can be overridden with the build-arg `TF_VERSION`.
 
 ```bash
-docker build --build-arg TF_VERSION=1.9.0-gpu -t $USER/deepcell-tf .
+docker build --build-arg TF_VERSION=1.15.0-gpu -t $USER/deepcell-tf .
 ```
 
 ### Run the new docker image

--- a/deepcell/applications/fluorescent_cytoplasm_segmentation_test.py
+++ b/deepcell/applications/fluorescent_cytoplasm_segmentation_test.py
@@ -45,12 +45,7 @@ class TestFluorCytoplasmSegmentationModel(test.TestCase):
         valid_backbones = ['featurenet']
         input_shape = (256, 256, 1)  # channels will be set to 3
 
-        batch_shape = tuple([8] + list(input_shape))
-
         for backbone in valid_backbones:
-            if int(tf.VERSION.split('.')[1]) < 10:
-                # retinanet backbones do not work with versions < 1.10.0
-                continue
 
             with self.cached_session():
                 model = FluorCytoplasmSegmentationModel(

--- a/deepcell/applications/fluorescent_cytoplasm_segmentation_test.py
+++ b/deepcell/applications/fluorescent_cytoplasm_segmentation_test.py
@@ -47,14 +47,12 @@ class TestFluorCytoplasmSegmentationModel(test.TestCase):
 
         batch_shape = tuple([8] + list(input_shape))
 
-        X = np.random.random(batch_shape)
-
         for backbone in valid_backbones:
             if int(tf.VERSION.split('.')[1]) < 10:
                 # retinanet backbones do not work with versions < 1.10.0
                 continue
 
-            with self.test_session():
+            with self.cached_session():
                 model = FluorCytoplasmSegmentationModel(
                     input_shape=input_shape,
                     backbone=backbone,

--- a/deepcell/applications/label_detection_test.py
+++ b/deepcell/applications/label_detection_test.py
@@ -49,7 +49,7 @@ class TestLabelDetectionModel(test.TestCase):
         X = np.random.random(batch_shape)
 
         for backbone in valid_backbones:
-            with self.test_session():
+            with self.cached_session():
                 inputs = Input(shape=input_shape)
                 model = LabelDetectionModel(
                     inputs=inputs,
@@ -61,7 +61,7 @@ class TestLabelDetectionModel(test.TestCase):
                 assert len(y.shape) == 2
                 assert y.shape[0] == X.shape[0]
 
-            with self.test_session():
+            with self.cached_session():
                 model = LabelDetectionModel(
                     input_shape=input_shape,
                     backbone=backbone,

--- a/deepcell/applications/nuclear_segmentation_test.py
+++ b/deepcell/applications/nuclear_segmentation_test.py
@@ -54,7 +54,7 @@ class TestNuclearSegmentationModel(test.TestCase):
                 # retinanet backbones do not work with versions < 1.10.0
                 continue
 
-            with self.test_session():
+            with self.cached_session():
                 model = NuclearSegmentationModel(
                     input_shape=input_shape,
                     backbone=backbone,

--- a/deepcell/applications/nuclear_segmentation_test.py
+++ b/deepcell/applications/nuclear_segmentation_test.py
@@ -45,14 +45,7 @@ class TestNuclearSegmentationModel(test.TestCase):
         valid_backbones = ['featurenet']
         input_shape = (256, 256, 1)  # channels will be set to 3
 
-        batch_shape = tuple([8] + list(input_shape))
-
-        X = np.random.random(batch_shape)
-
         for backbone in valid_backbones:
-            if int(tf.VERSION.split('.')[1]) < 10:
-                # retinanet backbones do not work with versions < 1.10.0
-                continue
 
             with self.cached_session():
                 model = NuclearSegmentationModel(

--- a/deepcell/applications/phase_segmentation_test.py
+++ b/deepcell/applications/phase_segmentation_test.py
@@ -54,7 +54,7 @@ class TestPhaseSegmentationModel(test.TestCase):
                 # retinanet backbones do not work with versions < 1.10.0
                 continue
 
-            with self.test_session():
+            with self.cached_session():
                 model = PhaseSegmentationModel(
                     input_shape=input_shape,
                     backbone=backbone,

--- a/deepcell/applications/phase_segmentation_test.py
+++ b/deepcell/applications/phase_segmentation_test.py
@@ -45,14 +45,7 @@ class TestPhaseSegmentationModel(test.TestCase):
         valid_backbones = ['featurenet']
         input_shape = (256, 256, 1)  # channels will be set to 3
 
-        batch_shape = tuple([8] + list(input_shape))
-
-        X = np.random.random(batch_shape)
-
         for backbone in valid_backbones:
-            if int(tf.VERSION.split('.')[1]) < 10:
-                # retinanet backbones do not work with versions < 1.10.0
-                continue
 
             with self.cached_session():
                 model = PhaseSegmentationModel(

--- a/deepcell/applications/scale_detection_test.py
+++ b/deepcell/applications/scale_detection_test.py
@@ -49,7 +49,7 @@ class TestScaleDetectionModel(test.TestCase):
         X = np.random.random(batch_shape)
 
         for backbone in valid_backbones:
-            with self.test_session():
+            with self.cached_session():
                 inputs = Input(shape=input_shape)
                 model = ScaleDetectionModel(
                     inputs=inputs,
@@ -61,7 +61,7 @@ class TestScaleDetectionModel(test.TestCase):
                 assert len(y.shape) == 2
                 assert y.shape[0] == X.shape[0]
 
-            with self.test_session():
+            with self.cached_session():
                 model = ScaleDetectionModel(
                     input_shape=input_shape,
                     backbone=backbone,

--- a/deepcell/callbacks_test.py
+++ b/deepcell/callbacks_test.py
@@ -35,6 +35,7 @@ import numpy as np
 
 from tensorflow.python import keras
 from tensorflow.python.platform import test
+from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.keras import testing_utils
 
 from deepcell.callbacks import RedirectModel
@@ -48,7 +49,8 @@ NUM_HIDDEN = 5
 BATCH_SIZE = 5
 
 
-class CallbacksTest(test.TestCase):
+@keras_parameterized.run_all_keras_modes
+class CallbacksTest(keras_parameterized.TestCase):
 
     def test_RedirectModel(self):
         with self.cached_session():

--- a/deepcell/callbacks_test.py
+++ b/deepcell/callbacks_test.py
@@ -51,7 +51,7 @@ BATCH_SIZE = 5
 class CallbacksTest(test.TestCase):
 
     def test_RedirectModel(self):
-        with self.test_session():
+        with self.cached_session():
             np.random.seed(123)
             (x_train, y_train), (x_test, y_test) = testing_utils.get_test_data(
                 train_samples=TRAIN_SAMPLES,

--- a/deepcell/image_generators/__init__.py
+++ b/deepcell/image_generators/__init__.py
@@ -35,15 +35,6 @@ import numpy as np
 
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.utils import to_categorical
-from tensorflow.python.keras.preprocessing.image import Iterator
-from tensorflow.python.keras.preprocessing.image import ImageDataGenerator
-
-# Check if ImageDataGenerator is 1.11.0 or later
-if not hasattr(ImageDataGenerator, 'apply_transform'):
-    # pylint: disable=W0404
-    # tf.version is 1.10.0 or earlier, use keras_preprocessing classes
-    from keras_preprocessing.image import Iterator
-    from keras_preprocessing.image import ImageDataGenerator
 
 from deepcell.utils import transform_utils
 

--- a/deepcell/image_generators/fully_convolutional.py
+++ b/deepcell/image_generators/fully_convolutional.py
@@ -35,6 +35,8 @@ import numpy as np
 
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.preprocessing.image import array_to_img
+from tensorflow.python.keras.preprocessing.image import Iterator
+from tensorflow.python.keras.preprocessing.image import ImageDataGenerator
 from tensorflow.python.platform import tf_logging as logging
 
 try:
@@ -47,8 +49,6 @@ except ImportError:
     scipy = None
 
 from deepcell.image_generators import _transform_masks
-from deepcell.image_generators import Iterator
-from deepcell.image_generators import ImageDataGenerator
 
 
 class ImageFullyConvIterator(Iterator):

--- a/deepcell/image_generators/retinanet.py
+++ b/deepcell/image_generators/retinanet.py
@@ -38,6 +38,7 @@ from skimage.segmentation import clear_border
 
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.preprocessing.image import array_to_img
+from tensorflow.python.keras.preprocessing.image import Iterator
 from tensorflow.python.platform import tf_logging as logging
 
 from deepcell.utils.retinanet_anchor_utils import anchor_targets_bbox
@@ -45,7 +46,6 @@ from deepcell.utils.retinanet_anchor_utils import anchors_for_shape
 from deepcell.utils.retinanet_anchor_utils import guess_shapes
 
 from deepcell.image_generators import _transform_masks
-from deepcell.image_generators import Iterator
 from deepcell.image_generators import ImageFullyConvDataGenerator
 from deepcell.image_generators import MovieDataGenerator
 

--- a/deepcell/image_generators/sample.py
+++ b/deepcell/image_generators/sample.py
@@ -37,10 +37,10 @@ from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.utils import to_categorical
 from tensorflow.python.keras.utils import conv_utils
 from tensorflow.python.keras.preprocessing.image import array_to_img
+from tensorflow.python.keras.preprocessing.image import Iterator
+from tensorflow.python.keras.preprocessing.image import ImageDataGenerator
 
 from deepcell.image_generators import _transform_masks
-from deepcell.image_generators import Iterator
-from deepcell.image_generators import ImageDataGenerator
 
 from deepcell.image_generators import MovieDataGenerator
 

--- a/deepcell/image_generators/scale.py
+++ b/deepcell/image_generators/scale.py
@@ -36,7 +36,8 @@ import numpy as np
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.preprocessing.image import array_to_img
 from tensorflow.python.keras.preprocessing.image import Iterator
-from tensorflow.python.keras.preprocessing.image import ImageDataGenerator
+
+from deepcell.image_generators import ImageFullyConvDataGenerator
 
 
 class ScaleIterator(Iterator):

--- a/deepcell/image_generators/scale.py
+++ b/deepcell/image_generators/scale.py
@@ -35,9 +35,8 @@ import numpy as np
 
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.preprocessing.image import array_to_img
-
-from deepcell.image_generators import Iterator
-from deepcell.image_generators import ImageFullyConvDataGenerator
+from tensorflow.python.keras.preprocessing.image import Iterator
+from tensorflow.python.keras.preprocessing.image import ImageDataGenerator
 
 
 class ScaleIterator(Iterator):

--- a/deepcell/image_generators/tracking.py
+++ b/deepcell/image_generators/tracking.py
@@ -35,9 +35,8 @@ from skimage.transform import resize
 
 from tensorflow.python.keras import backend as K
 from tensorflow.python.platform import tf_logging as logging
-
-from deepcell.image_generators import Iterator
-from deepcell.image_generators import ImageDataGenerator
+from tensorflow.python.keras.preprocessing.image import Iterator
+from tensorflow.python.keras.preprocessing.image import ImageDataGenerator
 
 
 class SiameseDataGenerator(ImageDataGenerator):

--- a/deepcell/initializers_test.py
+++ b/deepcell/initializers_test.py
@@ -51,6 +51,6 @@ class InitializersTest(test.TestCase):
     def test_prior_probability(self):
         tensor_shape = (8, 12, 99)
         # TODO: use self.test_session() if tf version >= 1.11.0
-        with self.test_session():
+        with self.cached_session():
             self._runner(PriorProbability(probability=0.01),
                          tensor_shape, target_mean=0., target_std=1)

--- a/deepcell/initializers_test.py
+++ b/deepcell/initializers_test.py
@@ -30,12 +30,13 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow.python.keras import backend as K
-from tensorflow.python.platform import test
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.initializers import PriorProbability
 
 
-class InitializersTest(test.TestCase):
+@keras_parameterized.run_all_keras_modes
+class InitializersTest(keras_parameterized.TestCase):
 
     def _runner(self, init, shape, target_mean=None, target_std=None,
                 target_max=None, target_min=None):

--- a/deepcell/layers/filter_detections_test.py
+++ b/deepcell/layers/filter_detections_test.py
@@ -177,57 +177,57 @@ class TestFilterDetections(keras_parameterized.TestCase):
         for a, e in zip(actual_other, expected_other):
             self.assertAllEqual(a, e)
 
-    # def test_mini_batch(self):
-    #     with self.cached_session():
-    #         # create simple FilterDetections layer
-    #         layer = layers.FilterDetections()
-    #
-    #         # create input with batch_size=2
-    #         boxes = np.array([
-    #             [
-    #                 [0, 0, 10, 10],  # this will be suppressed
-    #                 [0, 0, 10, 10],
-    #             ],
-    #             [
-    #                 [100, 100, 150, 150],
-    #                 [100, 100, 150, 150],  # this will be suppressed
-    #             ],
-    #         ], dtype=K.floatx())
-    #         boxes = K.constant(boxes)
-    #
-    #         classification = np.array([
-    #             [
-    #                 [0, 0.9],  # this will be suppressed
-    #                 [0, 1],
-    #             ],
-    #             [
-    #                 [1, 0],
-    #                 [0.9, 0],  # this will be suppressed
-    #             ],
-    #         ], dtype=K.floatx())
-    #         classification = K.constant(classification)
-    #
-    #         # compute output
-    #         actual_boxes, actual_scores, actual_labels = layer.call(
-    #             [boxes, classification])
-    #         actual_boxes = K.get_value(actual_boxes)
-    #         actual_scores = K.get_value(actual_scores)
-    #         actual_labels = K.get_value(actual_labels)
-    #
-    #         # define expected output
-    #         expected_boxes = -1 * np.ones((2, 300, 4), dtype=K.floatx())
-    #         expected_boxes[0, 0, :] = [0, 0, 10, 10]
-    #         expected_boxes[1, 0, :] = [100, 100, 150, 150]
-    #
-    #         expected_scores = -1 * np.ones((2, 300), dtype=K.floatx())
-    #         expected_scores[0, 0] = 1
-    #         expected_scores[1, 0] = 1
-    #
-    #         expected_labels = -1 * np.ones((2, 300), dtype=K.floatx())
-    #         expected_labels[0, 0] = 1
-    #         expected_labels[1, 0] = 0
-    #
-    #         # assert actual and expected are equal
-    #         self.assertAllEqual(actual_boxes, expected_boxes)
-    #         self.assertAllEqual(actual_scores, expected_scores)
-    #         self.assertAllEqual(actual_labels, expected_labels)
+    def test_mini_batch(self):
+        with self.cached_session():
+            # create simple FilterDetections layer
+            layer = layers.FilterDetections()
+
+            # create input with batch_size=2
+            boxes = np.array([
+                [
+                    [0, 0, 10, 10],  # this will be suppressed
+                    [0, 0, 10, 10],
+                ],
+                [
+                    [100, 100, 150, 150],
+                    [100, 100, 150, 150],  # this will be suppressed
+                ],
+            ], dtype=K.floatx())
+            boxes = K.constant(boxes)
+
+            classification = np.array([
+                [
+                    [0, 0.9],  # this will be suppressed
+                    [0, 1],
+                ],
+                [
+                    [1, 0],
+                    [0.9, 0],  # this will be suppressed
+                ],
+            ], dtype=K.floatx())
+            classification = K.constant(classification)
+
+            # compute output
+            actual_boxes, actual_scores, actual_labels = layer.call(
+                [boxes, classification])
+            actual_boxes = K.get_value(actual_boxes)
+            actual_scores = K.get_value(actual_scores)
+            actual_labels = K.get_value(actual_labels)
+
+            # define expected output
+            expected_boxes = -1 * np.ones((2, 300, 4), dtype=K.floatx())
+            expected_boxes[0, 0, :] = [0, 0, 10, 10]
+            expected_boxes[1, 0, :] = [100, 100, 150, 150]
+
+            expected_scores = -1 * np.ones((2, 300), dtype=K.floatx())
+            expected_scores[0, 0] = 1
+            expected_scores[1, 0] = 1
+
+            expected_labels = -1 * np.ones((2, 300), dtype=K.floatx())
+            expected_labels[0, 0] = 1
+            expected_labels[1, 0] = 0
+
+            # assert actual and expected are equal
+            self.assertAllEqual(actual_boxes, expected_boxes)
+            self.assertAllEqual(actual_scores, expected_scores)
+            self.assertAllEqual(actual_labels, expected_labels)

--- a/deepcell/layers/filter_detections_test.py
+++ b/deepcell/layers/filter_detections_test.py
@@ -40,148 +40,145 @@ class TestFilterDetections(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
-        with self.cached_session():
-            # create simple FilterDetections layer
-            layer = layers.FilterDetections()
+        # create simple FilterDetections layer
+        layer = layers.FilterDetections()
 
-            # create simple input
-            boxes = np.array([[
-                [0, 0, 10, 10],
-                [0, 0, 10, 10],  # this will be suppressed
-            ]], dtype=K.floatx())
-            boxes = K.constant(boxes)
+        # create simple input
+        boxes = np.array([[
+            [0, 0, 10, 10],
+            [0, 0, 10, 10],  # this will be suppressed
+        ]], dtype=K.floatx())
+        boxes = K.constant(boxes)
 
-            classification = np.array([[
-                [0, 0.9],  # this will be suppressed
-                [0, 1],
-            ]], dtype=K.floatx())
-            classification = K.constant(classification)
+        classification = np.array([[
+            [0, 0.9],  # this will be suppressed
+            [0, 1],
+        ]], dtype=K.floatx())
+        classification = K.constant(classification)
 
-            # compute output
-            actual_boxes, actual_scores, actual_labels = layer.call(
-                [boxes, classification])
-            actual_boxes = K.get_value(actual_boxes)
-            actual_scores = K.get_value(actual_scores)
-            actual_labels = K.get_value(actual_labels)
+        # compute output
+        actual_boxes, actual_scores, actual_labels = layer.call(
+            [boxes, classification])
+        actual_boxes = K.get_value(actual_boxes)
+        actual_scores = K.get_value(actual_scores)
+        actual_labels = K.get_value(actual_labels)
 
-            # define expected output
-            expected_boxes = -1 * np.ones((1, 300, 4), dtype=K.floatx())
-            expected_boxes[0, 0, :] = [0, 0, 10, 10]
+        # define expected output
+        expected_boxes = -1 * np.ones((1, 300, 4), dtype=K.floatx())
+        expected_boxes[0, 0, :] = [0, 0, 10, 10]
 
-            expected_scores = -1 * np.ones((1, 300), dtype=K.floatx())
-            expected_scores[0, 0] = 1
+        expected_scores = -1 * np.ones((1, 300), dtype=K.floatx())
+        expected_scores[0, 0] = 1
 
-            expected_labels = -1 * np.ones((1, 300), dtype=K.floatx())
-            expected_labels[0, 0] = 1
+        expected_labels = -1 * np.ones((1, 300), dtype=K.floatx())
+        expected_labels[0, 0] = 1
 
-            # assert actual and expected are equal
-            self.assertAllEqual(actual_boxes, expected_boxes)
-            self.assertAllEqual(actual_scores, expected_scores)
-            self.assertAllEqual(actual_labels, expected_labels)
+        # assert actual and expected are equal
+        self.assertAllEqual(actual_boxes, expected_boxes)
+        self.assertAllEqual(actual_scores, expected_scores)
+        self.assertAllEqual(actual_labels, expected_labels)
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple_3d(self):
-        with self.cached_session():
-            # create simple FilterDetections layer
-            layer = layers.FilterDetections()
+        # create simple FilterDetections layer
+        layer = layers.FilterDetections()
 
-            # create simple input
-            boxes = np.array([[
-                [0, 0, 10, 10],
-                [0, 0, 10, 10],  # this will be suppressed
-            ]], dtype=K.floatx())
-            boxes = np.expand_dims(boxes, 0)
-            boxes = K.constant(boxes)
+        # create simple input
+        boxes = np.array([[
+            [0, 0, 10, 10],
+            [0, 0, 10, 10],  # this will be suppressed
+        ]], dtype=K.floatx())
+        boxes = np.expand_dims(boxes, 0)
+        boxes = K.constant(boxes)
 
-            classification = np.array([[
-                [0, 0.9],  # this will be suppressed
-                [0, 1],
-            ]], dtype=K.floatx())
-            classification = np.expand_dims(classification, 0)
-            classification = K.constant(classification)
+        classification = np.array([[
+            [0, 0.9],  # this will be suppressed
+            [0, 1],
+        ]], dtype=K.floatx())
+        classification = np.expand_dims(classification, 0)
+        classification = K.constant(classification)
 
-            # compute output
-            actual_boxes, actual_scores, actual_labels = layer.call(
-                [boxes, classification])
-            actual_boxes = K.get_value(actual_boxes)
-            actual_scores = K.get_value(actual_scores)
-            actual_labels = K.get_value(actual_labels)
+        # compute output
+        actual_boxes, actual_scores, actual_labels = layer.call(
+            [boxes, classification])
+        actual_boxes = K.get_value(actual_boxes)
+        actual_scores = K.get_value(actual_scores)
+        actual_labels = K.get_value(actual_labels)
 
-            # define expected output
-            expected_boxes = -1 * np.ones((1, 1, 300, 4), dtype=K.floatx())
-            expected_boxes[0, 0, 0, :] = [0, 0, 10, 10]
+        # define expected output
+        expected_boxes = -1 * np.ones((1, 1, 300, 4), dtype=K.floatx())
+        expected_boxes[0, 0, 0, :] = [0, 0, 10, 10]
 
-            expected_scores = -1 * np.ones((1, 1, 300), dtype=K.floatx())
-            expected_scores[0, 0, 0] = 1
+        expected_scores = -1 * np.ones((1, 1, 300), dtype=K.floatx())
+        expected_scores[0, 0, 0] = 1
 
-            expected_labels = -1 * np.ones((1, 1, 300), dtype=K.floatx())
-            expected_labels[0, 0, 0] = 1
+        expected_labels = -1 * np.ones((1, 1, 300), dtype=K.floatx())
+        expected_labels[0, 0, 0] = 1
 
-            # assert actual and expected are equal
-            self.assertAllEqual(actual_boxes, expected_boxes)
-            self.assertAllEqual(actual_scores, expected_scores)
-            self.assertAllEqual(actual_labels, expected_labels)
+        # assert actual and expected are equal
+        self.assertAllEqual(actual_boxes, expected_boxes)
+        self.assertAllEqual(actual_scores, expected_scores)
+        self.assertAllEqual(actual_labels, expected_labels)
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple_with_other(self):
-        with self.cached_session():
-            # create simple FilterDetections layer
-            layer = layers.FilterDetections()
+        # create simple FilterDetections layer
+        layer = layers.FilterDetections()
 
-            # create simple input
-            boxes = np.array([[
-                [0, 0, 10, 10],
-                [0, 0, 10, 10],  # this will be suppressed
-            ]], dtype=K.floatx())
-            boxes = K.constant(boxes)
+        # create simple input
+        boxes = np.array([[
+            [0, 0, 10, 10],
+            [0, 0, 10, 10],  # this will be suppressed
+        ]], dtype=K.floatx())
+        boxes = K.constant(boxes)
 
-            classification = np.array([[
-                [0, 0.9],  # this will be suppressed
-                [0, 1],
-            ]], dtype=K.floatx())
-            classification = K.constant(classification)
+        classification = np.array([[
+            [0, 0.9],  # this will be suppressed
+            [0, 1],
+        ]], dtype=K.floatx())
+        classification = K.constant(classification)
 
-            other = []
-            other.append(np.array([[
-                [0, 1234],  # this will be suppressed
-                [0, 5678],
-            ]], dtype=K.floatx()))
-            other.append(np.array([[
-                5678,  # this will be suppressed
-                1234,
-            ]], dtype=K.floatx()))
-            other = [K.constant(o) for o in other]
+        other = []
+        other.append(np.array([[
+            [0, 1234],  # this will be suppressed
+            [0, 5678],
+        ]], dtype=K.floatx()))
+        other.append(np.array([[
+            5678,  # this will be suppressed
+            1234,
+        ]], dtype=K.floatx()))
+        other = [K.constant(o) for o in other]
 
-            # compute output
-            actual = layer.call([boxes, classification] + other)
-            actual_boxes = K.get_value(actual[0])
-            actual_scores = K.get_value(actual[1])
-            actual_labels = K.get_value(actual[2])
-            actual_other = [K.get_value(a) for a in actual[3:]]
+        # compute output
+        actual = layer.call([boxes, classification] + other)
+        actual_boxes = K.get_value(actual[0])
+        actual_scores = K.get_value(actual[1])
+        actual_labels = K.get_value(actual[2])
+        actual_other = [K.get_value(a) for a in actual[3:]]
 
-            # define expected output
-            expected_boxes = -1 * np.ones((1, 300, 4), dtype=K.floatx())
-            expected_boxes[0, 0, :] = [0, 0, 10, 10]
+        # define expected output
+        expected_boxes = -1 * np.ones((1, 300, 4), dtype=K.floatx())
+        expected_boxes[0, 0, :] = [0, 0, 10, 10]
 
-            expected_scores = -1 * np.ones((1, 300), dtype=K.floatx())
-            expected_scores[0, 0] = 1
+        expected_scores = -1 * np.ones((1, 300), dtype=K.floatx())
+        expected_scores[0, 0] = 1
 
-            expected_labels = -1 * np.ones((1, 300), dtype=K.floatx())
-            expected_labels[0, 0] = 1
+        expected_labels = -1 * np.ones((1, 300), dtype=K.floatx())
+        expected_labels[0, 0] = 1
 
-            expected_other = []
-            expected_other.append(-1 * np.ones((1, 300, 2), dtype=K.floatx()))
-            expected_other[-1][0, 0, :] = [0, 5678]
-            expected_other.append(-1 * np.ones((1, 300), dtype=K.floatx()))
-            expected_other[-1][0, 0] = 1234
+        expected_other = []
+        expected_other.append(-1 * np.ones((1, 300, 2), dtype=K.floatx()))
+        expected_other[-1][0, 0, :] = [0, 5678]
+        expected_other.append(-1 * np.ones((1, 300), dtype=K.floatx()))
+        expected_other[-1][0, 0] = 1234
 
-            # assert actual and expected are equal
-            self.assertAllEqual(actual_boxes, expected_boxes)
-            self.assertAllEqual(actual_scores, expected_scores)
-            self.assertAllEqual(actual_labels, expected_labels)
+        # assert actual and expected are equal
+        self.assertAllEqual(actual_boxes, expected_boxes)
+        self.assertAllEqual(actual_scores, expected_scores)
+        self.assertAllEqual(actual_labels, expected_labels)
 
-            for a, e in zip(actual_other, expected_other):
-                self.assertAllEqual(a, e)
+        for a, e in zip(actual_other, expected_other):
+            self.assertAllEqual(a, e)
 
     # @tf_test_util.run_in_graph_and_eager_modes()
     # def test_mini_batch(self):

--- a/deepcell/layers/filter_detections_test.py
+++ b/deepcell/layers/filter_detections_test.py
@@ -30,15 +30,14 @@ from __future__ import division
 
 import numpy as np
 from tensorflow.python.keras import backend as K
-from tensorflow.python.framework import test_util as tf_test_util
-from tensorflow.python.platform import test
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell import layers
 
 
-class TestFilterDetections(test.TestCase):
+@keras_parameterized.run_all_keras_modes
+class TestFilterDetections(keras_parameterized.TestCase):
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
         # create simple FilterDetections layer
         layer = layers.FilterDetections()
@@ -78,7 +77,6 @@ class TestFilterDetections(test.TestCase):
         self.assertAllEqual(actual_scores, expected_scores)
         self.assertAllEqual(actual_labels, expected_labels)
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple_3d(self):
         # create simple FilterDetections layer
         layer = layers.FilterDetections()
@@ -120,7 +118,6 @@ class TestFilterDetections(test.TestCase):
         self.assertAllEqual(actual_scores, expected_scores)
         self.assertAllEqual(actual_labels, expected_labels)
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple_with_other(self):
         # create simple FilterDetections layer
         layer = layers.FilterDetections()
@@ -180,7 +177,6 @@ class TestFilterDetections(test.TestCase):
         for a, e in zip(actual_other, expected_other):
             self.assertAllEqual(a, e)
 
-    # @tf_test_util.run_in_graph_and_eager_modes()
     # def test_mini_batch(self):
     #     with self.cached_session():
     #         # create simple FilterDetections layer

--- a/deepcell/layers/filter_detections_test.py
+++ b/deepcell/layers/filter_detections_test.py
@@ -40,7 +40,7 @@ class TestFilterDetections(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
-        with self.test_session():
+        with self.cached_session():
             # create simple FilterDetections layer
             layer = layers.FilterDetections()
 
@@ -81,7 +81,7 @@ class TestFilterDetections(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple_3d(self):
-        with self.test_session():
+        with self.cached_session():
             # create simple FilterDetections layer
             layer = layers.FilterDetections()
 
@@ -124,7 +124,7 @@ class TestFilterDetections(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple_with_other(self):
-        with self.test_session():
+        with self.cached_session():
             # create simple FilterDetections layer
             layer = layers.FilterDetections()
 
@@ -185,7 +185,7 @@ class TestFilterDetections(test.TestCase):
 
     # @tf_test_util.run_in_graph_and_eager_modes()
     # def test_mini_batch(self):
-    #     with self.test_session():
+    #     with self.cached_session():
     #         # create simple FilterDetections layer
     #         layer = layers.FilterDetections()
     #

--- a/deepcell/layers/location_test.py
+++ b/deepcell/layers/location_test.py
@@ -28,16 +28,15 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
-from tensorflow.python.framework import test_util as tf_test_util
-from tensorflow.python.platform import test
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.utils import testing_utils
 from deepcell import layers
 
 
-class LocationTest(test.TestCase):
+@keras_parameterized.run_all_keras_modes
+class LocationTest(keras_parameterized.TestCase):
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_location_2d(self):
         testing_utils.layer_test(
             layers.Location2D,
@@ -52,7 +51,6 @@ class LocationTest(test.TestCase):
             custom_objects={'Location2D': layers.Location2D},
             input_shape=(3, 4, 5, 6))
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_location_3d(self):
         testing_utils.layer_test(
             layers.Location3D,

--- a/deepcell/layers/location_test.py
+++ b/deepcell/layers/location_test.py
@@ -39,7 +39,7 @@ class LocationTest(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_location_2d(self):
-        with self.test_session():
+        with self.cached_session():
             testing_utils.layer_test(
                 layers.Location2D,
                 kwargs={'in_shape': (5, 6, 4),
@@ -55,7 +55,7 @@ class LocationTest(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_location_3d(self):
-        with self.test_session():
+        with self.cached_session():
             testing_utils.layer_test(
                 layers.Location3D,
                 kwargs={'in_shape': (11, 12, 10, 4),

--- a/deepcell/layers/location_test.py
+++ b/deepcell/layers/location_test.py
@@ -39,32 +39,30 @@ class LocationTest(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_location_2d(self):
-        with self.cached_session():
-            testing_utils.layer_test(
-                layers.Location2D,
-                kwargs={'in_shape': (5, 6, 4),
-                        'data_format': 'channels_last'},
-                custom_objects={'Location2D': layers.Location2D},
-                input_shape=(3, 5, 6, 4))
-            testing_utils.layer_test(
-                layers.Location2D,
-                kwargs={'in_shape': (4, 5, 6),
-                        'data_format': 'channels_first'},
-                custom_objects={'Location2D': layers.Location2D},
-                input_shape=(3, 4, 5, 6))
+        testing_utils.layer_test(
+            layers.Location2D,
+            kwargs={'in_shape': (5, 6, 4),
+                    'data_format': 'channels_last'},
+            custom_objects={'Location2D': layers.Location2D},
+            input_shape=(3, 5, 6, 4))
+        testing_utils.layer_test(
+            layers.Location2D,
+            kwargs={'in_shape': (4, 5, 6),
+                    'data_format': 'channels_first'},
+            custom_objects={'Location2D': layers.Location2D},
+            input_shape=(3, 4, 5, 6))
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_location_3d(self):
-        with self.cached_session():
-            testing_utils.layer_test(
-                layers.Location3D,
-                kwargs={'in_shape': (11, 12, 10, 4),
-                        'data_format': 'channels_last'},
-                custom_objects={'Location3D': layers.Location3D},
-                input_shape=(3, 11, 12, 10, 4))
-            testing_utils.layer_test(
-                layers.Location3D,
-                kwargs={'in_shape': (4, 11, 12, 10),
-                        'data_format': 'channels_first'},
-                custom_objects={'Location3D': layers.Location3D},
-                input_shape=(3, 4, 11, 12, 10))
+        testing_utils.layer_test(
+            layers.Location3D,
+            kwargs={'in_shape': (11, 12, 10, 4),
+                    'data_format': 'channels_last'},
+            custom_objects={'Location3D': layers.Location3D},
+            input_shape=(3, 11, 12, 10, 4))
+        testing_utils.layer_test(
+            layers.Location3D,
+            kwargs={'in_shape': (4, 11, 12, 10),
+                    'data_format': 'channels_first'},
+            custom_objects={'Location3D': layers.Location3D},
+            input_shape=(3, 4, 11, 12, 10))

--- a/deepcell/layers/normalization_test.py
+++ b/deepcell/layers/normalization_test.py
@@ -43,7 +43,7 @@ class ImageNormalizationTest(test.TestCase):
     def test_normalize_2d(self):
         custom_objects = {'ImageNormalization2D': layers.ImageNormalization2D}
         norm_methods = [None, 'std', 'max', 'whole_image']
-        with self.test_session():
+        with self.cached_session():
             # test each norm method
             for norm_method in norm_methods:
                 testing_utils.layer_test(
@@ -86,7 +86,7 @@ class ImageNormalizationTest(test.TestCase):
     def test_normalize_3d(self):
         custom_objects = {'ImageNormalization3D': layers.ImageNormalization3D}
         norm_methods = [None, 'std', 'max', 'whole_image']
-        with self.test_session():
+        with self.cached_session():
             # test each norm method
             for norm_method in norm_methods:
                 testing_utils.layer_test(

--- a/deepcell/layers/normalization_test.py
+++ b/deepcell/layers/normalization_test.py
@@ -30,16 +30,14 @@ from __future__ import division
 
 import numpy as np
 from tensorflow.python import keras
-from tensorflow.python.platform import test
-from tensorflow.python.framework import test_util as tf_test_util
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.utils import testing_utils
 from deepcell import layers
 
 
-class ImageNormalizationTest(test.TestCase):
+class ImageNormalizationTest(keras_parameterized.TestCase):
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_normalize_2d(self):
         custom_objects = {'ImageNormalization2D': layers.ImageNormalization2D}
         norm_methods = [None, 'std', 'max', 'whole_image']
@@ -81,7 +79,6 @@ class ImageNormalizationTest(test.TestCase):
                 layer = layers.ImageNormalization2D()
                 layer.build([3, 5, 6, None])
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_normalize_3d(self):
         custom_objects = {'ImageNormalization3D': layers.ImageNormalization3D}
         norm_methods = [None, 'std', 'max', 'whole_image']

--- a/deepcell/layers/normalization_test.py
+++ b/deepcell/layers/normalization_test.py
@@ -43,23 +43,22 @@ class ImageNormalizationTest(test.TestCase):
     def test_normalize_2d(self):
         custom_objects = {'ImageNormalization2D': layers.ImageNormalization2D}
         norm_methods = [None, 'std', 'max', 'whole_image']
-        with self.cached_session():
-            # test each norm method
-            for norm_method in norm_methods:
-                testing_utils.layer_test(
-                    layers.ImageNormalization2D,
-                    kwargs={'norm_method': norm_method,
-                            'filter_size': 3,
-                            'data_format': 'channels_last'},
-                    custom_objects=custom_objects,
-                    input_shape=(3, 5, 6, 4))
-                testing_utils.layer_test(
-                    layers.ImageNormalization2D,
-                    kwargs={'norm_method': norm_method,
-                            'filter_size': 3,
-                            'data_format': 'channels_first'},
-                    custom_objects=custom_objects,
-                    input_shape=(3, 4, 5, 6))
+        # test each norm method
+        for norm_method in norm_methods:
+            testing_utils.layer_test(
+                layers.ImageNormalization2D,
+                kwargs={'norm_method': norm_method,
+                        'filter_size': 3,
+                        'data_format': 'channels_last'},
+                custom_objects=custom_objects,
+                input_shape=(3, 5, 6, 4))
+            testing_utils.layer_test(
+                layers.ImageNormalization2D,
+                kwargs={'norm_method': norm_method,
+                        'filter_size': 3,
+                        'data_format': 'channels_first'},
+                custom_objects=custom_objects,
+                input_shape=(3, 4, 5, 6))
             # test constraints and bias
             k_constraint = keras.constraints.max_norm(0.01)
             b_constraint = keras.constraints.max_norm(0.01)
@@ -86,23 +85,22 @@ class ImageNormalizationTest(test.TestCase):
     def test_normalize_3d(self):
         custom_objects = {'ImageNormalization3D': layers.ImageNormalization3D}
         norm_methods = [None, 'std', 'max', 'whole_image']
-        with self.cached_session():
-            # test each norm method
-            for norm_method in norm_methods:
-                testing_utils.layer_test(
-                    layers.ImageNormalization3D,
-                    kwargs={'norm_method': norm_method,
-                            'filter_size': 3,
-                            'data_format': 'channels_last'},
-                    custom_objects=custom_objects,
-                    input_shape=(3, 11, 12, 10, 4))
-                testing_utils.layer_test(
-                    layers.ImageNormalization3D,
-                    kwargs={'norm_method': norm_method,
-                            'filter_size': 3,
-                            'data_format': 'channels_first'},
-                    custom_objects=custom_objects,
-                    input_shape=(3, 4, 11, 12, 10))
+        # test each norm method
+        for norm_method in norm_methods:
+            testing_utils.layer_test(
+                layers.ImageNormalization3D,
+                kwargs={'norm_method': norm_method,
+                        'filter_size': 3,
+                        'data_format': 'channels_last'},
+                custom_objects=custom_objects,
+                input_shape=(3, 11, 12, 10, 4))
+            testing_utils.layer_test(
+                layers.ImageNormalization3D,
+                kwargs={'norm_method': norm_method,
+                        'filter_size': 3,
+                        'data_format': 'channels_first'},
+                custom_objects=custom_objects,
+                input_shape=(3, 4, 11, 12, 10))
             # test constraints and bias
             k_constraint = keras.constraints.max_norm(0.01)
             b_constraint = keras.constraints.max_norm(0.01)

--- a/deepcell/layers/padding_test.py
+++ b/deepcell/layers/padding_test.py
@@ -33,8 +33,7 @@ import numpy as np
 
 # from tensorflow.python import keras
 # from tensorflow.python.eager import context
-from tensorflow.python.framework import test_util as tf_test_util
-from tensorflow.python.platform import test
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.utils import testing_utils
 from deepcell import layers
@@ -45,9 +44,9 @@ def _get_random_padding(dim):
     return tuple([(R(), R()) for _ in range(dim)])
 
 
-class ReflectionPaddingTest(test.TestCase):
+@keras_parameterized.run_all_keras_modes
+class ReflectionPaddingTest(keras_parameterized.TestCase):
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_reflection_padding_2d(self):
         num_samples = 2
         stack_size = 2
@@ -129,7 +128,6 @@ class ReflectionPaddingTest(test.TestCase):
             with self.assertRaises(ValueError):
                 layers.ReflectionPadding2D(padding=None)
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_reflection_padding_3d(self):
         num_samples = 2
         stack_size = 2

--- a/deepcell/layers/padding_test.py
+++ b/deepcell/layers/padding_test.py
@@ -60,7 +60,7 @@ class ReflectionPaddingTest(test.TestCase):
         data_formats = ['channels_first', 'channels_last']
         for data_format, inputs in zip(data_formats, [ins2, ins1]):
             # basic test
-            with self.test_session():
+            with self.cached_session():
                 testing_utils.layer_test(
                     layers.ReflectionPadding2D,
                     kwargs={'padding': (2, 2),
@@ -75,7 +75,7 @@ class ReflectionPaddingTest(test.TestCase):
                     input_shape=inputs.shape)
 
             # correctness test
-            # with self.test_session():
+            # with self.cached_session():
             #     layer = layers.ReflectionPadding2D(
             #         padding=(2, 2), data_format=data_format)
             #     layer.build(inputs.shape)
@@ -146,7 +146,7 @@ class ReflectionPaddingTest(test.TestCase):
         data_formats = ['channels_first', 'channels_last']
         for data_format, inputs in zip(data_formats, [inputs2, inputs1]):
             # basic test
-            with self.test_session():
+            with self.cached_session():
                 testing_utils.layer_test(
                     layers.ReflectionPadding3D,
                     kwargs={'padding': (2, 2, 2),
@@ -155,7 +155,7 @@ class ReflectionPaddingTest(test.TestCase):
                     input_shape=inputs.shape)
 
         # correctness test
-        # with self.test_session():
+        # with self.cached_session():
         #     layer = layers.ReflectionPadding3D(padding=(2, 2, 2))
         #     layer.build(inputs.shape)
         #     output = layer(keras.backend.variable(inputs))

--- a/deepcell/layers/padding_test.py
+++ b/deepcell/layers/padding_test.py
@@ -60,19 +60,18 @@ class ReflectionPaddingTest(test.TestCase):
         data_formats = ['channels_first', 'channels_last']
         for data_format, inputs in zip(data_formats, [ins2, ins1]):
             # basic test
-            with self.cached_session():
-                testing_utils.layer_test(
-                    layers.ReflectionPadding2D,
-                    kwargs={'padding': (2, 2),
-                            'data_format': data_format},
-                    custom_objects=custom_objects,
-                    input_shape=inputs.shape)
-                testing_utils.layer_test(
-                    layers.ReflectionPadding2D,
-                    kwargs={'padding': ((1, 2), (3, 4)),
-                            'data_format': data_format},
-                    custom_objects=custom_objects,
-                    input_shape=inputs.shape)
+            testing_utils.layer_test(
+                layers.ReflectionPadding2D,
+                kwargs={'padding': (2, 2),
+                        'data_format': data_format},
+                custom_objects=custom_objects,
+                input_shape=inputs.shape)
+            testing_utils.layer_test(
+                layers.ReflectionPadding2D,
+                kwargs={'padding': ((1, 2), (3, 4)),
+                        'data_format': data_format},
+                custom_objects=custom_objects,
+                input_shape=inputs.shape)
 
             # correctness test
             # with self.cached_session():
@@ -146,13 +145,12 @@ class ReflectionPaddingTest(test.TestCase):
         data_formats = ['channels_first', 'channels_last']
         for data_format, inputs in zip(data_formats, [inputs2, inputs1]):
             # basic test
-            with self.cached_session():
-                testing_utils.layer_test(
-                    layers.ReflectionPadding3D,
-                    kwargs={'padding': (2, 2, 2),
-                            'data_format': data_format},
-                    custom_objects=custom_objects,
-                    input_shape=inputs.shape)
+            testing_utils.layer_test(
+                layers.ReflectionPadding3D,
+                kwargs={'padding': (2, 2, 2),
+                        'data_format': data_format},
+                custom_objects=custom_objects,
+                input_shape=inputs.shape)
 
         # correctness test
         # with self.cached_session():

--- a/deepcell/layers/pooling_test.py
+++ b/deepcell/layers/pooling_test.py
@@ -28,16 +28,15 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
-from tensorflow.python.framework import test_util as tf_test_util
-from tensorflow.python.platform import test
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.utils import testing_utils
 from deepcell import layers
 
 
-class DilatedMaxPoolingTest(test.TestCase):
+@keras_parameterized.run_all_keras_modes
+class DilatedMaxPoolingTest(keras_parameterized.TestCase):
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_dilated_max_pool_2d(self):
         pool_size = (3, 3)
         custom_objects = {'DilatedMaxPool2D': layers.DilatedMaxPool2D}
@@ -63,7 +62,6 @@ class DilatedMaxPoolingTest(test.TestCase):
                         custom_objects=custom_objects,
                         input_shape=(3, 4, 5, 6))
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_dilated_max_pool_3d(self):
         custom_objects = {'DilatedMaxPool3D': layers.DilatedMaxPool3D}
         pool_size = (3, 3, 3)

--- a/deepcell/layers/pooling_test.py
+++ b/deepcell/layers/pooling_test.py
@@ -44,25 +44,24 @@ class DilatedMaxPoolingTest(test.TestCase):
         for strides in [(1, 1), (2, 2), None]:
             for dilation_rate in [1, 2, (1, 2)]:
                 for padding in ['valid', 'same']:
-                    with self.cached_session():
-                        testing_utils.layer_test(
-                            layers.DilatedMaxPool2D,
-                            kwargs={'strides': strides,
-                                    'pool_size': pool_size,
-                                    'padding': padding,
-                                    'dilation_rate': dilation_rate,
-                                    'data_format': 'channels_last'},
-                            custom_objects=custom_objects,
-                            input_shape=(3, 5, 6, 4))
-                        testing_utils.layer_test(
-                            layers.DilatedMaxPool2D,
-                            kwargs={'strides': strides,
-                                    'pool_size': pool_size,
-                                    'padding': padding,
-                                    'dilation_rate': dilation_rate,
-                                    'data_format': 'channels_first'},
-                            custom_objects=custom_objects,
-                            input_shape=(3, 4, 5, 6))
+                    testing_utils.layer_test(
+                        layers.DilatedMaxPool2D,
+                        kwargs={'strides': strides,
+                                'pool_size': pool_size,
+                                'padding': padding,
+                                'dilation_rate': dilation_rate,
+                                'data_format': 'channels_last'},
+                        custom_objects=custom_objects,
+                        input_shape=(3, 5, 6, 4))
+                    testing_utils.layer_test(
+                        layers.DilatedMaxPool2D,
+                        kwargs={'strides': strides,
+                                'pool_size': pool_size,
+                                'padding': padding,
+                                'dilation_rate': dilation_rate,
+                                'data_format': 'channels_first'},
+                        custom_objects=custom_objects,
+                        input_shape=(3, 4, 5, 6))
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_dilated_max_pool_3d(self):

--- a/deepcell/layers/pooling_test.py
+++ b/deepcell/layers/pooling_test.py
@@ -44,7 +44,7 @@ class DilatedMaxPoolingTest(test.TestCase):
         for strides in [(1, 1), (2, 2), None]:
             for dilation_rate in [1, 2, (1, 2)]:
                 for padding in ['valid', 'same']:
-                    with self.test_session():
+                    with self.cached_session():
                         testing_utils.layer_test(
                             layers.DilatedMaxPool2D,
                             kwargs={'strides': strides,
@@ -71,7 +71,7 @@ class DilatedMaxPoolingTest(test.TestCase):
         for strides in [1, 2, None]:
             for dilation_rate in [1, 2, (1, 2, 2)]:
                 for padding in ['valid', 'same']:
-                    with self.test_session():
+                    with self.cached_session():
                         testing_utils.layer_test(
                             layers.DilatedMaxPool3D,
                             kwargs={'strides': strides,

--- a/deepcell/layers/resize_test.py
+++ b/deepcell/layers/resize_test.py
@@ -39,15 +39,14 @@ class ResizeTest(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_resize_2d(self):
-        with self.cached_session():
-            testing_utils.layer_test(
-                layers.Resize2D,
-                kwargs={'scale': 2},
-                custom_objects={'Resize2D': layers.Resize2D},
-                input_shape=(3, 5, 6, 4))
-            testing_utils.layer_test(
-                layers.Resize2D,
-                kwargs={'scale': 3,
-                        'data_format': 'channels_first'},
-                custom_objects={'Resize2D': layers.Resize2D},
-                input_shape=(3, 5, 6, 4))
+        testing_utils.layer_test(
+            layers.Resize2D,
+            kwargs={'scale': 2},
+            custom_objects={'Resize2D': layers.Resize2D},
+            input_shape=(3, 5, 6, 4))
+        testing_utils.layer_test(
+            layers.Resize2D,
+            kwargs={'scale': 3,
+                    'data_format': 'channels_first'},
+            custom_objects={'Resize2D': layers.Resize2D},
+            input_shape=(3, 5, 6, 4))

--- a/deepcell/layers/resize_test.py
+++ b/deepcell/layers/resize_test.py
@@ -28,16 +28,15 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
-from tensorflow.python.framework import test_util as tf_test_util
-from tensorflow.python.platform import test
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.utils import testing_utils
 from deepcell import layers
 
 
-class ResizeTest(test.TestCase):
+@keras_parameterized.run_all_keras_modes
+class ResizeTest(keras_parameterized.TestCase):
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_resize_2d(self):
         testing_utils.layer_test(
             layers.Resize2D,

--- a/deepcell/layers/resize_test.py
+++ b/deepcell/layers/resize_test.py
@@ -39,7 +39,7 @@ class ResizeTest(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_resize_2d(self):
-        with self.test_session():
+        with self.cached_session():
             testing_utils.layer_test(
                 layers.Resize2D,
                 kwargs={'scale': 2},

--- a/deepcell/layers/retinanet.py
+++ b/deepcell/layers/retinanet.py
@@ -110,6 +110,9 @@ class Anchors(Layer):
                 total = K.prod(input_shape[2:4]) * self.num_anchors
             else:
                 total = K.prod(input_shape[1:3]) * self.num_anchors
+
+            # TODO: fails time_distributed tests for RetinaMask
+            # AttributeError: 'Tensor' object has no attribute 'numpy'
             total = K.get_value(total)
 
             return tensor_shape.TensorShape((input_shape[0], total, 4))

--- a/deepcell/layers/retinanet_test.py
+++ b/deepcell/layers/retinanet_test.py
@@ -37,7 +37,7 @@ from deepcell import layers
 
 
 @keras_parameterized.run_all_keras_modes
-class TestAnchors(run_all_keras_modes.TestCase):
+class TestAnchors(keras_parameterized.TestCase):
 
     def test_anchors_2d(self):
         testing_utils.layer_test(
@@ -118,7 +118,7 @@ class TestAnchors(run_all_keras_modes.TestCase):
 
 
 @keras_parameterized.run_all_keras_modes
-class TestRegressBoxes(run_all_keras_modes.TestCase):
+class TestRegressBoxes(keras_parameterized.TestCase):
 
     def test_simple(self):
         # create simple RegressBoxes layer
@@ -223,7 +223,7 @@ class TestRegressBoxes(run_all_keras_modes.TestCase):
 
 
 @keras_parameterized.run_all_keras_modes
-class ClipBoxesTest(run_all_keras_modes.TestCase):
+class ClipBoxesTest(keras_parameterized.TestCase):
 
     def test_simple(self):
         img_h, img_w = np.random.randint(2, 5), np.random.randint(5, 9)

--- a/deepcell/layers/retinanet_test.py
+++ b/deepcell/layers/retinanet_test.py
@@ -41,185 +41,180 @@ class TestAnchors(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_anchors_2d(self):
-        with self.cached_session():
-            testing_utils.layer_test(
-                layers.Anchors,
-                kwargs={'size': 1, 'stride': 1,
-                        'data_format': 'channels_last'},
-                custom_objects={'Anchors': layers.Anchors},
-                input_shape=(3, 5, 6, 4))
-            testing_utils.layer_test(
-                layers.Anchors,
-                kwargs={'size': 1, 'stride': 1,
-                        'data_format': 'channels_last'},
-                custom_objects={'Anchors': layers.Anchors},
-                input_shape=(3, None, None, None))
-            testing_utils.layer_test(
-                layers.Anchors,
-                kwargs={'size': 1, 'stride': 1,
-                        'data_format': 'channels_first'},
-                custom_objects={'Anchors': layers.Anchors},
-                input_shape=(3, 5, 6, 4))
+        testing_utils.layer_test(
+            layers.Anchors,
+            kwargs={'size': 1, 'stride': 1,
+                    'data_format': 'channels_last'},
+            custom_objects={'Anchors': layers.Anchors},
+            input_shape=(3, 5, 6, 4))
+        testing_utils.layer_test(
+            layers.Anchors,
+            kwargs={'size': 1, 'stride': 1,
+                    'data_format': 'channels_last'},
+            custom_objects={'Anchors': layers.Anchors},
+            input_shape=(3, None, None, None))
+        testing_utils.layer_test(
+            layers.Anchors,
+            kwargs={'size': 1, 'stride': 1,
+                    'data_format': 'channels_first'},
+            custom_objects={'Anchors': layers.Anchors},
+            input_shape=(3, 5, 6, 4))
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
-        with self.cached_session():
-            # create simple Anchors layer
-            anchors_layer = layers.Anchors(
-                size=32,
-                stride=8,
-                ratios=np.array([1], K.floatx()),
-                scales=np.array([1], K.floatx()),
-            )
+        # create simple Anchors layer
+        anchors_layer = layers.Anchors(
+            size=32,
+            stride=8,
+            ratios=np.array([1], K.floatx()),
+            scales=np.array([1], K.floatx()),
+        )
 
-            # create fake features input (only shape is used anyway)
-            features = np.zeros((1, 2, 2, 1024), dtype=K.floatx())
-            features = K.variable(features)
+        # create fake features input (only shape is used anyway)
+        features = np.zeros((1, 2, 2, 1024), dtype=K.floatx())
+        features = K.variable(features)
 
-            # call the Anchors layer
-            anchors = anchors_layer.call(features)
-            anchors = K.get_value(anchors)
+        # call the Anchors layer
+        anchors = anchors_layer.call(features)
+        anchors = K.get_value(anchors)
 
-            # expected anchor values
-            expected = np.array([[
-                [-12, -12, 20, 20],
-                [-4, -12, 28, 20],
-                [-12, -4, 20, 28],
-                [-4, -4, 28, 28],
-            ]], dtype=K.floatx())
+        # expected anchor values
+        expected = np.array([[
+            [-12, -12, 20, 20],
+            [-4, -12, 28, 20],
+            [-12, -4, 20, 28],
+            [-4, -4, 28, 28],
+        ]], dtype=K.floatx())
 
-            # test anchor values
-            self.assertAllEqual(anchors, expected)
+        # test anchor values
+        self.assertAllEqual(anchors, expected)
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_mini_batch(self):
-        with self.cached_session():
-            # create simple Anchors layer
-            anchors_layer = layers.Anchors(
-                size=32,
-                stride=8,
-                ratios=np.array([1], dtype=K.floatx()),
-                scales=np.array([1], dtype=K.floatx()),
-            )
+        # create simple Anchors layer
+        anchors_layer = layers.Anchors(
+            size=32,
+            stride=8,
+            ratios=np.array([1], dtype=K.floatx()),
+            scales=np.array([1], dtype=K.floatx()),
+        )
 
-            # create fake features input with batch_size=2
-            features = np.zeros((2, 2, 2, 1024), dtype=K.floatx())
-            features = K.variable(features)
+        # create fake features input with batch_size=2
+        features = np.zeros((2, 2, 2, 1024), dtype=K.floatx())
+        features = K.variable(features)
 
-            # call the Anchors layer
-            anchors = anchors_layer.call(features)
-            anchors = K.get_value(anchors)
+        # call the Anchors layer
+        anchors = anchors_layer.call(features)
+        anchors = K.get_value(anchors)
 
-            # expected anchor values
-            expected = np.array([[
-                [-12, -12, 20, 20],
-                [-4, -12, 28, 20],
-                [-12, -4, 20, 28],
-                [-4, -4, 28, 28],
-            ]], dtype=K.floatx())
-            expected = np.tile(expected, (2, 1, 1))
+        # expected anchor values
+        expected = np.array([[
+            [-12, -12, 20, 20],
+            [-4, -12, 28, 20],
+            [-12, -4, 20, 28],
+            [-4, -4, 28, 28],
+        ]], dtype=K.floatx())
+        expected = np.tile(expected, (2, 1, 1))
 
-            # test anchor values
-            self.assertAllEqual(anchors, expected)
+        # test anchor values
+        self.assertAllEqual(anchors, expected)
 
 
 class TestRegressBoxes(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
-        with self.cached_session():
-            # create simple RegressBoxes layer
-            layer = layers.RegressBoxes()
+        # create simple RegressBoxes layer
+        layer = layers.RegressBoxes()
 
-            # create input
-            anchors = np.array([[
-                [0, 0, 10, 10],
-                [50, 50, 100, 100],
-                [20, 20, 40, 40],
-            ]], dtype=K.floatx())
-            anchors = K.variable(anchors)
+        # create input
+        anchors = np.array([[
+            [0, 0, 10, 10],
+            [50, 50, 100, 100],
+            [20, 20, 40, 40],
+        ]], dtype=K.floatx())
+        anchors = K.variable(anchors)
 
-            regression = np.array([[
-                [0, 0, 0, 0],
-                [0.1, 0.1, 0, 0],
-                [0, 0, 0.1, 0.1],
-            ]], dtype=K.floatx())
-            regression = K.variable(regression)
+        regression = np.array([[
+            [0, 0, 0, 0],
+            [0.1, 0.1, 0, 0],
+            [0, 0, 0.1, 0.1],
+        ]], dtype=K.floatx())
+        regression = K.variable(regression)
 
-            # compute output
-            computed_shape = layer.compute_output_shape(
-                [anchors.shape, regression.shape])
-            actual = layer.call([anchors, regression])
-            actual = K.get_value(actual)
+        # compute output
+        computed_shape = layer.compute_output_shape(
+            [anchors.shape, regression.shape])
+        actual = layer.call([anchors, regression])
+        actual = K.get_value(actual)
 
-            self.assertEqual(actual.shape, computed_shape)
+        self.assertEqual(actual.shape, computed_shape)
 
-            # compute expected output
-            expected = np.array([[
-                [0, 0, 10, 10],
-                [51, 51, 100, 100],
-                [20, 20, 40.4, 40.4],
-            ]], dtype=K.floatx())
+        # compute expected output
+        expected = np.array([[
+            [0, 0, 10, 10],
+            [51, 51, 100, 100],
+            [20, 20, 40.4, 40.4],
+        ]], dtype=K.floatx())
 
-            self.assertAllClose(actual, expected)
+        self.assertAllClose(actual, expected)
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_mini_batch(self):
-        with self.cached_session():
-            mean = [0, 0, 0, 0]
-            std = [0.2, 0.2, 0.2, 0.2]
+        mean = [0, 0, 0, 0]
+        std = [0.2, 0.2, 0.2, 0.2]
 
-            # create simple RegressBoxes layer
-            layer = layers.RegressBoxes(mean=mean, std=std)
+        # create simple RegressBoxes layer
+        layer = layers.RegressBoxes(mean=mean, std=std)
 
-            # create input
-            anchors = np.array([
-                [
-                    [0, 0, 10, 10],  # 1
-                    [50, 50, 100, 100],  # 2
-                    [20, 20, 40, 40],  # 3
-                ],
-                [
-                    [20, 20, 40, 40],  # 3
-                    [0, 0, 10, 10],  # 1
-                    [50, 50, 100, 100],  # 2
-                ],
-            ], dtype=K.floatx())
-            anchors = K.variable(anchors)
+        # create input
+        anchors = np.array([
+            [
+                [0, 0, 10, 10],  # 1
+                [50, 50, 100, 100],  # 2
+                [20, 20, 40, 40],  # 3
+            ],
+            [
+                [20, 20, 40, 40],  # 3
+                [0, 0, 10, 10],  # 1
+                [50, 50, 100, 100],  # 2
+            ],
+        ], dtype=K.floatx())
+        anchors = K.variable(anchors)
 
-            regression = np.array([
-                [
-                    [0, 0, 0, 0],  # 1
-                    [0.1, 0.1, 0, 0],  # 2
-                    [0, 0, 0.1, 0.1],  # 3
-                ],
-                [
-                    [0, 0, 0.1, 0.1],  # 3
-                    [0, 0, 0, 0],  # 1
-                    [0.1, 0.1, 0, 0],  # 2
-                ],
-            ], dtype=K.floatx())
-            regression = K.variable(regression)
+        regression = np.array([
+            [
+                [0, 0, 0, 0],  # 1
+                [0.1, 0.1, 0, 0],  # 2
+                [0, 0, 0.1, 0.1],  # 3
+            ],
+            [
+                [0, 0, 0.1, 0.1],  # 3
+                [0, 0, 0, 0],  # 1
+                [0.1, 0.1, 0, 0],  # 2
+            ],
+        ], dtype=K.floatx())
+        regression = K.variable(regression)
 
-            # compute output
-            actual = layer.call([anchors, regression])
-            actual = K.get_value(actual)
+        # compute output
+        actual = layer.call([anchors, regression])
+        actual = K.get_value(actual)
 
-            # compute expected output
-            expected = np.array([
-                [
-                    [0, 0, 10, 10],  # 1
-                    [51, 51, 100, 100],  # 2
-                    [20, 20, 40.4, 40.4],  # 3
-                ],
-                [
-                    [20, 20, 40.4, 40.4],  # 3
-                    [0, 0, 10, 10],  # 1
-                    [51, 51, 100, 100],  # 2
-                ],
-            ], dtype=K.floatx())
+        # compute expected output
+        expected = np.array([
+            [
+                [0, 0, 10, 10],  # 1
+                [51, 51, 100, 100],  # 2
+                [20, 20, 40.4, 40.4],  # 3
+            ],
+            [
+                [20, 20, 40.4, 40.4],  # 3
+                [0, 0, 10, 10],  # 1
+                [51, 51, 100, 100],  # 2
+            ],
+        ], dtype=K.floatx())
 
-            self.assertAllClose(actual, expected)
+        self.assertAllClose(actual, expected)
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_invalid_input(self):
@@ -257,38 +252,36 @@ class ClipBoxesTest(test.TestCase):
         ]], dtype=K.floatx())
 
         # test channels_last
-        with self.cached_session():
-            # create input
-            image = K.variable(np.random.random((1, img_h, img_w, 3)))
+        # create input
+        image = K.variable(np.random.random((1, img_h, img_w, 3)))
 
-            # create simple ClipBoxes layer
-            layer = layers.ClipBoxes(data_format='channels_last')
+        # create simple ClipBoxes layer
+        layer = layers.ClipBoxes(data_format='channels_last')
 
-            # compute output
-            computed_shape = layer.compute_output_shape(
-                [image.shape, boxes.shape])
-            actual = layer.call([image, boxes])
-            actual = K.get_value(actual)
+        # compute output
+        computed_shape = layer.compute_output_shape(
+            [image.shape, boxes.shape])
+        actual = layer.call([image, boxes])
+        actual = K.get_value(actual)
 
-            self.assertEqual(actual.shape, tuple(computed_shape))
-            self.assertAllClose(actual, expected)
+        self.assertEqual(actual.shape, tuple(computed_shape))
+        self.assertAllClose(actual, expected)
 
         # test channels_first
-        with self.cached_session():
-            # create input
-            image = K.variable(np.random.random((1, 6, img_h, img_w)))
+        # create input
+        image = K.variable(np.random.random((1, 6, img_h, img_w)))
 
-            # create simple ClipBoxes layer
-            layer = layers.ClipBoxes(data_format='channels_first')
+        # create simple ClipBoxes layer
+        layer = layers.ClipBoxes(data_format='channels_first')
 
-            # compute output
-            computed_shape = layer.compute_output_shape(
-                [image.shape, boxes.shape])
-            actual = layer.call([image, boxes])
-            actual = K.get_value(actual)
+        # compute output
+        computed_shape = layer.compute_output_shape(
+            [image.shape, boxes.shape])
+        actual = layer.call([image, boxes])
+        actual = K.get_value(actual)
 
-            self.assertEqual(actual.shape, tuple(computed_shape))
-            self.assertAllClose(actual, expected)
+        self.assertEqual(actual.shape, tuple(computed_shape))
+        self.assertAllClose(actual, expected)
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple_3d(self):
@@ -315,35 +308,33 @@ class ClipBoxesTest(test.TestCase):
         expected = np.expand_dims(expected, axis=0)
 
         # test channels_last
-        with self.cached_session():
-            # create input
-            image = K.variable(np.random.random((1, 1, img_h, img_w, 3)))
+        # create input
+        image = K.variable(np.random.random((1, 1, img_h, img_w, 3)))
 
-            # create simple ClipBoxes layer
-            layer = layers.ClipBoxes(data_format='channels_last')
+        # create simple ClipBoxes layer
+        layer = layers.ClipBoxes(data_format='channels_last')
 
-            # compute output
-            computed_shape = layer.compute_output_shape(
-                [image.shape, boxes.shape])
-            actual = layer.call([image, boxes])
-            actual = K.get_value(actual)
+        # compute output
+        computed_shape = layer.compute_output_shape(
+            [image.shape, boxes.shape])
+        actual = layer.call([image, boxes])
+        actual = K.get_value(actual)
 
-            self.assertEqual(actual.shape, tuple(computed_shape))
-            self.assertAllClose(actual, expected)
+        self.assertEqual(actual.shape, tuple(computed_shape))
+        self.assertAllClose(actual, expected)
 
         # test channels_first
-        with self.cached_session():
-            # create input
-            image = K.variable(np.random.random((1, 6, 1, img_h, img_w)))
+        # create input
+        image = K.variable(np.random.random((1, 6, 1, img_h, img_w)))
 
-            # create simple ClipBoxes layer
-            layer = layers.ClipBoxes(data_format='channels_first')
+        # create simple ClipBoxes layer
+        layer = layers.ClipBoxes(data_format='channels_first')
 
-            # compute output
-            computed_shape = layer.compute_output_shape(
-                [image.shape, boxes.shape])
-            actual = layer.call([image, boxes])
-            actual = K.get_value(actual)
+        # compute output
+        computed_shape = layer.compute_output_shape(
+            [image.shape, boxes.shape])
+        actual = layer.call([image, boxes])
+        actual = K.get_value(actual)
 
-            self.assertEqual(actual.shape, tuple(computed_shape))
-            self.assertAllClose(actual, expected)
+        self.assertEqual(actual.shape, tuple(computed_shape))
+        self.assertAllClose(actual, expected)

--- a/deepcell/layers/retinanet_test.py
+++ b/deepcell/layers/retinanet_test.py
@@ -30,16 +30,15 @@ from __future__ import division
 
 import numpy as np
 from tensorflow.python.keras import backend as K
-from tensorflow.python.framework import test_util as tf_test_util
-from tensorflow.python.platform import test
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.utils import testing_utils
 from deepcell import layers
 
 
-class TestAnchors(test.TestCase):
+@keras_parameterized.run_all_keras_modes
+class TestAnchors(run_all_keras_modes.TestCase):
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_anchors_2d(self):
         testing_utils.layer_test(
             layers.Anchors,
@@ -60,7 +59,6 @@ class TestAnchors(test.TestCase):
             custom_objects={'Anchors': layers.Anchors},
             input_shape=(3, 5, 6, 4))
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
         # create simple Anchors layer
         anchors_layer = layers.Anchors(
@@ -89,7 +87,6 @@ class TestAnchors(test.TestCase):
         # test anchor values
         self.assertAllEqual(anchors, expected)
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_mini_batch(self):
         # create simple Anchors layer
         anchors_layer = layers.Anchors(
@@ -120,9 +117,9 @@ class TestAnchors(test.TestCase):
         self.assertAllEqual(anchors, expected)
 
 
-class TestRegressBoxes(test.TestCase):
+@keras_parameterized.run_all_keras_modes
+class TestRegressBoxes(run_all_keras_modes.TestCase):
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
         # create simple RegressBoxes layer
         layer = layers.RegressBoxes()
@@ -159,7 +156,6 @@ class TestRegressBoxes(test.TestCase):
 
         self.assertAllClose(actual, expected)
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_mini_batch(self):
         mean = [0, 0, 0, 0]
         std = [0.2, 0.2, 0.2, 0.2]
@@ -216,7 +212,6 @@ class TestRegressBoxes(test.TestCase):
 
         self.assertAllClose(actual, expected)
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_invalid_input(self):
         bad_mean = 'invalid_data_type'
         bad_std = 'invalid_data_type'
@@ -227,9 +222,9 @@ class TestRegressBoxes(test.TestCase):
             layers.RegressBoxes(mean=None, std=bad_std)
 
 
-class ClipBoxesTest(test.TestCase):
+@keras_parameterized.run_all_keras_modes
+class ClipBoxesTest(run_all_keras_modes.TestCase):
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
         img_h, img_w = np.random.randint(2, 5), np.random.randint(5, 9)
 
@@ -283,7 +278,6 @@ class ClipBoxesTest(test.TestCase):
         self.assertEqual(actual.shape, tuple(computed_shape))
         self.assertAllClose(actual, expected)
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple_3d(self):
         img_h, img_w = np.random.randint(2, 5), np.random.randint(5, 9)
 

--- a/deepcell/layers/retinanet_test.py
+++ b/deepcell/layers/retinanet_test.py
@@ -41,7 +41,7 @@ class TestAnchors(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_anchors_2d(self):
-        with self.test_session():
+        with self.cached_session():
             testing_utils.layer_test(
                 layers.Anchors,
                 kwargs={'size': 1, 'stride': 1,
@@ -63,7 +63,7 @@ class TestAnchors(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
-        with self.test_session():
+        with self.cached_session():
             # create simple Anchors layer
             anchors_layer = layers.Anchors(
                 size=32,
@@ -93,7 +93,7 @@ class TestAnchors(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_mini_batch(self):
-        with self.test_session():
+        with self.cached_session():
             # create simple Anchors layer
             anchors_layer = layers.Anchors(
                 size=32,
@@ -127,7 +127,7 @@ class TestRegressBoxes(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
-        with self.test_session():
+        with self.cached_session():
             # create simple RegressBoxes layer
             layer = layers.RegressBoxes()
 
@@ -165,7 +165,7 @@ class TestRegressBoxes(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_mini_batch(self):
-        with self.test_session():
+        with self.cached_session():
             mean = [0, 0, 0, 0]
             std = [0.2, 0.2, 0.2, 0.2]
 
@@ -257,7 +257,7 @@ class ClipBoxesTest(test.TestCase):
         ]], dtype=K.floatx())
 
         # test channels_last
-        with self.test_session():
+        with self.cached_session():
             # create input
             image = K.variable(np.random.random((1, img_h, img_w, 3)))
 
@@ -274,7 +274,7 @@ class ClipBoxesTest(test.TestCase):
             self.assertAllClose(actual, expected)
 
         # test channels_first
-        with self.test_session():
+        with self.cached_session():
             # create input
             image = K.variable(np.random.random((1, 6, img_h, img_w)))
 
@@ -315,7 +315,7 @@ class ClipBoxesTest(test.TestCase):
         expected = np.expand_dims(expected, axis=0)
 
         # test channels_last
-        with self.test_session():
+        with self.cached_session():
             # create input
             image = K.variable(np.random.random((1, 1, img_h, img_w, 3)))
 
@@ -332,7 +332,7 @@ class ClipBoxesTest(test.TestCase):
             self.assertAllClose(actual, expected)
 
         # test channels_first
-        with self.test_session():
+        with self.cached_session():
             # create input
             image = K.variable(np.random.random((1, 6, 1, img_h, img_w)))
 

--- a/deepcell/layers/tensor_product_test.py
+++ b/deepcell/layers/tensor_product_test.py
@@ -92,7 +92,7 @@ class TensorProdTest(test.TestCase):
                 input_shape=(3, 5, 6, None))
 
     def test_tensorproduct_regularization(self):
-        with self.test_session():
+        with self.cached_session():
             layer = layers.TensorProduct(
                 3,
                 kernel_regularizer=keras.regularizers.l1(0.01),
@@ -103,7 +103,7 @@ class TensorProdTest(test.TestCase):
             self.assertEqual(3, len(layer.losses))
 
     def test_tensorproduct_constraints(self):
-        with self.test_session():
+        with self.cached_session():
             k_constraint = keras.constraints.max_norm(0.01)
             b_constraint = keras.constraints.max_norm(0.01)
             layer = layers.TensorProduct(

--- a/deepcell/layers/tensor_product_test.py
+++ b/deepcell/layers/tensor_product_test.py
@@ -31,16 +31,15 @@ from __future__ import division
 import numpy as np
 
 from tensorflow.python import keras
-from tensorflow.python.framework import test_util as tf_test_util
-from tensorflow.python.platform import test
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.utils import testing_utils
 from deepcell import layers
 
 
-class TensorProdTest(test.TestCase):
+@keras_parameterized.run_all_keras_modes
+class TensorProdTest(keras_parameterized.TestCase):
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_tensorproduct(self):
         custom_objects = {'TensorProduct': layers.TensorProduct}
 

--- a/deepcell/layers/tensor_product_test.py
+++ b/deepcell/layers/tensor_product_test.py
@@ -92,24 +92,22 @@ class TensorProdTest(test.TestCase):
                 input_shape=(3, 5, 6, None))
 
     def test_tensorproduct_regularization(self):
-        with self.cached_session():
-            layer = layers.TensorProduct(
-                3,
-                kernel_regularizer=keras.regularizers.l1(0.01),
-                bias_regularizer='l1',
-                activity_regularizer='l2',
-                name='tensorproduct_reg')
-            layer(keras.backend.variable(np.ones((2, 4))))
-            self.assertEqual(3, len(layer.losses))
+        layer = layers.TensorProduct(
+            3,
+            kernel_regularizer=keras.regularizers.l1(0.01),
+            bias_regularizer='l1',
+            activity_regularizer='l2',
+            name='tensorproduct_reg')
+        layer(keras.backend.variable(np.ones((2, 4))))
+        self.assertEqual(3, len(layer.losses))
 
     def test_tensorproduct_constraints(self):
-        with self.cached_session():
-            k_constraint = keras.constraints.max_norm(0.01)
-            b_constraint = keras.constraints.max_norm(0.01)
-            layer = layers.TensorProduct(
-                3,
-                kernel_constraint=k_constraint,
-                bias_constraint=b_constraint)
-            layer(keras.backend.variable(np.ones((2, 4))))
-            self.assertEqual(layer.kernel.constraint, k_constraint)
-            self.assertEqual(layer.bias.constraint, b_constraint)
+        k_constraint = keras.constraints.max_norm(0.01)
+        b_constraint = keras.constraints.max_norm(0.01)
+        layer = layers.TensorProduct(
+            3,
+            kernel_constraint=k_constraint,
+            bias_constraint=b_constraint)
+        layer(keras.backend.variable(np.ones((2, 4))))
+        self.assertEqual(layer.kernel.constraint, k_constraint)
+        self.assertEqual(layer.bias.constraint, b_constraint)

--- a/deepcell/layers/upsample_test.py
+++ b/deepcell/layers/upsample_test.py
@@ -30,16 +30,15 @@ from __future__ import division
 
 import numpy as np
 from tensorflow.python.keras import backend as K
-from tensorflow.python.framework import test_util as tf_test_util
-from tensorflow.python.platform import test
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.utils import testing_utils
 from deepcell import layers
 
 
-class TestUpsampleLike(test.TestCase):
+@keras_parameterized.run_all_keras_modes
+class TestUpsampleLike(keras_parameterized.TestCase):
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
         # channels_last
         # create simple UpsampleLike layer
@@ -82,7 +81,6 @@ class TestUpsampleLike(test.TestCase):
         self.assertEqual(actual.shape, computed_shape)
         self.assertAllEqual(actual, expected)
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple_3d(self):
         # create simple UpsampleLike layer
         upsample_like_layer = layers.UpsampleLike()
@@ -125,7 +123,6 @@ class TestUpsampleLike(test.TestCase):
         self.assertEqual(actual.shape, computed_shape)
         self.assertAllEqual(actual, expected)
 
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_mini_batch(self):
         # create simple UpsampleLike layer
         upsample_like_layer = layers.UpsampleLike()
@@ -145,8 +142,8 @@ class TestUpsampleLike(test.TestCase):
         self.assertAllEqual(actual, expected)
 
 
-class TestUpsample(test.TestCase):
-    @tf_test_util.run_in_graph_and_eager_modes()
+class TestUpsample(keras_parameterized.TestCase):
+
     def test_simple(self):
         testing_utils.layer_test(
             layers.Upsample,

--- a/deepcell/layers/upsample_test.py
+++ b/deepcell/layers/upsample_test.py
@@ -42,126 +42,120 @@ class TestUpsampleLike(test.TestCase):
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
         # channels_last
-        with self.cached_session():
-            # create simple UpsampleLike layer
-            upsample_like_layer = layers.UpsampleLike()
+        # create simple UpsampleLike layer
+        upsample_like_layer = layers.UpsampleLike()
 
-            # create input source
-            source = np.zeros((1, 2, 2, 1), dtype=K.floatx())
-            source = K.variable(source)
-            target = np.zeros((1, 5, 5, 1), dtype=K.floatx())
-            expected = target
-            target = K.variable(target)
+        # create input source
+        source = np.zeros((1, 2, 2, 1), dtype=K.floatx())
+        source = K.variable(source)
+        target = np.zeros((1, 5, 5, 1), dtype=K.floatx())
+        expected = target
+        target = K.variable(target)
 
-            # compute output
-            computed_shape = upsample_like_layer.compute_output_shape(
-                [source.shape, target.shape])
+        # compute output
+        computed_shape = upsample_like_layer.compute_output_shape(
+            [source.shape, target.shape])
 
-            actual = upsample_like_layer.call([source, target])
-            actual = K.get_value(actual)
+        actual = upsample_like_layer.call([source, target])
+        actual = K.get_value(actual)
 
-            self.assertEqual(actual.shape, computed_shape)
-            self.assertAllEqual(actual, expected)
+        self.assertEqual(actual.shape, computed_shape)
+        self.assertAllEqual(actual, expected)
         # channels_first
-        with self.cached_session():
-            # create simple UpsampleLike layer
-            upsample_like_layer = layers.UpsampleLike(
-                data_format='channels_first')
+        # create simple UpsampleLike layer
+        upsample_like_layer = layers.UpsampleLike(
+            data_format='channels_first')
 
-            # create input source
-            source = np.zeros((1, 1, 2, 2), dtype=K.floatx())
-            source = K.variable(source)
-            target = np.zeros((1, 1, 5, 5), dtype=K.floatx())
-            expected = target
-            target = K.variable(target)
+        # create input source
+        source = np.zeros((1, 1, 2, 2), dtype=K.floatx())
+        source = K.variable(source)
+        target = np.zeros((1, 1, 5, 5), dtype=K.floatx())
+        expected = target
+        target = K.variable(target)
 
-            # compute output
-            computed_shape = upsample_like_layer.compute_output_shape(
-                [source.shape, target.shape])
-            actual = upsample_like_layer.call([source, target])
-            actual = K.get_value(actual)
+        # compute output
+        computed_shape = upsample_like_layer.compute_output_shape(
+            [source.shape, target.shape])
+        actual = upsample_like_layer.call([source, target])
+        actual = K.get_value(actual)
 
-            self.assertEqual(actual.shape, computed_shape)
-            self.assertAllEqual(actual, expected)
+        self.assertEqual(actual.shape, computed_shape)
+        self.assertAllEqual(actual, expected)
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple_3d(self):
-        with self.cached_session():
-            # create simple UpsampleLike layer
-            upsample_like_layer = layers.UpsampleLike()
+        # create simple UpsampleLike layer
+        upsample_like_layer = layers.UpsampleLike()
 
-            # create input source
-            source = np.zeros((1, 2, 2, 2, 1), dtype=K.floatx())
-            source = K.variable(source)
-            target = np.zeros((1, 5, 5, 5, 1), dtype=K.floatx())
-            expected = target
-            target = K.variable(target)
+        # create input source
+        source = np.zeros((1, 2, 2, 2, 1), dtype=K.floatx())
+        source = K.variable(source)
+        target = np.zeros((1, 5, 5, 5, 1), dtype=K.floatx())
+        expected = target
+        target = K.variable(target)
 
-            # compute output
-            computed_shape = upsample_like_layer.compute_output_shape(
-                [source.shape, target.shape])
+        # compute output
+        computed_shape = upsample_like_layer.compute_output_shape(
+            [source.shape, target.shape])
 
-            actual = upsample_like_layer.call([source, target])
-            actual = K.get_value(actual)
+        actual = upsample_like_layer.call([source, target])
+        actual = K.get_value(actual)
 
-            self.assertEqual(actual.shape, computed_shape)
-            self.assertAllEqual(actual, expected)
+        self.assertEqual(actual.shape, computed_shape)
+        self.assertAllEqual(actual, expected)
 
         # channels_first
-        with self.cached_session():
-            # create simple UpsampleLike layer
-            upsample_like_layer = layers.UpsampleLike(
-                data_format='channels_first')
+        # create simple UpsampleLike layer
+        upsample_like_layer = layers.UpsampleLike(
+            data_format='channels_first')
 
-            # create input source
-            source = np.zeros((1, 1, 2, 2, 2), dtype=K.floatx())
-            source = K.variable(source)
-            target = np.zeros((1, 1, 5, 5, 5), dtype=K.floatx())
-            expected = target
-            target = K.variable(target)
+        # create input source
+        source = np.zeros((1, 1, 2, 2, 2), dtype=K.floatx())
+        source = K.variable(source)
+        target = np.zeros((1, 1, 5, 5, 5), dtype=K.floatx())
+        expected = target
+        target = K.variable(target)
 
-            # compute output
-            computed_shape = upsample_like_layer.compute_output_shape(
-                [source.shape, target.shape])
-            actual = upsample_like_layer.call([source, target])
-            actual = K.get_value(actual)
+        # compute output
+        computed_shape = upsample_like_layer.compute_output_shape(
+            [source.shape, target.shape])
+        actual = upsample_like_layer.call([source, target])
+        actual = K.get_value(actual)
 
-            self.assertEqual(actual.shape, computed_shape)
-            self.assertAllEqual(actual, expected)
+        self.assertEqual(actual.shape, computed_shape)
+        self.assertAllEqual(actual, expected)
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_mini_batch(self):
-        with self.cached_session():
-            # create simple UpsampleLike layer
-            upsample_like_layer = layers.UpsampleLike()
+        # create simple UpsampleLike layer
+        upsample_like_layer = layers.UpsampleLike()
 
-            # create input source
-            source = np.zeros((2, 2, 2, 1), dtype=K.floatx())
-            source = K.variable(source)
+        # create input source
+        source = np.zeros((2, 2, 2, 1), dtype=K.floatx())
+        source = K.variable(source)
 
-            target = np.zeros((2, 5, 5, 1), dtype=K.floatx())
-            expected = target
-            target = K.variable(target)
+        target = np.zeros((2, 5, 5, 1), dtype=K.floatx())
+        expected = target
+        target = K.variable(target)
 
-            # compute output
-            actual = upsample_like_layer.call([source, target])
-            actual = K.get_value(actual)
+        # compute output
+        actual = upsample_like_layer.call([source, target])
+        actual = K.get_value(actual)
 
-            self.assertAllEqual(actual, expected)
+        self.assertAllEqual(actual, expected)
 
 
 class TestUpsample(test.TestCase):
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
-        with self.cached_session():
-            testing_utils.layer_test(
-                layers.Upsample,
-                kwargs={'target_size': (2, 2)},
-                custom_objects={'Upsample': layers.Upsample},
-                input_shape=(3, 5, 6, 4))
-            testing_utils.layer_test(
-                layers.Upsample,
-                kwargs={'target_size': (2, 2),
-                        'data_format': 'channels_first'},
-                custom_objects={'Upsample': layers.Upsample},
-                input_shape=(3, 4, 5, 6))
+        testing_utils.layer_test(
+            layers.Upsample,
+            kwargs={'target_size': (2, 2)},
+            custom_objects={'Upsample': layers.Upsample},
+            input_shape=(3, 5, 6, 4))
+        testing_utils.layer_test(
+            layers.Upsample,
+            kwargs={'target_size': (2, 2),
+                    'data_format': 'channels_first'},
+            custom_objects={'Upsample': layers.Upsample},
+            input_shape=(3, 4, 5, 6))

--- a/deepcell/layers/upsample_test.py
+++ b/deepcell/layers/upsample_test.py
@@ -42,7 +42,7 @@ class TestUpsampleLike(test.TestCase):
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
         # channels_last
-        with self.test_session():
+        with self.cached_session():
             # create simple UpsampleLike layer
             upsample_like_layer = layers.UpsampleLike()
 
@@ -63,7 +63,7 @@ class TestUpsampleLike(test.TestCase):
             self.assertEqual(actual.shape, computed_shape)
             self.assertAllEqual(actual, expected)
         # channels_first
-        with self.test_session():
+        with self.cached_session():
             # create simple UpsampleLike layer
             upsample_like_layer = layers.UpsampleLike(
                 data_format='channels_first')
@@ -86,7 +86,7 @@ class TestUpsampleLike(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple_3d(self):
-        with self.test_session():
+        with self.cached_session():
             # create simple UpsampleLike layer
             upsample_like_layer = layers.UpsampleLike()
 
@@ -108,7 +108,7 @@ class TestUpsampleLike(test.TestCase):
             self.assertAllEqual(actual, expected)
 
         # channels_first
-        with self.test_session():
+        with self.cached_session():
             # create simple UpsampleLike layer
             upsample_like_layer = layers.UpsampleLike(
                 data_format='channels_first')
@@ -131,7 +131,7 @@ class TestUpsampleLike(test.TestCase):
 
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_mini_batch(self):
-        with self.test_session():
+        with self.cached_session():
             # create simple UpsampleLike layer
             upsample_like_layer = layers.UpsampleLike()
 
@@ -153,7 +153,7 @@ class TestUpsampleLike(test.TestCase):
 class TestUpsample(test.TestCase):
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_simple(self):
-        with self.test_session():
+        with self.cached_session():
             testing_utils.layer_test(
                 layers.Upsample,
                 kwargs={'target_size': (2, 2)},

--- a/deepcell/losses_test.py
+++ b/deepcell/losses_test.py
@@ -23,9 +23,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Tests for custom loss functions
-@author: David Van Valen
-"""
+"""Tests for custom loss functions"""
 
 from __future__ import absolute_import
 from __future__ import division

--- a/deepcell/losses_test.py
+++ b/deepcell/losses_test.py
@@ -76,7 +76,7 @@ class _MSEMAELoss(object):
 class KerasLossesTest(test.TestCase):
 
     def test_objective_shapes_3d(self):
-        with self.test_session():
+        with self.cached_session():
             y_a = keras.backend.variable(np.random.random((5, 6, 7)))
             y_b = keras.backend.variable(np.random.random((5, 6, 7)))
             for obj in ALL_LOSSES:
@@ -85,7 +85,7 @@ class KerasLossesTest(test.TestCase):
                 self.assertListEqual(objective_output.get_shape().as_list(), [5, 6])
 
     def test_objective_shapes_2d(self):
-        with self.test_session():
+        with self.cached_session():
             y_a = keras.backend.variable(np.random.random((6, 7)))
             y_b = keras.backend.variable(np.random.random((6, 7)))
             for obj in ALL_LOSSES:
@@ -94,7 +94,7 @@ class KerasLossesTest(test.TestCase):
                 self.assertListEqual(objective_output.get_shape().as_list(), [6])
 
     def test_cce_one_hot(self):
-        with self.test_session():
+        with self.cached_session():
             y_a = keras.backend.variable(np.random.randint(0, 7, (5, 6)))
             y_b = keras.backend.variable(np.random.random((5, 6, 7)))
             objective_output = keras.losses.sparse_categorical_crossentropy(y_a, y_b)
@@ -133,7 +133,7 @@ class KerasLossesTest(test.TestCase):
         self.addCleanup(shutil.rmtree, tmpdir)
         model_filename = os.path.join(tmpdir, 'custom_loss.h5')
 
-        with self.test_session():
+        with self.cached_session():
             with keras.utils.custom_object_scope({'_MSEMAELoss': _MSEMAELoss}):
                 loss = _MSEMAELoss(0.3)
                 inputs = keras.layers.Input((2,))

--- a/deepcell/model_zoo/featurenet_test.py
+++ b/deepcell/model_zoo/featurenet_test.py
@@ -186,7 +186,7 @@ class FeatureNetTest(test.TestCase, parameterized.TestCase):
         # BAD: dilated=True, include_top=False
         # BAD: inputs != None
 
-        with self.test_session():
+        with self.cached_session():
             K.set_image_data_format(data_format)
             model = featurenet.bn_feature_net_2D(
                 include_top=include_top,
@@ -216,7 +216,7 @@ class FeatureNetTest(test.TestCase, parameterized.TestCase):
         input_shape = (256, 256, 1)
         n_skips = 1
 
-        with self.test_session():
+        with self.cached_session():
             K.set_image_data_format(data_format)
             axis = 1 if data_format == 'channels_first' else -1
 
@@ -383,7 +383,7 @@ class FeatureNetTest(test.TestCase, parameterized.TestCase):
         n_frames = 5
         # input_shape = (10, 32, 32, 1)
 
-        with self.test_session():
+        with self.cached_session():
             K.set_image_data_format(data_format)
             model = featurenet.bn_feature_net_3D(
                 include_top=include_top,
@@ -413,7 +413,7 @@ class FeatureNetTest(test.TestCase, parameterized.TestCase):
         input_shape = (10, 32, 32, 1)
         n_skips = 1
 
-        with self.test_session():
+        with self.cached_session():
             K.set_image_data_format(data_format)
             axis = 1 if data_format == 'channels_first' else -1
 

--- a/deepcell/model_zoo/featurenet_test.py
+++ b/deepcell/model_zoo/featurenet_test.py
@@ -200,7 +200,7 @@ class FeatureNetTest(keras_parameterized.TestCase):
             axis = 1 if data_format == 'channels_first' else -1
             self.assertEqual(model.output_shape[axis], output)
 
-    # @keras_parameterized.run_all_keras_modes
+    @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         ('channels_last',) * 2,
         ('channels_first',) * 2,
@@ -397,7 +397,7 @@ class FeatureNetTest(keras_parameterized.TestCase):
             channel_axis = 1 if data_format == 'channels_first' else -1
             self.assertEqual(model.output_shape[channel_axis], n_features)
 
-    # @keras_parameterized.run_all_keras_modes
+    @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         ('channels_last',) * 2,
         ('channels_first',) * 2,

--- a/deepcell/model_zoo/featurenet_test.py
+++ b/deepcell/model_zoo/featurenet_test.py
@@ -200,7 +200,7 @@ class FeatureNetTest(keras_parameterized.TestCase):
             axis = 1 if data_format == 'channels_first' else -1
             self.assertEqual(model.output_shape[axis], output)
 
-    @keras_parameterized.run_all_keras_modes
+    # @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         ('channels_last',) * 2,
         ('channels_first',) * 2,
@@ -397,7 +397,7 @@ class FeatureNetTest(keras_parameterized.TestCase):
             channel_axis = 1 if data_format == 'channels_first' else -1
             self.assertEqual(model.output_shape[channel_axis], n_features)
 
-    @keras_parameterized.run_all_keras_modes
+    # @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         ('channels_last',) * 2,
         ('channels_first',) * 2,

--- a/deepcell/model_zoo/featurenet_test.py
+++ b/deepcell/model_zoo/featurenet_test.py
@@ -31,18 +31,15 @@ from __future__ import print_function
 
 from absl.testing import parameterized
 
-import numpy as np
-import tensorflow as tf
 from tensorflow.python.keras import backend as K
-
-from tensorflow.python.framework import test_util as tf_test_util
-from tensorflow.python.platform import test
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.model_zoo import featurenet
 
 
-class FeatureNetTest(test.TestCase, parameterized.TestCase):
+class FeatureNetTest(keras_parameterized.TestCase):
 
+    @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         {
             'testcase_name': 'dilated_include_top',
@@ -177,7 +174,6 @@ class FeatureNetTest(test.TestCase, parameterized.TestCase):
             'data_format': 'channels_first',
         },
     ])
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_bn_feature_net_2D(self, include_top, padding, padding_mode, shape,
                                dilated, multires, location, data_format):
         n_features = 3
@@ -204,11 +200,11 @@ class FeatureNetTest(test.TestCase, parameterized.TestCase):
             axis = 1 if data_format == 'channels_first' else -1
             self.assertEqual(model.output_shape[axis], output)
 
+    # @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         ('channels_last',) * 2,
         ('channels_first',) * 2,
     ])
-    # @tf_test_util.run_in_graph_and_eager_modes()
     def test_bn_feature_net_2D_skip(self, data_format):
         receptive_field = 61
         n_features = 3
@@ -243,6 +239,7 @@ class FeatureNetTest(test.TestCase, parameterized.TestCase):
             self.assertEqual(len(model.output_shape), 4)
             self.assertEqual(model.output_shape[axis], n_features)
 
+    @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         {
             'testcase_name': 'dilated_include_top',
@@ -375,7 +372,6 @@ class FeatureNetTest(test.TestCase, parameterized.TestCase):
             'data_format': 'channels_first',
         },
     ])
-    @tf_test_util.run_in_graph_and_eager_modes()
     def test_bn_feature_net_3D(self, include_top, padding, padding_mode, shape,
                                dilated, multires, location, data_format):
         n_features = 3
@@ -401,11 +397,11 @@ class FeatureNetTest(test.TestCase, parameterized.TestCase):
             channel_axis = 1 if data_format == 'channels_first' else -1
             self.assertEqual(model.output_shape[channel_axis], n_features)
 
+    # @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         ('channels_last',) * 2,
         ('channels_first',) * 2,
     ])
-    # @tf_test_util.run_in_graph_and_eager_modes()
     def test_bn_feature_net_3D_skip(self, data_format):
         receptive_field = 61
         n_features = 3

--- a/deepcell/model_zoo/maskrcnn_test.py
+++ b/deepcell/model_zoo/maskrcnn_test.py
@@ -31,18 +31,15 @@ from __future__ import print_function
 
 from absl.testing import parameterized
 
-import numpy as np
-import tensorflow as tf
 from tensorflow.python.keras import backend as K
-
-from tensorflow.python.framework import test_util as tf_test_util
-from tensorflow.python.platform import test
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.model_zoo import RetinaMask
 
 
-class RetinaMaskTest(test.TestCase, parameterized.TestCase):
+class RetinaMaskTest(keras_parameterized.TestCase):
 
+    # @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         {
             'testcase_name': 'maskrcnn_basic',
@@ -135,7 +132,6 @@ class RetinaMaskTest(test.TestCase, parameterized.TestCase):
             'pyramid_levels': ['P3', 'P4', 'P5', 'P6', 'P7'],
         }
     ])
-    # @tf_test_util.run_in_graph_and_eager_modes()
     def test_maskrcnn(self, pooling, panoptic, location, frames,
                       pyramid_levels, nms, class_specific_filter):
         num_classes = 3

--- a/deepcell/model_zoo/maskrcnn_test.py
+++ b/deepcell/model_zoo/maskrcnn_test.py
@@ -39,7 +39,7 @@ from deepcell.model_zoo import RetinaMask
 
 class RetinaMaskTest(keras_parameterized.TestCase):
 
-    # @keras_parameterized.run_all_keras_modes
+    @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         {
             'testcase_name': 'maskrcnn_basic',

--- a/deepcell/model_zoo/maskrcnn_test.py
+++ b/deepcell/model_zoo/maskrcnn_test.py
@@ -151,7 +151,7 @@ class RetinaMaskTest(test.TestCase, parameterized.TestCase):
         # TODO: RetinaMask fails with channels_first
         data_format = 'channels_last'
 
-        with self.test_session():
+        with self.cached_session():
             K.set_image_data_format(data_format)
             if data_format == 'channels_first':
                 axis = 1

--- a/deepcell/model_zoo/maskrcnn_test.py
+++ b/deepcell/model_zoo/maskrcnn_test.py
@@ -39,7 +39,7 @@ from deepcell.model_zoo import RetinaMask
 
 class RetinaMaskTest(keras_parameterized.TestCase):
 
-    @keras_parameterized.run_all_keras_modes
+    # @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         {
             'testcase_name': 'maskrcnn_basic',

--- a/deepcell/model_zoo/retinanet_test.py
+++ b/deepcell/model_zoo/retinanet_test.py
@@ -40,7 +40,7 @@ from deepcell.model_zoo import RetinaNet
 
 class RetinaNetTest(keras_parameterized.TestCase):
 
-    # @keras_parameterized.run_all_keras_modes
+    @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         {
             'testcase_name': 'retinanet_basic',

--- a/deepcell/model_zoo/retinanet_test.py
+++ b/deepcell/model_zoo/retinanet_test.py
@@ -218,7 +218,7 @@ class RetinaNetTest(test.TestCase, parameterized.TestCase):
         if frames > 1 and data_format == 'channels_first':
             return
 
-        with self.test_session():
+        with self.cached_session():
             K.set_image_data_format(data_format)
             if data_format == 'channels_first':
                 axis = 1

--- a/deepcell/model_zoo/retinanet_test.py
+++ b/deepcell/model_zoo/retinanet_test.py
@@ -32,15 +32,15 @@ from __future__ import print_function
 from absl.testing import parameterized
 
 from tensorflow.python.keras import backend as K
-
-from tensorflow.python.framework import test_util as tf_test_util
+from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.platform import test
 
 from deepcell.model_zoo import RetinaNet
 
 
-class RetinaNetTest(test.TestCase, parameterized.TestCase):
+class RetinaNetTest(keras_parameterized.TestCase):
 
+    # @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         {
             'testcase_name': 'retinanet_basic',
@@ -205,7 +205,6 @@ class RetinaNetTest(test.TestCase, parameterized.TestCase):
             'data_format': 'channels_first',
         }
     ])
-    # @tf_test_util.run_in_graph_and_eager_modes()
     def test_retinanet(self, pooling, panoptic, location,
                        frames, pyramid_levels, data_format):
         num_classes = 3

--- a/deepcell/running_test.py
+++ b/deepcell/running_test.py
@@ -157,7 +157,7 @@ class RunningTests(test.TestCase, parameterized.TestCase):
             data_format=data_format)
 
         for padding in ['reflect', 'zero']:
-            with self.test_session():
+            with self.cached_session():
                 inputs = keras.layers.Input(shape=input_shape)
                 outputs = layers.TensorProduct(features)(inputs)
                 model = keras.models.Model(inputs=inputs,

--- a/deepcell/utils/backbone_utils_test.py
+++ b/deepcell/utils/backbone_utils_test.py
@@ -53,7 +53,7 @@ class TestBackboneUtils(test.TestCase, parameterized.TestCase):
         backbone = 'featurenet'
         input_shape = (256, 256, 3)
         inputs = Input(shape=input_shape)
-        with self.test_session():
+        with self.cached_session():
             K.set_image_data_format(data_format)
             model, output_dict = backbone_utils.get_backbone(
                 backbone, inputs, return_dict=True)
@@ -74,7 +74,7 @@ class TestBackboneUtils(test.TestCase, parameterized.TestCase):
         backbone = 'featurenet3d'
         input_shape = (40, 256, 256, 3)
         inputs = Input(shape=input_shape)
-        with self.test_session():
+        with self.cached_session():
             K.set_image_data_format(data_format)
             model, output_dict = backbone_utils.get_backbone(
                 backbone, inputs, return_dict=True)
@@ -107,7 +107,7 @@ class TestBackboneUtils(test.TestCase, parameterized.TestCase):
     ])
     # @tf_test_util.run_in_graph_and_eager_modes()
     def test_get_backbone(self, backbone):
-        with self.test_session():
+        with self.cached_session():
             K.set_image_data_format('channels_last')
             inputs = Input(shape=(256, 256, 3))
             model, output_dict = backbone_utils.get_backbone(

--- a/deepcell/utils/backbone_utils_test.py
+++ b/deepcell/utils/backbone_utils_test.py
@@ -42,7 +42,7 @@ from deepcell.utils import backbone_utils
 
 class TestBackboneUtils(keras_parameterized.TestCase):
 
-    # @keras_parameterized.run_all_keras_modes
+    @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         ('channels_last',) * 2,
         # ('channels_first',) * 2,

--- a/deepcell/utils/backbone_utils_test.py
+++ b/deepcell/utils/backbone_utils_test.py
@@ -31,24 +31,22 @@ from __future__ import division
 
 from absl.testing import parameterized
 
-import sys
-
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.layers import Input
 from tensorflow.python.keras.models import Model
-from tensorflow.python.framework import test_util as tf_test_util
+from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.platform import test
 
 from deepcell.utils import backbone_utils
 
 
-class TestBackboneUtils(test.TestCase, parameterized.TestCase):
+class TestBackboneUtils(keras_parameterized.TestCase):
 
+    # @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         ('channels_last',) * 2,
         # ('channels_first',) * 2,
     ])
-    # @tf_test_util.run_in_graph_and_eager_modes()
     def test_get_featurenet_backbone(self, data_format):
         backbone = 'featurenet'
         input_shape = (256, 256, 3)
@@ -65,11 +63,11 @@ class TestBackboneUtils(test.TestCase, parameterized.TestCase):
             with self.assertRaises(ValueError):
                 backbone_utils.get_backbone(backbone, inputs, use_imagenet=True)
 
+    # @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         ('channels_last',) * 2,
         # ('channels_first',) * 2,
     ])
-    # @tf_test_util.run_in_graph_and_eager_modes()
     def test_get_featurenet3d_backbone(self, data_format):
         backbone = 'featurenet3d'
         input_shape = (40, 256, 256, 3)
@@ -86,6 +84,7 @@ class TestBackboneUtils(test.TestCase, parameterized.TestCase):
             with self.assertRaises(ValueError):
                 backbone_utils.get_backbone(backbone, inputs, use_imagenet=True)
 
+    # @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters([
         ('resnet50',) * 2,
         ('resnet101',) * 2,
@@ -105,7 +104,6 @@ class TestBackboneUtils(test.TestCase, parameterized.TestCase):
         ('nasnet_large',) * 2,
         ('nasnet_mobile',) * 2,
     ])
-    # @tf_test_util.run_in_graph_and_eager_modes()
     def test_get_backbone(self, backbone):
         with self.cached_session():
             K.set_image_data_format('channels_last')

--- a/deepcell/utils/transform_utils_test.py
+++ b/deepcell/utils/transform_utils_test.py
@@ -54,7 +54,7 @@ def _generate_test_masks():
 
 class TransformUtilsTest(test.TestCase):
     def test_pixelwise_transform_2d(self):
-        with self.test_session():
+        with self.cached_session():
             K.set_image_data_format('channels_last')
             # test single edge class
             maskstack = np.array([label(i) for i in _generate_test_masks()])
@@ -96,7 +96,7 @@ class TransformUtilsTest(test.TestCase):
             img_stack = np.array(frame_list)
             img_list.append(img_stack)
 
-        with self.test_session():
+        with self.cached_session():
             K.set_image_data_format('channels_last')
             # test single edge class
             maskstack = np.vstack(img_list)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ scikit-learn>=0.19.1,<1
 tensorflow>=1.14.0,<2
 jupyter>=1.0.0,<2
 nbformat>=4.4.0,<5
-keras-preprocessing==1.1.0
 keras-applications==1.0.8
 networkx>=2.1
 opencv-python>=3.4.2.17,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 pandas>=0.23.3,<1
-numpy>=1.14.5,<2
+numpy>=1.16.4,<2
 scipy>=1.1.0,<2
 scikit-image>=0.14.1,<1
 scikit-learn>=0.19.1,<1
-tensorflow>=1.10.0,<2
+tensorflow>=1.14.0,<2
 jupyter>=1.0.0,<2
 nbformat>=4.4.0,<5
-keras-preprocessing==1.0.6
+keras-preprocessing==1.1.0
 keras-applications==1.0.8
 networkx>=2.1
 opencv-python>=3.4.2.17,<4


### PR DESCRIPTION
Upgraded `deepcell-tf` to compatibility with `1.14.0` and `1.15.0` (the final 1.x release!).  This PR also drops support of python 3.5, as 1.15.0 is not available on that python version.  To make up for it, this PR begins support for python3.7.

This allows for a number of improvements to the codebase:

* Remove dependency on `keras-preprocessing` as the `ImageDataGenerator` will have `apply_transform` in all forward TensorFlow versions.

* Upgrade tests to use `keras_parameterized.run_all_keras_modes` and `cached_session`. (Fixes #243)

* Removes support for `tensorflow==1.12.x` (effectively resolves #244).

* Removes support for `tensorflow==1.13.x` (effectively resolves #245).

* Re-introduces `TestFilterDetections.test_mini_batch` correctness tests, which work in versions after 1.12.0. (resolves #155).

* Update the default `TF_VERSION` build-arg to `1.14.0` for use and travis deployment.
