### PR TITLE
Update README with python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ It can also be helpful to mount the local copy of the repository and the scripts
 ```bash
 NV_GPU='0' nvidia-docker run -it \
   -p 8888:8888 \
-  -v $PWD/deepcell:/usr/local/lib/python3.5/dist-packages/deepcell/ \
+  -v $PWD/deepcell:/usr/local/lib/python3.6/dist-packages/deepcell/ \
   -v $PWD/scripts:/notebooks \
   -v /data:/data \
   $USER/deepcell-tf:latest


### PR DESCRIPTION
It looks like the latest version is using python 3.6. I had to change the mounting path in order to get file changes to sync to docker. Should update the readme for appropriate mounting of containers (unless this is a result of me doing something wrong)