### PR TITLE
Update test_utils.py from TensorFlow 1.14.0

### DIFF
--- a/deepcell/layers/filter_detections_test.py
+++ b/deepcell/layers/filter_detections_test.py
@@ -31,6 +31,7 @@ from __future__ import division
 import numpy as np
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.platform import test
 
 from deepcell import layers
 
@@ -231,3 +232,7 @@ class TestFilterDetections(keras_parameterized.TestCase):
             self.assertAllEqual(actual_boxes, expected_boxes)
             self.assertAllEqual(actual_scores, expected_scores)
             self.assertAllEqual(actual_labels, expected_labels)
+
+
+if __name__ == '__main__':
+    test.main()

--- a/deepcell/layers/location_test.py
+++ b/deepcell/layers/location_test.py
@@ -29,6 +29,7 @@ from __future__ import print_function
 from __future__ import division
 
 from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils
 from deepcell import layers
@@ -64,3 +65,7 @@ class LocationTest(keras_parameterized.TestCase):
                     'data_format': 'channels_first'},
             custom_objects={'Location3D': layers.Location3D},
             input_shape=(3, 4, 11, 12, 10))
+
+
+if __name__ == '__main__':
+    test.main()

--- a/deepcell/layers/normalization_test.py
+++ b/deepcell/layers/normalization_test.py
@@ -31,6 +31,7 @@ from __future__ import division
 import numpy as np
 from tensorflow.python import keras
 from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils
 from deepcell import layers
@@ -120,3 +121,7 @@ class ImageNormalizationTest(keras_parameterized.TestCase):
             with self.assertRaises(ValueError):
                 layer = layers.ImageNormalization3D()
                 layer.build([3, 10, 11, 12, None])
+
+
+if __name__ == '__main__':
+    test.main()

--- a/deepcell/layers/normalization_test.py
+++ b/deepcell/layers/normalization_test.py
@@ -36,6 +36,7 @@ from deepcell.utils import testing_utils
 from deepcell import layers
 
 
+@keras_parameterized.run_all_keras_modes
 class ImageNormalizationTest(keras_parameterized.TestCase):
 
     def test_normalize_2d(self):

--- a/deepcell/layers/padding_test.py
+++ b/deepcell/layers/padding_test.py
@@ -34,6 +34,7 @@ import numpy as np
 # from tensorflow.python import keras
 # from tensorflow.python.eager import context
 from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils
 from deepcell import layers
@@ -170,6 +171,7 @@ class ReflectionPaddingTest(keras_parameterized.TestCase):
             layers.ReflectionPadding3D(padding=(1, 1))
         with self.assertRaises(ValueError):
             layers.ReflectionPadding3D(padding=None)
+
 
 if __name__ == '__main__':
     test.main()

--- a/deepcell/layers/pooling_test.py
+++ b/deepcell/layers/pooling_test.py
@@ -34,9 +34,9 @@ from deepcell.utils import testing_utils
 from deepcell import layers
 
 
-@keras_parameterized.run_all_keras_modes
 class DilatedMaxPoolingTest(keras_parameterized.TestCase):
 
+    @keras_parameterized.run_all_keras_modes(always_skip_v1=True)
     def test_dilated_max_pool_2d(self):
         pool_size = (3, 3)
         custom_objects = {'DilatedMaxPool2D': layers.DilatedMaxPool2D}
@@ -62,6 +62,7 @@ class DilatedMaxPoolingTest(keras_parameterized.TestCase):
                         custom_objects=custom_objects,
                         input_shape=(3, 4, 5, 6))
 
+    @keras_parameterized.run_all_keras_modes(always_skip_v1=True)
     def test_dilated_max_pool_3d(self):
         custom_objects = {'DilatedMaxPool3D': layers.DilatedMaxPool3D}
         pool_size = (3, 3, 3)

--- a/deepcell/layers/pooling_test.py
+++ b/deepcell/layers/pooling_test.py
@@ -29,6 +29,7 @@ from __future__ import print_function
 from __future__ import division
 
 from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils
 from deepcell import layers
@@ -87,3 +88,7 @@ class DilatedMaxPoolingTest(keras_parameterized.TestCase):
                                     'pool_size': pool_size},
                             custom_objects=custom_objects,
                             input_shape=(3, 4, 11, 12, 10))
+
+
+if __name__ == '__main__':
+    test.main()

--- a/deepcell/layers/resize_test.py
+++ b/deepcell/layers/resize_test.py
@@ -29,6 +29,7 @@ from __future__ import print_function
 from __future__ import division
 
 from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils
 from deepcell import layers
@@ -49,3 +50,7 @@ class ResizeTest(keras_parameterized.TestCase):
                     'data_format': 'channels_first'},
             custom_objects={'Resize2D': layers.Resize2D},
             input_shape=(3, 5, 6, 4))
+
+
+if __name__ == '__main__':
+    test.main()

--- a/deepcell/layers/retinanet_test.py
+++ b/deepcell/layers/retinanet_test.py
@@ -31,6 +31,7 @@ from __future__ import division
 import numpy as np
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils
 from deepcell import layers
@@ -332,3 +333,7 @@ class ClipBoxesTest(keras_parameterized.TestCase):
 
         self.assertEqual(actual.shape, tuple(computed_shape))
         self.assertAllClose(actual, expected)
+
+
+if __name__ == '__main__':
+    test.main()

--- a/deepcell/layers/tensor_product_test.py
+++ b/deepcell/layers/tensor_product_test.py
@@ -32,6 +32,7 @@ import numpy as np
 
 from tensorflow.python import keras
 from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils
 from deepcell import layers
@@ -110,3 +111,7 @@ class TensorProdTest(keras_parameterized.TestCase):
         layer(keras.backend.variable(np.ones((2, 4))))
         self.assertEqual(layer.kernel.constraint, k_constraint)
         self.assertEqual(layer.bias.constraint, b_constraint)
+
+
+if __name__ == '__main__':
+    test.main()

--- a/deepcell/layers/upsample_test.py
+++ b/deepcell/layers/upsample_test.py
@@ -31,6 +31,7 @@ from __future__ import division
 import numpy as np
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils
 from deepcell import layers
@@ -156,3 +157,7 @@ class TestUpsample(keras_parameterized.TestCase):
                     'data_format': 'channels_first'},
             custom_objects={'Upsample': layers.Upsample},
             input_shape=(3, 4, 5, 6))
+
+
+if __name__ == '__main__':
+    test.main()

--- a/deepcell/layers/upsample_test.py
+++ b/deepcell/layers/upsample_test.py
@@ -143,6 +143,7 @@ class TestUpsampleLike(keras_parameterized.TestCase):
         self.assertAllEqual(actual, expected)
 
 
+@keras_parameterized.run_all_keras_modes
 class TestUpsample(keras_parameterized.TestCase):
 
     def test_simple(self):

--- a/deepcell/utils/testing_utils.py
+++ b/deepcell/utils/testing_utils.py
@@ -29,9 +29,12 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
+import threading
+
 import numpy as np
 
 from tensorflow.python import keras
+from tensorflow.python.eager import context
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.training.rmsprop import RMSPropOptimizer
 from tensorflow.python.util import tf_inspect
@@ -136,7 +139,18 @@ def layer_test(layer_cls, kwargs=None, input_shape=None, input_dtype=None,
         np.testing.assert_allclose(output, actual_output, rtol=1e-3)
 
     # test training mode (e.g. useful for dropout tests)
-    model.compile(RMSPropOptimizer(0.01), 'mse')
+    # Rebuild the model to avoid the graph being reused between predict() and
+    # train(). This was causing some error for layer with Defun as it body.
+    # See b/120160788 for more details. This should be mitigated after 2.0.
+    model = keras.models.Model(x, layer(x))
+    if _thread_local_data.run_eagerly is not None:
+        model.compile(
+            'rmsprop',
+            'mse',
+            weighted_metrics=['acc'],
+            run_eagerly=should_run_eagerly())
+    else:
+        model.compile('rmsprop', 'mse', weighted_metrics=['acc'])
     model.train_on_batch(input_data, actual_output)
 
     # test as first layer in Sequential API
@@ -176,3 +190,18 @@ def layer_test(layer_cls, kwargs=None, input_shape=None, input_dtype=None,
 
     # for further checks in the caller function
     return actual_output
+
+
+_thread_local_data = threading.local()
+_thread_local_data.model_type = None
+_thread_local_data.run_eagerly = None
+
+
+def should_run_eagerly():
+    """Returns whether the models we are testing should be run eagerly."""
+    if _thread_local_data.run_eagerly is None:
+        raise ValueError('Cannot call `should_run_eagerly()` outside of a '
+                        '`run_eagerly_scope()` or `run_all_keras_modes` '
+                        'decorator.')
+
+    return _thread_local_data.run_eagerly and context.executing_eagerly()

--- a/deepcell/utils/testing_utils.py
+++ b/deepcell/utils/testing_utils.py
@@ -201,7 +201,7 @@ def should_run_eagerly():
     """Returns whether the models we are testing should be run eagerly."""
     if _thread_local_data.run_eagerly is None:
         raise ValueError('Cannot call `should_run_eagerly()` outside of a '
-                        '`run_eagerly_scope()` or `run_all_keras_modes` '
-                        'decorator.')
+                         '`run_eagerly_scope()` or `run_all_keras_modes` '
+                         'decorator.')
 
     return _thread_local_data.run_eagerly and context.executing_eagerly()


### PR DESCRIPTION
The TensorFlow 1.14.0 release has updated the `layer_test` function.  It is still incompatible with `custom_objects`, so the testing_utils file has been updated appropriately.