### PR TITLE
Correct upper limit for clipping boxes.

### DIFF
--- a/deepcell/layers/retinanet.py
+++ b/deepcell/layers/retinanet.py
@@ -203,33 +203,18 @@ class ClipBoxes(Layer):
     def call(self, inputs, **kwargs):
         image, boxes = inputs
         shape = K.cast(K.shape(image), K.floatx())
-        if K.ndim(image) == 4:
-            if self.data_format == "channels_first":
-                height = shape[2]
-                width = shape[3]
-            else:
-                height = shape[1]
-                width = shape[2]
-        elif K.ndim(image) == 5:
-            if self.data_format == "channels_first":
-                height = shape[3]
-                width = shape[4]
-            else:
-                height = shape[2]
-                width = shape[3]
-
-        if K.ndim(image) == 4:
-            x1 = tf.clip_by_value(boxes[:, :, 0], 0, width)
-            y1 = tf.clip_by_value(boxes[:, :, 1], 0, height)
-            x2 = tf.clip_by_value(boxes[:, :, 2], 0, width)
-            y2 = tf.clip_by_value(boxes[:, :, 3], 0, height)
-            return K.stack([x1, y1, x2, y2], axis=2)
-        elif K.ndim(image) == 5:
-            x1 = tf.clip_by_value(boxes[:, :, :, 0], 0, width)
-            y1 = tf.clip_by_value(boxes[:, :, :, 1], 0, height)
-            x2 = tf.clip_by_value(boxes[:, :, :, 2], 0, width)
-            y2 = tf.clip_by_value(boxes[:, :, :, 3], 0, height)
-            return K.stack([x1, y1, x2, y2], axis=3)
+        ndim = K.ndim(image)
+        if self.data_format == "channels_first":
+            height = shape[ndim - 2]
+            width = shape[ndim - 1]
+        else:
+            height = shape[ndim - 3]
+            width = shape[ndim - 2]
+        x1 = tf.clip_by_value(boxes[..., 0], 0, width - 1)
+        y1 = tf.clip_by_value(boxes[..., 1], 0, height - 1)
+        x2 = tf.clip_by_value(boxes[..., 2], 0, width - 1)
+        y2 = tf.clip_by_value(boxes[..., 3], 0, height - 1)
+        return K.stack([x1, y1, x2, y2], axis=ndim - 2)
 
     def compute_output_shape(self, input_shape):
         return tensor_shape.TensorShape(input_shape[1]).as_list()

--- a/deepcell/layers/retinanet.py
+++ b/deepcell/layers/retinanet.py
@@ -210,10 +210,12 @@ class ClipBoxes(Layer):
         else:
             height = shape[ndim - 3]
             width = shape[ndim - 2]
-        x1 = tf.clip_by_value(boxes[..., 0], 0, width - 1)
-        y1 = tf.clip_by_value(boxes[..., 1], 0, height - 1)
-        x2 = tf.clip_by_value(boxes[..., 2], 0, width - 1)
-        y2 = tf.clip_by_value(boxes[..., 3], 0, height - 1)
+
+        x1, y1, x2, y2 = tf.unstack(boxes, axis=-1)
+        x1 = tf.clip_by_value(x1, 0, width - 1)
+        y1 = tf.clip_by_value(y1, 0, height - 1)
+        x2 = tf.clip_by_value(x2, 0, width - 1)
+        y2 = tf.clip_by_value(y2, 0, height - 1)
         return K.stack([x1, y1, x2, y2], axis=ndim - 2)
 
     def compute_output_shape(self, input_shape):

--- a/deepcell/layers/retinanet_test.py
+++ b/deepcell/layers/retinanet_test.py
@@ -293,11 +293,11 @@ class ClipBoxesTest(keras_parameterized.TestCase):
 
         # compute expected output
         expected = np.array([[
-            [img_w, img_h, img_w, img_h],
+            [img_w - 1, img_h - 1, img_w - 1, img_h - 1],
             [0, 0, 0, 0],
-            [0, 0, img_w, img_h],
-            [0, 0, img_w, img_h],
             [0, 0, img_w - 1, img_h - 1],
+            [0, 0, img_w - 1, img_h - 1],
+            [0, 0, img_w - 2, img_h - 2],
         ]], dtype=K.floatx())
         expected = np.expand_dims(expected, axis=0)
 

--- a/deepcell/layers/retinanet_test.py
+++ b/deepcell/layers/retinanet_test.py
@@ -239,10 +239,10 @@ class ClipBoxesTest(keras_parameterized.TestCase):
 
         # compute expected output
         expected = np.array([[
-            [img_w, img_h, img_w, img_h],
+            [img_w - 1, img_h - 1, img_w - 1, img_h - 1],
             [0, 0, 0, 0],
-            [0, 0, img_w, img_h],
-            [0, 0, img_w, img_h],
+            [0, 0, img_w - 1, img_h - 1],
+            [0, 0, img_w - 1, img_h - 1],
             [0, 0, img_w - 1, img_h - 1],
         ]], dtype=K.floatx())
 
@@ -297,7 +297,7 @@ class ClipBoxesTest(keras_parameterized.TestCase):
             [0, 0, 0, 0],
             [0, 0, img_w - 1, img_h - 1],
             [0, 0, img_w - 1, img_h - 1],
-            [0, 0, img_w - 2, img_h - 2],
+            [0, 0, img_w - 1, img_h - 1],
         ]], dtype=K.floatx())
         expected = np.expand_dims(expected, axis=0)
 


### PR DESCRIPTION
From  [the same PR in keras-retinanet](https://github.com/fizyr/keras-retinanet/commit/5524619f91699732ba24c6f52fb9e4b0b780b019).