### PR TITLE
Updated tests from tensorflow.keras.layers.convolutional_recurrent_test

### DIFF
--- a/deepcell/layers/__init__.py
+++ b/deepcell/layers/__init__.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from deepcell.layers import convolutional_recurrent
 from deepcell.layers import location
 from deepcell.layers import normalization
 from deepcell.layers import pooling
@@ -59,6 +60,7 @@ from deepcell.layers.retinanet import Shape
 from deepcell.layers.retinanet import Cast
 from deepcell.layers.upsample import Upsample
 from deepcell.layers.upsample import UpsampleLike
+from deepcell.layers.convolutional_recurrent import ConvGRU2D
 
 del absolute_import
 del division

--- a/deepcell/layers/convolutional_recurrent.py
+++ b/deepcell/layers/convolutional_recurrent.py
@@ -169,7 +169,6 @@ class ConvGRU2DCell(Layer):
         self.built = True
 
     def call(self, inputs, states, training=None):
-        h_tm1 = states[0]  # previous memory state
         if 0 < self.dropout < 1 and self._dropout_mask is None:
             self._dropout_mask = _generate_dropout_mask(
                 K.ones_like(inputs),
@@ -179,7 +178,7 @@ class ConvGRU2DCell(Layer):
         if (0 < self.recurrent_dropout < 1 and
                 self._recurrent_dropout_mask is None):
             self._recurrent_dropout_mask = _generate_dropout_mask(
-                K.ones_like(h_tm1),
+                K.ones_like(states[1]),
                 self.recurrent_dropout,
                 training=training,
                 count=3)
@@ -188,6 +187,8 @@ class ConvGRU2DCell(Layer):
         dp_mask = self._dropout_mask
         # dropout matrices for recurrent units
         rec_dp_mask = self._recurrent_dropout_mask
+
+        h_tm1 = states[0]  # previous memory state
 
         if 0. < self.dropout < 1.:
             inputs_z = inputs * dp_mask[0]

--- a/deepcell/layers/convolutional_recurrent.py
+++ b/deepcell/layers/convolutional_recurrent.py
@@ -297,6 +297,7 @@ class ConvGRU2D(ConvRNN2D):
                  recurrent_constraint=None,
                  bias_constraint=None,
                  return_sequences=False,
+                 return_state=False,
                  go_backwards=False,
                  stateful=False,
                  dropout=0.,
@@ -325,6 +326,7 @@ class ConvGRU2D(ConvRNN2D):
 
         super(ConvGRU2D, self).__init__(cell,
                                         return_sequences=return_sequences,
+                                        return_state=return_state,
                                         go_backwards=go_backwards,
                                         stateful=stateful,
                                         **kwargs)

--- a/deepcell/layers/convolutional_recurrent.py
+++ b/deepcell/layers/convolutional_recurrent.py
@@ -1,0 +1,479 @@
+''' 
+References:
+
+Keras GRU
+https://github.com/keras-team/keras/blob/master/keras/layers/recurrent.py#L422
+Keras ConvLSTM2D
+https://github.com/keras-team/keras/blob/master/keras/layers/convolutional_recurrent.py
+
+RFCNN 
+https://gitlab.com/sepehr.valipour/RFCNN/blob/master/rfcnn/layers/convolutional.py
+Literature at https://ieeexplore.ieee.org/abstract/document/8296851
+
+TODO:
+1. Get versions of packages; put in header
+tensorflow-1.12.0
+keras-applications-1.0.6                               
+keras-preprocessing: 1.0.5
+python-3.6.6
+
+'''
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import warnings
+import os
+# import pylab as plt
+import matplotlib
+matplotlib.use('Agg')
+import pylab as plt
+
+
+import tensorflow as tf
+
+from tensorflow.python.keras import activations
+from tensorflow.python.keras import backend as K
+from tensorflow.python.keras import constraints
+from tensorflow.python.keras import initializers
+from tensorflow.python.keras import regularizers
+from tensorflow.python.keras.engine.base_layer import Layer
+from tensorflow.python.keras.layers.recurrent import _generate_dropout_mask
+from tensorflow.python.keras.layers.recurrent import RNN
+
+from tensorflow.python.keras.utils import conv_utils
+from tensorflow.python.keras.utils import generic_utils
+from tensorflow.python.keras.utils import tf_utils
+
+from tensorflow.python.keras.engine.base_layer import Layer
+
+from tensorflow.python.keras.models import Sequential
+from tensorflow.python.keras.layers.convolutional import Conv3D
+from tensorflow.python.keras.layers.normalization import BatchNormalization
+from tensorflow.python.keras.layers.convolutional_recurrent import ConvLSTM2D, ConvRNN2D
+
+
+class ConvGRU2DCell(Layer):
+    """Cell class for the ConvGRU2D layer."""
+    
+    def __init__(self,
+                 filters,
+                 kernel_size,
+                 strides=(1, 1),
+                 padding='valid',
+                 data_format=None,
+                 dilation_rate=(1, 1),
+                 activation='tanh',
+                 recurrent_activation='hard_sigmoid',
+                 use_bias=True,
+                 kernel_initializer='glorot_uniform',
+                 recurrent_initializer='orthogonal',
+                 bias_initializer='zeros',
+                 kernel_regularizer=None,
+                 recurrent_regularizer=None,
+                 bias_regularizer=None,
+                 kernel_constraint=None,
+                 recurrent_constraint=None,
+                 bias_constraint=None,
+                 dropout=0.,
+                 recurrent_dropout=0.,
+                 **kwargs):
+        super(ConvGRU2DCell, self).__init__(**kwargs)
+        self.filters = filters
+        self.kernel_size = conv_utils.normalize_tuple(kernel_size, 2, 'kernel_size')
+        
+        self.strides = conv_utils.normalize_tuple(strides, 2, 'strides')
+        self.padding = conv_utils.normalize_padding(padding)
+        self.data_format = conv_utils.normalize_data_format(data_format)
+        self.dilation_rate = conv_utils.normalize_tuple(dilation_rate, 2,
+                                                        'dilation_rate')
+        self.activation = activations.get(activation)
+        self.recurrent_activation = activations.get(recurrent_activation)
+        self.use_bias = use_bias
+
+        self.kernel_initializer = initializers.get(kernel_initializer)
+        self.recurrent_initializer = initializers.get(recurrent_initializer)
+        self.bias_initializer = initializers.get(bias_initializer)
+
+        self.kernel_regularizer = regularizers.get(kernel_regularizer)
+        self.recurrent_regularizer = regularizers.get(recurrent_regularizer)
+        self.bias_regularizer = regularizers.get(bias_regularizer)
+
+        self.kernel_constraint = constraints.get(kernel_constraint)
+        self.recurrent_constraint = constraints.get(recurrent_constraint)
+        self.bias_constraint = constraints.get(bias_constraint)
+
+        self.dropout = min(1., max(0., dropout))
+        self.recurrent_dropout = min(1., max(0., recurrent_dropout))
+        self.state_size = (self.filters, self.filters)
+        self._dropout_mask = None
+        self._recurrent_dropout_mask = None
+            
+
+    def build(self, input_shape):
+
+      # print("building ConvGRU2DCell")
+      if self.data_format == 'channels_first':
+          channel_axis = 1
+      else:
+          channel_axis = -1
+      if input_shape[channel_axis] is None:
+          raise ValueError('The channel dimension of the inputs '
+                           'should be defined. Found `None`.')
+      input_dim = input_shape[channel_axis]
+      kernel_shape = self.kernel_size + (input_dim, self.filters * 3)
+      self.kernel_shape = kernel_shape
+      recurrent_kernel_shape = self.kernel_size + (self.filters, self.filters * 3)
+
+      self.kernel = self.add_weight(shape=kernel_shape,
+                                      initializer=self.kernel_initializer,
+                                      name='kernel',
+                                      regularizer=self.kernel_regularizer,
+                                      constraint=self.kernel_constraint)
+      self.recurrent_kernel = self.add_weight(
+            shape=recurrent_kernel_shape,
+            initializer=self.recurrent_initializer,
+            name='recurrent_kernel',
+            regularizer=self.recurrent_regularizer,
+            constraint=self.recurrent_constraint)
+
+      if self.use_bias:
+          bias_initializer = self.bias_initializer
+          self.bias = self.add_weight(
+                shape=(self.filters * 3,), 
+                name='bias',
+                initializer= self.bias_initializer,
+                regularizer=self.bias_regularizer,
+                constraint=self.bias_constraint)
+      else:
+          self.bias = None
+
+      # update gate
+      self.kernel_z = self.kernel[:, :, :, :self.filters]
+      self.recurrent_kernel_z = self.recurrent_kernel[:, :, :, :self.filters]
+      # reset gate
+      self.kernel_r = self.kernel[:, :, :, self.filters: self.filters * 2]
+      self.recurrent_kernel_r = self.recurrent_kernel[:, :, :, self.filters:
+                                                        self.filters * 2]
+      # new gate 
+      self.kernel_h = self.kernel[:, :, :, self.filters * 2:]
+      self.recurrent_kernel_h = self.recurrent_kernel[:, :, :, self.filters * 2:]
+
+      if self.use_bias:
+          # bias for inputs
+          self.bias_z = self.bias[:self.filters]
+          self.bias_r = self.bias[self.filters: self.filters * 2]
+          self.bias_h = self.bias[self.filters * 2:]
+      else:
+          self.bias_z = None
+          self.bias_r = None
+          self.bias_h = None
+      self.built = True
+
+        
+        
+    def call(self, inputs, states, training=None):
+        h_tm1 = states[0]  # previous memory state
+
+        if 0 < self.dropout < 1 and self._dropout_mask is None:
+            self._dropout_mask = _generate_dropout_mask(
+                K.ones_like(inputs),
+                self.dropout,
+                training=training,
+                count=3)
+        if (0 < self.recurrent_dropout < 1 and
+            self._recurrent_dropout_mask is None):
+            self._recurrent_dropout_mask = _generate_dropout_mask(
+                K.ones_like(h_tm1),
+                self.recurrent_dropout,
+                training=training,
+                count=3)
+
+        # dropout matrices for input units
+        dp_mask = self._dropout_mask
+
+        # dropout matrices for recurrent units
+        rec_dp_mask = self._recurrent_dropout_mask
+
+        if 0. < self.dropout < 1.:
+            inputs_z = inputs * dp_mask[0]
+            inputs_r = inputs * dp_mask[1]
+            inputs_h = inputs * dp_mask[2]
+        else:
+            inputs_z = inputs
+            inputs_r = inputs
+            inputs_h = inputs
+
+        if 0. < self.recurrent_dropout < 1.:
+            h_tm1_z = h_tm1 * rec_dp_mask[0]
+            h_tm1_r = h_tm1 * rec_dp_mask[1]
+            h_tm1_h = h_tm1 * rec_dp_mask[2]
+        else:
+            h_tm1_z = h_tm1
+            h_tm1_r = h_tm1
+            h_tm1_h = h_tm1
+
+        x_z = self.input_conv(inputs_z, self.kernel_z, self.bias_z,
+                            padding=self.padding)
+        x_r = self.input_conv(inputs_r, self.kernel_r, self.bias_r,
+                            padding=self.padding)
+        x_h = self.input_conv(inputs_h, self.kernel_h, self.bias_h,
+                            padding=self.padding)
+      
+        h_z = self.recurrent_conv(h_tm1_z,
+                                self.recurrent_kernel_z)
+        h_r = self.recurrent_conv(h_tm1_r,
+                                self.recurrent_kernel_r)
+
+        z = self.recurrent_activation(x_z + h_z)
+        r = self.recurrent_activation(x_r + h_r)
+
+        h_h = self.recurrent_conv(r * h_tm1_h,
+                                self.recurrent_kernel_h)
+
+        hh = self.recurrent_activation(x_h + h_h)
+
+        # previous and candidate state mixed by update gate
+        h = z * h_tm1 + (1 - z) * hh
+
+        if 0 < self.dropout + self.recurrent_dropout:
+            if training is None:
+                h._uses_learning_phase = True
+
+        return h, [h,hh]
+
+    def input_conv(self, x, w, b=None, padding='valid'):
+        conv_out = K.conv2d(x, w, strides=self.strides,
+                          padding=padding,
+                          data_format=self.data_format,
+                          dilation_rate=self.dilation_rate)
+        if b is not None:
+            conv_out = K.bias_add(conv_out, b,
+                              data_format=self.data_format)
+        return conv_out
+
+    def recurrent_conv(self, x, w):
+        conv_out = K.conv2d(x, w, strides=(1, 1),
+                          padding='same',
+                          data_format=self.data_format)
+        return conv_out
+    
+
+    def get_config(self):
+        config = {'filters': self.filters,
+                  'kernel_size': self.kernel_size,
+                  'strides': self.strides,
+                  'padding': self.padding,
+                  'data_format': self.data_format,
+                  'dilation_rate': self.dilation_rate,
+                  'activation': activations.serialize(self.activation),
+                  'recurrent_activation': activations.serialize(self.recurrent_activation),
+                  'use_bias': self.use_bias,
+                  'kernel_initializer': initializers.serialize(self.kernel_initializer),
+                  'recurrent_initializer': initializers.serialize(self.recurrent_initializer),
+                  'bias_initializer': initializers.serialize(self.bias_initializer),
+                  'kernel_regularizer': regularizers.serialize(self.kernel_regularizer),
+                  'recurrent_regularizer': regularizers.serialize(self.recurrent_regularizer),
+                  'bias_regularizer': regularizers.serialize(self.bias_regularizer),
+                  'kernel_constraint': constraints.serialize(self.kernel_constraint),
+                  'recurrent_constraint': constraints.serialize(self.recurrent_constraint),
+                  'bias_constraint': constraints.serialize(self.bias_constraint),
+                  'dropout': self.dropout,
+                  'recurrent_dropout': self.recurrent_dropout}
+        base_config = super(ConvGRU2DCell, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+
+class ConvGRU2D(ConvRNN2D):
+    def __init__(self,
+               filters,
+               kernel_size,
+               strides=(1, 1),
+               padding='valid',
+               data_format=None,
+               dilation_rate=(1, 1),
+               activation='tanh',
+               recurrent_activation='hard_sigmoid',
+               use_bias=True,
+               kernel_initializer='glorot_uniform',
+               recurrent_initializer='orthogonal',
+               bias_initializer='zeros',
+               kernel_regularizer=None,
+               recurrent_regularizer=None,
+               bias_regularizer=None,
+               activity_regularizer=None,
+               kernel_constraint=None,
+               recurrent_constraint=None,
+               bias_constraint=None,
+               return_sequences=False,
+               go_backwards=False,
+               stateful=False,
+               dropout=0.,
+               recurrent_dropout=0.,
+               **kwargs):
+        cell = ConvGRU2DCell(filters=filters,
+                             kernel_size=kernel_size,
+                             strides=strides,
+                            padding=padding,
+                            data_format=data_format,
+                            dilation_rate=dilation_rate,
+                            activation=activation,
+                            recurrent_activation=recurrent_activation,
+                            use_bias=use_bias,
+                            kernel_initializer=kernel_initializer,
+                            recurrent_initializer=recurrent_initializer,
+                            bias_initializer=bias_initializer,
+                            kernel_regularizer=kernel_regularizer,
+                            recurrent_regularizer=recurrent_regularizer,
+                            bias_regularizer=bias_regularizer,
+                            kernel_constraint=kernel_constraint,
+                            recurrent_constraint=recurrent_constraint,
+                            bias_constraint=bias_constraint,
+                            dropout=dropout,
+                            recurrent_dropout=recurrent_dropout)
+    
+        super(ConvGRU2D, self).__init__(cell,
+                                        return_sequences=return_sequences,
+                                        go_backwards=go_backwards,
+                                        stateful=stateful,
+                                        **kwargs)
+        self.activity_regularizer = regularizers.get(activity_regularizer)
+        
+    def call(self, inputs, mask=None, training=None, initial_state=None):
+        result = super(ConvGRU2D, self).call(inputs, 
+                                          mask=mask,
+                                          training=training, 
+                                          initial_state=initial_state)
+        return result
+
+    @property
+    def filters(self):
+        return self.cell.filters
+    
+    @property
+    def kernel_size(self):
+        return self.cell.kernel_size
+
+    @property
+    def strides(self):
+        return self.cell.strides
+
+    @property
+    def padding(self):
+        return self.cell.padding
+
+    @property
+    def data_format(self):
+        return self.cell.data_format
+
+    @property
+    def dilation_rate(self):
+        return self.cell.dilation_rate
+
+    @property
+    def activation(self):
+        return self.cell.activation
+
+    @property
+    def recurrent_activation(self):
+        return self.cell.recurrent_activation
+
+    @property
+    def use_bias(self):
+        return self.cell.use_bias
+
+    @property
+    def kernel_initializer(self):
+        return self.cell.kernel_initializer
+
+    @property
+    def recurrent_initializer(self):
+        return self.cell.recurrent_initializer
+
+    @property
+    def bias_initializer(self):
+        return self.cell.bias_initializer
+
+    @property
+    def unit_forget_bias(self):
+        return self.cell.unit_forget_bias
+
+    @property
+    def kernel_regularizer(self):
+        return self.cell.kernel_regularizer
+
+    @property
+    def recurrent_regularizer(self):
+        return self.cell.recurrent_regularizer
+
+    @property
+    def bias_regularizer(self):
+        return self.cell.bias_regularizer
+
+    @property
+    def kernel_constraint(self):
+        return self.cell.kernel_constraint
+
+    @property
+    def recurrent_constraint(self):
+        return self.cell.recurrent_constraint
+
+    @property
+    def bias_constraint(self):
+        return self.cell.bias_constraint
+
+    @property
+    def dropout(self):
+        return self.cell.dropout
+
+    @property
+    def recurrent_dropout(self):
+        return self.cell.recurrent_dropout
+
+    def get_config(self):
+        config = {'filters': self.filters,
+                  'kernel_size': self.kernel_size,
+                  'strides': self.strides,
+                  'padding': self.padding,
+                  'data_format': self.data_format,
+                  'dilation_rate': self.dilation_rate,
+                  'activation': activations.serialize(self.activation),
+                  'recurrent_activation': activations.serialize(
+                  self.recurrent_activation),
+              'use_bias': self.use_bias,
+              'kernel_initializer': initializers.serialize(
+                  self.kernel_initializer),
+              'recurrent_initializer': initializers.serialize(
+                  self.recurrent_initializer),
+              'bias_initializer': initializers.serialize(self.bias_initializer),
+              'kernel_regularizer': regularizers.serialize(
+                  self.kernel_regularizer),
+              'recurrent_regularizer': regularizers.serialize(
+                  self.recurrent_regularizer),
+              'bias_regularizer': regularizers.serialize(self.bias_regularizer),
+              'activity_regularizer': regularizers.serialize(
+                  self.activity_regularizer),
+              'kernel_constraint': constraints.serialize(
+                  self.kernel_constraint),
+              'recurrent_constraint': constraints.serialize(
+                  self.recurrent_constraint),
+              'bias_constraint': constraints.serialize(self.bias_constraint),
+              'dropout': self.dropout,
+              'recurrent_dropout': self.recurrent_dropout}
+        base_config = super(ConvGRU2D, self).get_config()
+        del base_config['cell']
+        return dict(list(base_config.items()) + list(config.items()))
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(**config)
+
+
+
+
+
+
+

--- a/deepcell/layers/convolutional_recurrent.py
+++ b/deepcell/layers/convolutional_recurrent.py
@@ -49,13 +49,13 @@ from tensorflow.python.keras import backend as K
 from tensorflow.python.keras import constraints
 from tensorflow.python.keras import initializers
 from tensorflow.python.keras import regularizers
-from tensorflow.python.keras.layers.recurrent import AbstractRNNCell
+from tensorflow.python.keras.layers import Layer
 from tensorflow.python.keras.layers.recurrent import DropoutRNNCellMixin
 from tensorflow.python.keras.layers.convolutional_recurrent import ConvRNN2D
 from tensorflow.python.keras.utils import conv_utils
 
 
-class ConvGRU2DCell(DropoutRNNCellMixin, AbstractRNNCell):
+class ConvGRU2DCell(DropoutRNNCellMixin, Layer):
     """Cell class for the ConvGRU2D layer."""
 
     def __init__(self,

--- a/deepcell/layers/convolutional_recurrent.py
+++ b/deepcell/layers/convolutional_recurrent.py
@@ -169,7 +169,7 @@ class ConvGRU2DCell(Layer):
         self.built = True
 
     def call(self, inputs, states, training=None):
-        
+        h_tm1 = states[0]  # previous memory state
         if 0 < self.dropout < 1 and self._dropout_mask is None:
             self._dropout_mask = _generate_dropout_mask(
                 K.ones_like(inputs),
@@ -188,8 +188,6 @@ class ConvGRU2DCell(Layer):
         dp_mask = self._dropout_mask
         # dropout matrices for recurrent units
         rec_dp_mask = self._recurrent_dropout_mask
-
-        h_tm1 = states[0]  # previous memory state
 
         if 0. < self.dropout < 1.:
             inputs_z = inputs * dp_mask[0]

--- a/deepcell/layers/convolutional_recurrent.py
+++ b/deepcell/layers/convolutional_recurrent.py
@@ -228,7 +228,7 @@ class ConvGRU2DCell(Layer):
         # previous and candidate state mixed by update gate
         h = (1 - z) * h_tm1 + z * hh
 
-        if 0 < self.dropout + self.recurrent_dropout:
+        if self.dropout + self.recurrent_dropout > 0:
             if training is None:
                 h._uses_learning_phase = True
         zeros = K.zeros_like(h_tm1)

--- a/deepcell/layers/convolutional_recurrent.py
+++ b/deepcell/layers/convolutional_recurrent.py
@@ -333,6 +333,8 @@ class ConvGRU2D(ConvRNN2D):
         self.activity_regularizer = regularizers.get(activity_regularizer)
 
     def call(self, inputs, mask=None, training=None, initial_state=None):
+        # self.cell.reset_dropout_mask()
+        # self.cell.reset_recurrent_dropout_mask()
         result = super(ConvGRU2D, self).call(inputs,
                                              mask=mask,
                                              training=training,

--- a/deepcell/layers/convolutional_recurrent.py
+++ b/deepcell/layers/convolutional_recurrent.py
@@ -33,7 +33,7 @@ https://github.com/keras-team/keras/blob/master/keras/layers/recurrent.py#L422
 Keras ConvLSTM2D
 https://github.com/keras-team/keras/blob/master/keras/layers/convolutional_recurrent.py
 
-RFCNN 
+RFCNN
 https://gitlab.com/sepehr.valipour/RFCNN/blob/master/rfcnn/layers/convolutional.py
 Literature at https://ieeexplore.ieee.org/abstract/document/8296851
 """
@@ -57,7 +57,7 @@ from tensorflow.python.keras.utils import conv_utils
 
 class ConvGRU2DCell(Layer):
     """Cell class for the ConvGRU2D layer."""
-    
+
     def __init__(self,
                  filters,
                  kernel_size,
@@ -83,7 +83,7 @@ class ConvGRU2DCell(Layer):
         super(ConvGRU2DCell, self).__init__(**kwargs)
         self.filters = filters
         self.kernel_size = conv_utils.normalize_tuple(kernel_size, 2, 'kernel_size')
-        
+
         self.strides = conv_utils.normalize_tuple(strides, 2, 'strides')
         self.padding = conv_utils.normalize_padding(padding)
         self.data_format = conv_utils.normalize_data_format(data_format)
@@ -109,7 +109,6 @@ class ConvGRU2DCell(Layer):
         self.state_size = (self.filters, self.filters)
         self._dropout_mask = None
         self._recurrent_dropout_mask = None
-
 
     def build(self, input_shape):
         if self.data_format == 'channels_first':
@@ -138,9 +137,9 @@ class ConvGRU2DCell(Layer):
 
         if self.use_bias:
             self.bias = self.add_weight(
-                shape=(self.filters * 3,), 
+                shape=(self.filters * 3,),
                 name='bias',
-                initializer= self.bias_initializer,
+                initializer=self.bias_initializer,
                 regularizer=self.bias_regularizer,
                 constraint=self.bias_constraint)
         else:
@@ -152,7 +151,7 @@ class ConvGRU2DCell(Layer):
         # reset gate
         self.kernel_r = self.kernel[:, :, :, self.filters: self.filters * 2]
         self.recurrent_kernel_r = self.recurrent_kernel[:, :, :, self.filters:self.filters * 2]
-        # new gate 
+        # new gate
         self.kernel_h = self.kernel[:, :, :, self.filters * 2:self.filters * 3]
         self.recurrent_kernel_h = self.recurrent_kernel[:, :, :, self.filters * 2: self.filters * 3]
 
@@ -167,7 +166,6 @@ class ConvGRU2DCell(Layer):
             self.bias_h = None
         self.built = True
 
-        
     def call(self, inputs, states, training=None):
         
         if 0 < self.dropout < 1 and self._dropout_mask is None:
@@ -177,7 +175,7 @@ class ConvGRU2DCell(Layer):
                 training=training,
                 count=3)
         if (0 < self.recurrent_dropout < 1 and
-            self._recurrent_dropout_mask is None):
+                self._recurrent_dropout_mask is None):
             self._recurrent_dropout_mask = _generate_dropout_mask(
                 K.ones_like(h_tm1),
                 self.recurrent_dropout,
@@ -210,25 +208,22 @@ class ConvGRU2DCell(Layer):
             h_tm1_h = h_tm1
 
         x_z = self.input_conv(inputs_z, self.kernel_z, self.bias_z,
-                            padding=self.padding)
+                              padding=self.padding)
         x_r = self.input_conv(inputs_r, self.kernel_r, self.bias_r,
-                            padding=self.padding)
+                              padding=self.padding)
         x_h = self.input_conv(inputs_h, self.kernel_h, self.bias_h,
-                            padding=self.padding)
-        
-        h_z = self.recurrent_conv(h_tm1_z,
-                                self.recurrent_kernel_z)
-        h_r = self.recurrent_conv(h_tm1_r,
-                                self.recurrent_kernel_r)
+                              padding=self.padding)
+
+        h_z = self.recurrent_conv(h_tm1_z, self.recurrent_kernel_z)
+        h_r = self.recurrent_conv(h_tm1_r, self.recurrent_kernel_r)
 
         z = self.recurrent_activation(x_z + h_z)
         r = self.recurrent_activation(x_r + h_r)
 
-        h_h = self.recurrent_conv(r * h_tm1_h,
-                                self.recurrent_kernel_h)
+        h_h = self.recurrent_conv(r * h_tm1_h, self.recurrent_kernel_h)
 
         hh = self.activation(x_h + h_h)
-        
+
         # previous and candidate state mixed by update gate
         h = (1 - z) * h_tm1 + z * hh
 
@@ -279,9 +274,8 @@ class ConvGRU2DCell(Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
-
 class ConvGRU2D(ConvRNN2D):
-    def __init__(self, 
+    def __init__(self,
                  filters,
                  kernel_size,
                  strides=(1, 1),
@@ -327,15 +321,15 @@ class ConvGRU2D(ConvRNN2D):
                              bias_constraint=bias_constraint,
                              dropout=dropout,
                              recurrent_dropout=recurrent_dropout)
-                
+
         super(ConvGRU2D, self).__init__(cell,
                                         return_sequences=return_sequences,
                                         go_backwards=go_backwards,
                                         stateful=stateful,
                                         **kwargs)
-      
+
         self.activity_regularizer = regularizers.get(activity_regularizer)
-        
+
     def call(self, inputs, mask=None, training=None, initial_state=None):
         result = super(ConvGRU2D, self).call(inputs,
                                              mask=mask,

--- a/deepcell/layers/convolutional_recurrent.py
+++ b/deepcell/layers/convolutional_recurrent.py
@@ -1,4 +1,31 @@
-''' 
+# Copyright 2016-2019 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/deepcell-tf/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Convolutational Recurrent Layers
+
 References:
 
 Keras GRU
@@ -9,15 +36,7 @@ https://github.com/keras-team/keras/blob/master/keras/layers/convolutional_recur
 RFCNN 
 https://gitlab.com/sepehr.valipour/RFCNN/blob/master/rfcnn/layers/convolutional.py
 Literature at https://ieeexplore.ieee.org/abstract/document/8296851
-
-TODO:
-1. Get versions of packages; put in header
-tensorflow-1.12.0
-keras-applications-1.0.6                               
-keras-preprocessing: 1.0.5
-python-3.6.6
-
-'''
+"""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -26,11 +45,6 @@ from __future__ import print_function
 import numpy as np
 import warnings
 import os
-# import pylab as plt
-import matplotlib
-matplotlib.use('Agg')
-import pylab as plt
-
 
 import tensorflow as tf
 
@@ -74,6 +88,7 @@ class ConvGRU2DCell(Layer):
                  kernel_regularizer=None,
                  recurrent_regularizer=None,
                  bias_regularizer=None,
+                 activity_regularizer=None,
                  kernel_constraint=None,
                  recurrent_constraint=None,
                  bias_constraint=None,
@@ -113,66 +128,61 @@ class ConvGRU2DCell(Layer):
             
 
     def build(self, input_shape):
-
-      # print("building ConvGRU2DCell")
-      if self.data_format == 'channels_first':
-          channel_axis = 1
-      else:
-          channel_axis = -1
-      if input_shape[channel_axis] is None:
-          raise ValueError('The channel dimension of the inputs '
+        if self.data_format == 'channels_first':
+            channel_axis = 1
+        else:
+            channel_axis = -1
+        if input_shape[channel_axis] is None:
+            raise ValueError('The channel dimension of the inputs '
                            'should be defined. Found `None`.')
-      input_dim = input_shape[channel_axis]
-      kernel_shape = self.kernel_size + (input_dim, self.filters * 3)
-      self.kernel_shape = kernel_shape
-      recurrent_kernel_shape = self.kernel_size + (self.filters, self.filters * 3)
+        input_dim = input_shape[channel_axis]
+        kernel_shape = self.kernel_size + (input_dim, self.filters * 3)
+        self.kernel_shape = kernel_shape
+        recurrent_kernel_shape = self.kernel_size + (self.filters, self.filters * 3)
 
-      self.kernel = self.add_weight(shape=kernel_shape,
+        self.kernel = self.add_weight(shape=kernel_shape,
                                       initializer=self.kernel_initializer,
                                       name='kernel',
                                       regularizer=self.kernel_regularizer,
                                       constraint=self.kernel_constraint)
-      self.recurrent_kernel = self.add_weight(
+        self.recurrent_kernel = self.add_weight(
             shape=recurrent_kernel_shape,
             initializer=self.recurrent_initializer,
             name='recurrent_kernel',
             regularizer=self.recurrent_regularizer,
             constraint=self.recurrent_constraint)
 
-      if self.use_bias:
-          bias_initializer = self.bias_initializer
-          self.bias = self.add_weight(
+        if self.use_bias:
+            self.bias = self.add_weight(
                 shape=(self.filters * 3,), 
                 name='bias',
                 initializer= self.bias_initializer,
                 regularizer=self.bias_regularizer,
                 constraint=self.bias_constraint)
-      else:
-          self.bias = None
+        else:
+            self.bias = None
 
-      # update gate
-      self.kernel_z = self.kernel[:, :, :, :self.filters]
-      self.recurrent_kernel_z = self.recurrent_kernel[:, :, :, :self.filters]
-      # reset gate
-      self.kernel_r = self.kernel[:, :, :, self.filters: self.filters * 2]
-      self.recurrent_kernel_r = self.recurrent_kernel[:, :, :, self.filters:
-                                                        self.filters * 2]
-      # new gate 
-      self.kernel_h = self.kernel[:, :, :, self.filters * 2:]
-      self.recurrent_kernel_h = self.recurrent_kernel[:, :, :, self.filters * 2:]
+        # update gate
+        self.kernel_z = self.kernel[:, :, :, :self.filters]
+        self.recurrent_kernel_z = self.recurrent_kernel[:, :, :, :self.filters]
+        # reset gate
+        self.kernel_r = self.kernel[:, :, :, self.filters: self.filters * 2]
+        self.recurrent_kernel_r = self.recurrent_kernel[:, :, :, self.filters:self.filters * 2]
+        # new gate 
+        self.kernel_h = self.kernel[:, :, :, self.filters * 2:]
+        self.recurrent_kernel_h = self.recurrent_kernel[:, :, :, self.filters * 2:]
 
-      if self.use_bias:
-          # bias for inputs
-          self.bias_z = self.bias[:self.filters]
-          self.bias_r = self.bias[self.filters: self.filters * 2]
-          self.bias_h = self.bias[self.filters * 2:]
-      else:
-          self.bias_z = None
-          self.bias_r = None
-          self.bias_h = None
-      self.built = True
+        if self.use_bias:
+            # bias for inputs
+            self.bias_z = self.bias[:self.filters]
+            self.bias_r = self.bias[self.filters: self.filters * 2]
+            self.bias_h = self.bias[self.filters * 2:]
+        else:
+            self.bias_z = None
+            self.bias_r = None
+            self.bias_h = None
+        self.built = True
 
-        
         
     def call(self, inputs, states, training=None):
         h_tm1 = states[0]  # previous memory state
@@ -221,7 +231,7 @@ class ConvGRU2DCell(Layer):
                             padding=self.padding)
         x_h = self.input_conv(inputs_h, self.kernel_h, self.bias_h,
                             padding=self.padding)
-      
+        
         h_z = self.recurrent_conv(h_tm1_z,
                                 self.recurrent_kernel_z)
         h_r = self.recurrent_conv(h_tm1_r,
@@ -233,16 +243,18 @@ class ConvGRU2DCell(Layer):
         h_h = self.recurrent_conv(r * h_tm1_h,
                                 self.recurrent_kernel_h)
 
-        hh = self.recurrent_activation(x_h + h_h)
-
+        hh = self.activation(x_h + h_h)
+        
         # previous and candidate state mixed by update gate
-        h = z * h_tm1 + (1 - z) * hh
+        # h = (1 - z) * h_tm1 + z * hh
+
+        h = z * h_tm1 + (1.0 - z) * hh
 
         if 0 < self.dropout + self.recurrent_dropout:
             if training is None:
                 h._uses_learning_phase = True
 
-        return h, [h,hh]
+        return h, [h, hh]
 
     def input_conv(self, x, w, b=None, padding='valid'):
         conv_out = K.conv2d(x, w, strides=self.strides,
@@ -259,7 +271,6 @@ class ConvGRU2DCell(Layer):
                           padding='same',
                           data_format=self.data_format)
         return conv_out
-    
 
     def get_config(self):
         config = {'filters': self.filters,
@@ -288,58 +299,59 @@ class ConvGRU2DCell(Layer):
 
 
 class ConvGRU2D(ConvRNN2D):
-    def __init__(self,
-               filters,
-               kernel_size,
-               strides=(1, 1),
-               padding='valid',
-               data_format=None,
-               dilation_rate=(1, 1),
-               activation='tanh',
-               recurrent_activation='hard_sigmoid',
-               use_bias=True,
-               kernel_initializer='glorot_uniform',
-               recurrent_initializer='orthogonal',
-               bias_initializer='zeros',
-               kernel_regularizer=None,
-               recurrent_regularizer=None,
-               bias_regularizer=None,
-               activity_regularizer=None,
-               kernel_constraint=None,
-               recurrent_constraint=None,
-               bias_constraint=None,
-               return_sequences=False,
-               go_backwards=False,
-               stateful=False,
-               dropout=0.,
-               recurrent_dropout=0.,
-               **kwargs):
+    def __init__(self, 
+                 filters,
+                 kernel_size,
+                 strides=(1, 1),
+                 padding='valid',
+                 data_format=None,
+                 dilation_rate=(1, 1),
+                 activation='tanh',
+                 recurrent_activation='hard_sigmoid',
+                 use_bias=True,
+                 kernel_initializer='glorot_uniform',
+                 recurrent_initializer='orthogonal',
+                 bias_initializer='zeros',
+                 kernel_regularizer=None,
+                 recurrent_regularizer=None,
+                 bias_regularizer=None,
+                 activity_regularizer=None,
+                 kernel_constraint=None,
+                 recurrent_constraint=None,
+                 bias_constraint=None,
+                 return_sequences=False,
+                 go_backwards=False,
+                 stateful=False,
+                 dropout=0.,
+                 recurrent_dropout=0.,
+                 **kwargs):
         cell = ConvGRU2DCell(filters=filters,
                              kernel_size=kernel_size,
                              strides=strides,
-                            padding=padding,
-                            data_format=data_format,
-                            dilation_rate=dilation_rate,
-                            activation=activation,
-                            recurrent_activation=recurrent_activation,
-                            use_bias=use_bias,
-                            kernel_initializer=kernel_initializer,
-                            recurrent_initializer=recurrent_initializer,
-                            bias_initializer=bias_initializer,
-                            kernel_regularizer=kernel_regularizer,
-                            recurrent_regularizer=recurrent_regularizer,
-                            bias_regularizer=bias_regularizer,
-                            kernel_constraint=kernel_constraint,
-                            recurrent_constraint=recurrent_constraint,
-                            bias_constraint=bias_constraint,
-                            dropout=dropout,
-                            recurrent_dropout=recurrent_dropout)
-    
+                             padding=padding,
+                             data_format=data_format,
+                             dilation_rate=dilation_rate,
+                             activation=activation,
+                             recurrent_activation=recurrent_activation,
+                             use_bias=use_bias,
+                             kernel_initializer=kernel_initializer,
+                             recurrent_initializer=recurrent_initializer,
+                             bias_initializer=bias_initializer,
+                             kernel_regularizer=kernel_regularizer,
+                             recurrent_regularizer=recurrent_regularizer,
+                             bias_regularizer=bias_regularizer,
+                             kernel_constraint=kernel_constraint,
+                             recurrent_constraint=recurrent_constraint,
+                             bias_constraint=bias_constraint,
+                             dropout=dropout,
+                             recurrent_dropout=recurrent_dropout)
+                
         super(ConvGRU2D, self).__init__(cell,
                                         return_sequences=return_sequences,
                                         go_backwards=go_backwards,
                                         stateful=stateful,
                                         **kwargs)
+      
         self.activity_regularizer = regularizers.get(activity_regularizer)
         
     def call(self, inputs, mask=None, training=None, initial_state=None):
@@ -352,7 +364,7 @@ class ConvGRU2D(ConvRNN2D):
     @property
     def filters(self):
         return self.cell.filters
-    
+
     @property
     def kernel_size(self):
         return self.cell.kernel_size
@@ -398,10 +410,6 @@ class ConvGRU2D(ConvRNN2D):
         return self.cell.bias_initializer
 
     @property
-    def unit_forget_bias(self):
-        return self.cell.unit_forget_bias
-
-    @property
     def kernel_regularizer(self):
         return self.cell.kernel_regularizer
 
@@ -441,28 +449,20 @@ class ConvGRU2D(ConvRNN2D):
                   'data_format': self.data_format,
                   'dilation_rate': self.dilation_rate,
                   'activation': activations.serialize(self.activation),
-                  'recurrent_activation': activations.serialize(
-                  self.recurrent_activation),
-              'use_bias': self.use_bias,
-              'kernel_initializer': initializers.serialize(
-                  self.kernel_initializer),
-              'recurrent_initializer': initializers.serialize(
-                  self.recurrent_initializer),
-              'bias_initializer': initializers.serialize(self.bias_initializer),
-              'kernel_regularizer': regularizers.serialize(
-                  self.kernel_regularizer),
-              'recurrent_regularizer': regularizers.serialize(
-                  self.recurrent_regularizer),
-              'bias_regularizer': regularizers.serialize(self.bias_regularizer),
-              'activity_regularizer': regularizers.serialize(
-                  self.activity_regularizer),
-              'kernel_constraint': constraints.serialize(
-                  self.kernel_constraint),
-              'recurrent_constraint': constraints.serialize(
-                  self.recurrent_constraint),
-              'bias_constraint': constraints.serialize(self.bias_constraint),
-              'dropout': self.dropout,
-              'recurrent_dropout': self.recurrent_dropout}
+                  'recurrent_activation': activations.serialize(self.recurrent_activation),
+                  'use_bias': self.use_bias,
+                  'kernel_initializer': initializers.serialize(self.kernel_initializer),
+                  'recurrent_initializer': initializers.serialize(self.recurrent_initializer),
+                  'bias_initializer': initializers.serialize(self.bias_initializer),
+                  'kernel_regularizer': regularizers.serialize(self.kernel_regularizer),
+                  'recurrent_regularizer': regularizers.serialize(self.recurrent_regularizer),
+                  'bias_regularizer': regularizers.serialize(self.bias_regularizer),
+                  'activity_regularizer': regularizers.serialize(self.activity_regularizer),
+                  'kernel_constraint': constraints.serialize(self.kernel_constraint),
+                  'recurrent_constraint': constraints.serialize(self.recurrent_constraint),
+                  'bias_constraint': constraints.serialize(self.bias_constraint),
+                  'dropout': self.dropout,
+                  'recurrent_dropout': self.recurrent_dropout}
         base_config = super(ConvGRU2D, self).get_config()
         del base_config['cell']
         return dict(list(base_config.items()) + list(config.items()))
@@ -470,10 +470,3 @@ class ConvGRU2D(ConvRNN2D):
     @classmethod
     def from_config(cls, config):
         return cls(**config)
-
-
-
-
-
-
-

--- a/deepcell/layers/convolutional_recurrent.py
+++ b/deepcell/layers/convolutional_recurrent.py
@@ -150,10 +150,12 @@ class ConvGRU2DCell(Layer):
         self.recurrent_kernel_z = self.recurrent_kernel[:, :, :, :self.filters]
         # reset gate
         self.kernel_r = self.kernel[:, :, :, self.filters: self.filters * 2]
-        self.recurrent_kernel_r = self.recurrent_kernel[:, :, :, self.filters:self.filters * 2]
+        self.recurrent_kernel_r = \
+            self.recurrent_kernel[:, :, :, self.filters:self.filters * 2]
         # new gate
         self.kernel_h = self.kernel[:, :, :, self.filters * 2:self.filters * 3]
-        self.recurrent_kernel_h = self.recurrent_kernel[:, :, :, self.filters * 2: self.filters * 3]
+        self.recurrent_kernel_h = \
+            self.recurrent_kernel[:, :, :, self.filters * 2: self.filters * 3]
 
         if self.use_bias:
             # bias for inputs

--- a/deepcell/layers/convolutional_recurrent.py
+++ b/deepcell/layers/convolutional_recurrent.py
@@ -111,7 +111,7 @@ class ConvGRU2DCell(DropoutRNNCellMixin, AbstractRNNCell):
 
     @property
     def state_size(self):
-        return (self.filters, self.filters)
+        return (self.filters,)
 
     def build(self, input_shape):
         if self.data_format == 'channels_first':
@@ -230,8 +230,8 @@ class ConvGRU2DCell(DropoutRNNCellMixin, AbstractRNNCell):
         if self.dropout + self.recurrent_dropout > 0:
             if training is None:
                 h._uses_learning_phase = True
-        zeros = K.zeros_like(h_tm1)
-        return h, [h, zeros]
+
+        return h, [h]
 
     def input_conv(self, x, w, b=None, padding='valid'):
         conv_out = K.conv2d(x, w, strides=self.strides,

--- a/deepcell/layers/convolutional_recurrent.py
+++ b/deepcell/layers/convolutional_recurrent.py
@@ -42,10 +42,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import numpy as np
-import warnings
-import os
-
 import tensorflow as tf
 
 from tensorflow.python.keras import activations
@@ -53,20 +49,10 @@ from tensorflow.python.keras import backend as K
 from tensorflow.python.keras import constraints
 from tensorflow.python.keras import initializers
 from tensorflow.python.keras import regularizers
-from tensorflow.python.keras.engine.base_layer import Layer
+from tensorflow.python.keras.layers import Layer
 from tensorflow.python.keras.layers.recurrent import _generate_dropout_mask
-from tensorflow.python.keras.layers.recurrent import RNN
-
-from tensorflow.python.keras.utils import conv_utils
-from tensorflow.python.keras.utils import generic_utils
-from tensorflow.python.keras.utils import tf_utils
-
-from tensorflow.python.keras.engine.base_layer import Layer
-
-from tensorflow.python.keras.models import Sequential
-from tensorflow.python.keras.layers.convolutional import Conv3D
-from tensorflow.python.keras.layers.normalization import BatchNormalization
 from tensorflow.python.keras.layers.convolutional_recurrent import ConvRNN2D
+from tensorflow.python.keras.utils import conv_utils
 
 
 class ConvGRU2DCell(Layer):

--- a/deepcell/layers/convolutional_recurrent_test.py
+++ b/deepcell/layers/convolutional_recurrent_test.py
@@ -59,7 +59,7 @@ class ConvGRU2DTest(keras_parameterized.TestCase):
 
         outputs = layer(x)
         _, states = outputs[0], outputs[1:]
-        self.assertEqual(len(states), 1)  # TODO: changed from 2 to 1 due to cell.state_size
+        self.assertEqual(len(states), len(layer.cell.state_size))
         model = keras.models.Model(x, states[0])
         state = model.predict(inputs)
 

--- a/deepcell/layers/convolutional_recurrent_test.py
+++ b/deepcell/layers/convolutional_recurrent_test.py
@@ -19,7 +19,7 @@ from deepcell import layers
 
 class ConvGRU2DTest(keras_parameterized.TestCase):
 
-    # @keras_parameterized.run_all_keras_modes
+    @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters(
         *tf_test_util.generate_combinations_with_testcase_name(
             data_format=['channels_first', 'channels_last'],

--- a/deepcell/layers/convolutional_recurrent_test.py
+++ b/deepcell/layers/convolutional_recurrent_test.py
@@ -8,6 +8,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
+from tensorflow.python.keras import keras_parameterized
+
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.models import Sequential, Model
 from tensorflow.python.keras.layers import Input
@@ -19,9 +21,9 @@ from deepcell.utils import testing_utils
 from deepcell import layers
 
 
-class ConvoluationalRecurrentTest(test.TestCase):
+class ConvolutionalRecurrentTest(keras_parameterized.TestCase):
     
-    @tf_test_util.run_in_graph_and_eager_modes()
+    @keras_parameterized.run_all_keras_modes
     def test_convolutional_gru_2d(self):
         num_row = 3
         num_col = 3
@@ -33,6 +35,7 @@ class ConvoluationalRecurrentTest(test.TestCase):
         sequence_len = 2
     
         custom_objects = {'ConvGRU2D': layers.ConvGRU2D}
+        # custom_objects = {'ConvLSTM2D': convolutional_recurrent.ConvLSTM2D}
         
         for data_format in ['channels_first', 'channels_last']:
             if data_format == 'channels_first':
@@ -52,6 +55,7 @@ class ConvoluationalRecurrentTest(test.TestCase):
                           'filters': filters,
                           'kernel_size': (num_row, num_col),
                           'padding': 'valid'}
+                #layer = convolutional_recurrent.ConvLSTM2D(**kwargs) 
                 layer = layers.ConvGRU2D(**kwargs)
                 layer.build(inputs.shape)
                 
@@ -64,6 +68,7 @@ class ConvoluationalRecurrentTest(test.TestCase):
                 np.testing.assert_allclose(K.eval(layer.states[0]), state, atol=1e-4)
 
                 # test for output shape:
+                # output = testing_utils.layer_test(convolutional_recurrent.ConvLSTM2D,
                 output = testing_utils.layer_test(layers.ConvGRU2D,
                         kwargs={'data_format': data_format,
                                 'return_sequences': return_sequences,

--- a/deepcell/layers/convolutional_recurrent_test.py
+++ b/deepcell/layers/convolutional_recurrent_test.py
@@ -35,7 +35,6 @@ class ConvGRU2DTest(keras_parameterized.TestCase):
         sequence_len = 2
 
         custom_objects = {'ConvGRU2D': layers.ConvGRU2D}
-        # custom_objects = {'ConvLSTM2D': convolutional_recurrent.ConvLSTM2D}
 
         if data_format == 'channels_first':
             inputs = np.random.rand(num_samples, sequence_len,
@@ -55,7 +54,6 @@ class ConvGRU2DTest(keras_parameterized.TestCase):
                   'filters': filters,
                   'kernel_size': (num_row, num_col),
                   'padding': 'valid'}
-        # layer = convolutional_recurrent.ConvLSTM2D(**kwargs)
         layer = layers.ConvGRU2D(**kwargs)
         layer.build(inputs.shape)
 
@@ -71,7 +69,6 @@ class ConvGRU2DTest(keras_parameterized.TestCase):
         # test for output shape:
         testing_utils.layer_test(
             layers.ConvGRU2D,
-            # convolutional_recurrent.ConvLSTM2D,
             kwargs={'data_format': data_format,
                     'return_sequences': return_sequences,
                     'filters': filters,

--- a/deepcell/layers/convolutional_recurrent_test.py
+++ b/deepcell/layers/convolutional_recurrent_test.py
@@ -1,7 +1,16 @@
 """Tests for the convolutional recurrent layers"""
+
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
+
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+
+from tensorflow.python.keras import backend as K
+from tensorflow.python.keras.models import Sequential, Model
+from tensorflow.python.keras.layers import Input
 
 from tensorflow.python.framework import test_util as tf_test_util
 from tensorflow.python.platform import test
@@ -9,36 +18,59 @@ from tensorflow.python.platform import test
 from deepcell.utils import testing_utils
 from deepcell import layers
 
+
 class ConvoluationalRecurrentTest(test.TestCase):
+    
     @tf_test_util.run_in_graph_and_eager_modes()
     def test_convolutional_gru_2d(self):
-        kernel_size = (3, 3)
-        filters = 3
+        num_row = 3
+        num_col = 3
+        filters = 2
+        num_samples = 1
+        input_channel = 2
+        input_num_row = 5
+        input_num_col = 5
+        sequence_len = 2
+    
         custom_objects = {'ConvGRU2D': layers.ConvGRU2D}
-        for strides in [(1, 1), (2, 2), None]:
-            for dilation_rate in [1, 2, (1, 2)]:
-                for padding in ['valid', 'same']:
-                    with self.test_session():
-                        testing_utils.layer_test(
-                            layers.ConvGRU2D,
-                            kwargs={'filters': filters,
-                                    'strides': strides,
-                                    'kernel_size': kernel_size,
-                                    'padding': padding,
-                                    'dilation_rate': dilation_rate,
-                                    'data_format': 'channels_last'},
-                            custom_objects=custom_objects,
-                            input_shape=(3, 11, 12, 10, 4))
-                        testing_utils.layer_test(
-                            layers.ConvGRU2D,
-                            kwargs={'filters': filters,
-                                    'strides': strides,
-                                    'kernel_size': kernel_size,
-                                    'padding': padding,
-                                    'dilation_rate': dilation_rate,
-                                    'data_format': 'channels_first'},
-                            custom_objects=custom_objects,
-                            input_shape=(3, 4, 11, 12, 10))
+        
+        for data_format in ['channels_first', 'channels_last']:
+            if data_format == 'channels_first':
+                inputs = np.random.rand(num_samples, sequence_len,
+                                        input_channel,
+                                        input_num_row, input_num_col)
+            else:
+                inputs = np.random.rand(num_samples, sequence_len,
+                                        input_num_row, input_num_col,
+                                        input_channel)
+            for return_sequences in [True, False]:
+                x = Input(batch_shape=inputs.shape)
+                kwargs = {'data_format': data_format,
+                          'return_sequences': return_sequences,
+                          'return_state': True,
+                          'stateful': True,
+                          'filters': filters,
+                          'kernel_size': (num_row, num_col),
+                          'padding': 'valid'}
+                layer = layers.ConvGRU2D(**kwargs)
+                layer.build(inputs.shape)
+                
+                outputs = layer(x)
+                output, states = outputs[0], outputs[1:]
+                
+                assert len(states) == 2
+                model = Model(x, states[0])
+                state = model.predict(inputs)
+                np.testing.assert_allclose(K.eval(layer.states[0]), state, atol=1e-4)
+
+                # test for output shape:
+                output = testing_utils.layer_test(layers.ConvGRU2D,
+                        kwargs={'data_format': data_format,
+                                'return_sequences': return_sequences,
+                                'filters': filters,
+                                'kernel_size': (num_row, num_col),
+                                'padding': 'valid'},
+                        custom_objects=custom_objects,
+                        input_shape=inputs.shape)
+  
                         
-
-

--- a/deepcell/layers/convolutional_recurrent_test.py
+++ b/deepcell/layers/convolutional_recurrent_test.py
@@ -4,27 +4,27 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
-import pytest
+from absl.testing import parameterized
 import numpy as np
-from numpy.testing import assert_allclose
 
 from tensorflow.python.keras import keras_parameterized
 
-from tensorflow.python.keras import backend as K
-from tensorflow.python.keras.models import Sequential, Model
-from tensorflow.python.keras.layers import Input
+from tensorflow.python import keras
 
 from tensorflow.python.framework import test_util as tf_test_util
-from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils
 from deepcell import layers
 
 
-class ConvolutionalRecurrentTest(keras_parameterized.TestCase):
-    
+class ConvGRU2DTest(keras_parameterized.TestCase):
+
     @keras_parameterized.run_all_keras_modes
-    def test_convolutional_gru_2d(self):
+    @parameterized.named_parameters(
+        *tf_test_util.generate_combinations_with_testcase_name(
+            data_format=['channels_first', 'channels_last'],
+            return_sequences=[True, False]))
+    def test_conv_gru_2d(self, data_format, return_sequences):
         num_row = 3
         num_col = 3
         filters = 2
@@ -33,49 +33,169 @@ class ConvolutionalRecurrentTest(keras_parameterized.TestCase):
         input_num_row = 5
         input_num_col = 5
         sequence_len = 2
-    
+
         custom_objects = {'ConvGRU2D': layers.ConvGRU2D}
         # custom_objects = {'ConvLSTM2D': convolutional_recurrent.ConvLSTM2D}
-        
-        for data_format in ['channels_first', 'channels_last']:
-            if data_format == 'channels_first':
-                inputs = np.random.rand(num_samples, sequence_len,
-                                        input_channel,
-                                        input_num_row, input_num_col)
-            else:
-                inputs = np.random.rand(num_samples, sequence_len,
-                                        input_num_row, input_num_col,
-                                        input_channel)
-            for return_sequences in [True, False]:
-                x = Input(batch_shape=inputs.shape)
-                kwargs = {'data_format': data_format,
-                          'return_sequences': return_sequences,
-                          'return_state': True,
-                          'stateful': True,
-                          'filters': filters,
-                          'kernel_size': (num_row, num_col),
-                          'padding': 'valid'}
-                #layer = convolutional_recurrent.ConvLSTM2D(**kwargs) 
-                layer = layers.ConvGRU2D(**kwargs)
-                layer.build(inputs.shape)
-                
-                outputs = layer(x)
-                output, states = outputs[0], outputs[1:]
-                
-                assert len(states) == 2
-                model = Model(x, states[0])
-                state = model.predict(inputs)
-                np.testing.assert_allclose(K.eval(layer.states[0]), state, atol=1e-4)
 
-                # test for output shape:
-                # output = testing_utils.layer_test(convolutional_recurrent.ConvLSTM2D,
-                output = testing_utils.layer_test(layers.ConvGRU2D,
-                        kwargs={'data_format': data_format,
-                                'return_sequences': return_sequences,
-                                'filters': filters,
-                                'kernel_size': (num_row, num_col),
-                                'padding': 'valid'},
-                        custom_objects=custom_objects,
-                        input_shape=inputs.shape)
-  
-                        
+        if data_format == 'channels_first':
+            inputs = np.random.rand(num_samples, sequence_len,
+                                    input_channel,
+                                    input_num_row, input_num_col)
+        else:
+            inputs = np.random.rand(num_samples, sequence_len,
+                                    input_num_row, input_num_col,
+                                    input_channel)
+
+        # test for return state:
+        x = keras.layers.Input(batch_shape=inputs.shape)
+        kwargs = {'data_format': data_format,
+                  'return_sequences': return_sequences,
+                  'return_state': True,
+                  'stateful': True,
+                  'filters': filters,
+                  'kernel_size': (num_row, num_col),
+                  'padding': 'valid'}
+        #layer = convolutional_recurrent.ConvLSTM2D(**kwargs)
+        layer = layers.ConvGRU2D(**kwargs)
+        layer.build(inputs.shape)
+
+        outputs = layer(x)
+        _, states = outputs[0], outputs[1:]
+        self.assertEqual(len(states), 2)
+        model = keras.models.Model(x, states[0])
+        state = model.predict(inputs)
+
+        self.assertAllClose(
+            keras.backend.eval(layer.states[0]), state, atol=1e-4)
+
+        # test for output shape:
+        testing_utils.layer_test(
+            layers.ConvGRU2D,
+            # convolutional_recurrent.ConvLSTM2D,
+            kwargs={'data_format': data_format,
+                    'return_sequences': return_sequences,
+                    'filters': filters,
+                    'kernel_size': (num_row, num_col),
+                    'padding': 'valid'},
+            custom_objects=custom_objects,
+            input_shape=inputs.shape)
+
+    def test_conv_gru_2d_statefulness(self):
+        # Tests for statefulness
+        num_row = 3
+        num_col = 3
+        filters = 2
+        num_samples = 1
+        input_channel = 2
+        input_num_row = 5
+        input_num_col = 5
+        sequence_len = 2
+        inputs = np.random.rand(num_samples, sequence_len,
+                                input_num_row, input_num_col,
+                                input_channel)
+
+        with self.cached_session():
+            model = keras.models.Sequential()
+            kwargs = {'data_format': 'channels_last',
+                      'return_sequences': False,
+                      'filters': filters,
+                      'kernel_size': (num_row, num_col),
+                      'stateful': True,
+                      'batch_input_shape': inputs.shape,
+                      'padding': 'same'}
+            layer = layers.ConvGRU2D(**kwargs)
+
+            model.add(layer)
+            model.compile(optimizer='sgd', loss='mse')
+            out1 = model.predict(np.ones_like(inputs))
+
+            # train once so that the states change
+            model.train_on_batch(np.ones_like(inputs),
+                                 np.random.random(out1.shape))
+            out2 = model.predict(np.ones_like(inputs))
+
+            # if the state is not reset, output should be different
+            self.assertNotEqual(out1.max(), out2.max())
+
+            # check that output changes after states are reset
+            # (even though the model itself didn't change)
+            layer.reset_states()
+            out3 = model.predict(np.ones_like(inputs))
+            self.assertNotEqual(out3.max(), out2.max())
+
+            # check that container-level reset_states() works
+            model.reset_states()
+            out4 = model.predict(np.ones_like(inputs))
+            self.assertAllClose(out3, out4, atol=1e-5)
+
+            # check that the call to `predict` updated the states
+            out5 = model.predict(np.ones_like(inputs))
+            self.assertNotEqual(out4.max(), out5.max())
+
+    def test_conv_gru_2d_regularizers(self):
+        # check regularizers
+        num_row = 3
+        num_col = 3
+        filters = 2
+        num_samples = 1
+        input_channel = 2
+        input_num_row = 5
+        input_num_col = 5
+        sequence_len = 2
+        inputs = np.random.rand(num_samples, sequence_len,
+                                input_num_row, input_num_col,
+                                input_channel)
+
+        with self.cached_session():
+            kwargs = {'data_format': 'channels_last',
+                      'return_sequences': False,
+                      'kernel_size': (num_row, num_col),
+                      'stateful': True,
+                      'filters': filters,
+                      'batch_input_shape': inputs.shape,
+                      'kernel_regularizer': keras.regularizers.L1L2(l1=0.01),
+                      'recurrent_regularizer': keras.regularizers.L1L2(l1=0.01),
+                      'activity_regularizer': 'l2',
+                      'bias_regularizer': 'l2',
+                      'kernel_constraint': 'max_norm',
+                      'recurrent_constraint': 'max_norm',
+                      'bias_constraint': 'max_norm',
+                      'padding': 'same'}
+
+            layer = layers.ConvGRU2D(**kwargs)
+            layer.build(inputs.shape)
+            self.assertEqual(len(layer.losses), 3)
+            layer(keras.backend.variable(np.ones(inputs.shape)))
+            self.assertEqual(len(layer.losses), 4)
+
+    def test_conv_gru_2d_dropout(self):
+        # check dropout
+        with self.cached_session():
+            testing_utils.layer_test(
+                layers.ConvGRU2D,
+                kwargs={'data_format': 'channels_last',
+                        'return_sequences': False,
+                        'filters': 2,
+                        'kernel_size': (3, 3),
+                        'padding': 'same',
+                        'dropout': 0.1,
+                        'recurrent_dropout': 0.1},
+                custom_objects={'ConvGRU2D': layers.ConvGRU2D},
+                input_shape=(1, 2, 5, 5, 2))
+
+    def test_conv_gru_2d_cloning(self):
+        with self.cached_session():
+            model = keras.models.Sequential()
+            model.add(layers.ConvGRU2D(5, 3, input_shape=(None, 5, 5, 3)))
+
+            test_inputs = np.random.random((2, 4, 5, 5, 3))
+            reference_outputs = model.predict(test_inputs)
+            weights = model.get_weights()
+
+        # Use a new graph to clone the model
+        with self.cached_session():
+            clone = keras.models.clone_model(model)
+            clone.set_weights(weights)
+
+            outputs = clone.predict(test_inputs)
+            self.assertAllClose(reference_outputs, outputs, atol=1e-5)

--- a/deepcell/layers/convolutional_recurrent_test.py
+++ b/deepcell/layers/convolutional_recurrent_test.py
@@ -59,7 +59,7 @@ class ConvGRU2DTest(keras_parameterized.TestCase):
 
         outputs = layer(x)
         _, states = outputs[0], outputs[1:]
-        self.assertEqual(len(states), 2)
+        self.assertEqual(len(states), 1)  # TODO: changed from 2 to 1 due to cell.state_size
         model = keras.models.Model(x, states[0])
         state = model.predict(inputs)
 

--- a/deepcell/layers/convolutional_recurrent_test.py
+++ b/deepcell/layers/convolutional_recurrent_test.py
@@ -55,7 +55,7 @@ class ConvGRU2DTest(keras_parameterized.TestCase):
                   'filters': filters,
                   'kernel_size': (num_row, num_col),
                   'padding': 'valid'}
-        #layer = convolutional_recurrent.ConvLSTM2D(**kwargs)
+        # layer = convolutional_recurrent.ConvLSTM2D(**kwargs)
         layer = layers.ConvGRU2D(**kwargs)
         layer.build(inputs.shape)
 

--- a/deepcell/layers/convolutional_recurrent_test.py
+++ b/deepcell/layers/convolutional_recurrent_test.py
@@ -19,7 +19,7 @@ from deepcell import layers
 
 class ConvGRU2DTest(keras_parameterized.TestCase):
 
-    @keras_parameterized.run_all_keras_modes
+    # @keras_parameterized.run_all_keras_modes
     @parameterized.named_parameters(
         *tf_test_util.generate_combinations_with_testcase_name(
             data_format=['channels_first', 'channels_last'],

--- a/deepcell/layers/convolutional_recurrent_test.py
+++ b/deepcell/layers/convolutional_recurrent_test.py
@@ -1,0 +1,44 @@
+"""Tests for the convolutional recurrent layers"""
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+
+from tensorflow.python.framework import test_util as tf_test_util
+from tensorflow.python.platform import test
+
+from deepcell.utils import testing_utils
+from deepcell import layers
+
+class ConvoluationalRecurrentTest(test.TestCase):
+    @tf_test_util.run_in_graph_and_eager_modes()
+    def test_convolutional_gru_2d(self):
+        kernel_size = (3, 3)
+        filters = 3
+        custom_objects = {'ConvGRU2D': layers.ConvGRU2D}
+        for strides in [(1, 1), (2, 2), None]:
+            for dilation_rate in [1, 2, (1, 2)]:
+                for padding in ['valid', 'same']:
+                    with self.test_session():
+                        testing_utils.layer_test(
+                            layers.ConvGRU2D,
+                            kwargs={'filters': filters,
+                                    'strides': strides,
+                                    'kernel_size': kernel_size,
+                                    'padding': padding,
+                                    'dilation_rate': dilation_rate,
+                                    'data_format': 'channels_last'},
+                            custom_objects=custom_objects,
+                            input_shape=(3, 11, 12, 10, 4))
+                        testing_utils.layer_test(
+                            layers.ConvGRU2D,
+                            kwargs={'filters': filters,
+                                    'strides': strides,
+                                    'kernel_size': kernel_size,
+                                    'padding': padding,
+                                    'dilation_rate': dilation_rate,
+                                    'data_format': 'channels_first'},
+                            custom_objects=custom_objects,
+                            input_shape=(3, 4, 11, 12, 10))
+                        
+
+


### PR DESCRIPTION
Parameterized the `test_conv_gru_2d` test.

Added several new tests from the TensorFlow tests including:
* test_conv_gru_2d_statefulness
* test_conv_gru_2d_regularizers
* test_conv_gru_2d_dropout
* test_conv_gru_2d_cloning

Fixed a potential bug with dropout where we were passing `h_tm1` instead of `states[1]`.

Also some general linting fixes.