### PR TITLE
Speeding up the pixel transform

### DIFF
--- a/deepcell/image_generators/__init__.py
+++ b/deepcell/image_generators/__init__.py
@@ -96,7 +96,7 @@ def _transform_masks(y, transform, data_format=None, **kwargs):
         edge_class_shape = 4 if separate_edge_classes else 3
 
         if data_format == 'channels_first':
-            y_transform = np.zeros(tuple([y.shape[0]] + list(y.shape[2:]) + [edge_class_shape]))
+            y_transform = np.zeros(tuple([y.shape[0]] + [edge_class_shape] + list(y.shape[2:])))
         else:
             y_transform = np.zeros(tuple(list(y.shape[0:-1]) + [edge_class_shape]))
 
@@ -108,9 +108,6 @@ def _transform_masks(y, transform, data_format=None, **kwargs):
 
             y_transform[batch] = transform_utils.pixelwise_transform(mask, dilation_radius, data_format=data_format,
                                                                      separate_edge_classes=separate_edge_classes)
-
-            if data_format == 'channels_first':
-                y_transform = np.rollaxis(y_transform, y.ndim - 1, 1)
 
     elif transform == 'watershed':
         distance_bins = kwargs.pop('distance_bins', 4)

--- a/deepcell/image_generators/__init__.py
+++ b/deepcell/image_generators/__init__.py
@@ -106,8 +106,9 @@ def _transform_masks(y, transform, data_format=None, **kwargs):
             else:
                 mask = y[batch, ..., 0]
 
-            y_transform[batch] = transform_utils.pixelwise_transform(mask, dilation_radius, data_format=data_format,
-                                                                     separate_edge_classes=separate_edge_classes)
+            y_transform[batch] = transform_utils.pixelwise_transform(
+                mask, dilation_radius, data_format=data_format,
+                separate_edge_classes=separate_edge_classes)
 
     elif transform == 'watershed':
         distance_bins = kwargs.pop('distance_bins', 4)

--- a/deepcell/image_generators/__init__.py
+++ b/deepcell/image_generators/__init__.py
@@ -92,10 +92,25 @@ def _transform_masks(y, transform, data_format=None, **kwargs):
     if transform == 'pixelwise':
         dilation_radius = kwargs.pop('dilation_radius', None)
         separate_edge_classes = kwargs.pop('separate_edge_classes', False)
-        y_transform = transform_utils.pixelwise_transform(
-            y, dilation_radius,
-            data_format=data_format,
-            separate_edge_classes=separate_edge_classes)
+
+        edge_class_shape = 4 if separate_edge_classes else 3
+
+        if data_format == 'channels_first':
+            y_transform = np.zeros(tuple([y.shape[0]] + list(y.shape[2:]) + [edge_class_shape]))
+        else:
+            y_transform = np.zeros(tuple(list(y.shape[0:-1]) + [edge_class_shape]))
+
+        for batch in range(y_transform.shape[0]):
+            if data_format == 'channels_first':
+                mask = y[batch, 0, ...]
+            else:
+                mask = y[batch, ..., 0]
+
+            y_transform[batch] = transform_utils.pixelwise_transform(mask, dilation_radius, data_format=data_format,
+                                                                     separate_edge_classes=separate_edge_classes)
+
+            if data_format == 'channels_first':
+                y_transform = np.rollaxis(y_transform, y.ndim - 1, 1)
 
     elif transform == 'watershed':
         distance_bins = kwargs.pop('distance_bins', 4)

--- a/deepcell/utils/transform_utils.py
+++ b/deepcell/utils/transform_utils.py
@@ -55,6 +55,15 @@ def pixelwise_transform(mask, dilation_radius=None, data_format=None,
             if not separate_edge_classes: [cell_edge, cell_interior, background]
             otherwise: [bg_cell_edge, cell_cell_edge, cell_interior, background]
     """
+    if data_format is None:
+        data_format = K.image_data_format()
+
+    if data_format == 'channels_first':
+        channel_axis = 1
+    else:
+        channel_axis = len(mask.shape) - 1
+
+    mask = np.squeeze(mask, axis=channel_axis)
 
     # Detect the edges and interiors
     new_mask = np.zeros(mask.shape)
@@ -87,7 +96,7 @@ def pixelwise_transform(mask, dilation_radius=None, data_format=None,
             background
         ]
 
-        return np.stack(all_stacks, axis=-1)
+        return np.stack(all_stacks, axis=channel_axis)
 
     # dilate the background masks and subtract from all edges for background-edges
     background = (mask == 0).astype('int')
@@ -118,7 +127,7 @@ def pixelwise_transform(mask, dilation_radius=None, data_format=None,
         background
     ]
 
-    return np.stack(all_stacks, axis=-1)
+    return np.stack(all_stacks, axis=channel_axis)
 
 
 def erode_edges(mask, erosion_width):

--- a/deepcell/utils/transform_utils.py
+++ b/deepcell/utils/transform_utils.py
@@ -59,11 +59,9 @@ def pixelwise_transform(mask, dilation_radius=None, data_format=None,
         data_format = K.image_data_format()
 
     if data_format == 'channels_first':
-        channel_axis = 1
+        channel_axis = 0
     else:
-        channel_axis = len(mask.shape) - 1
-
-    mask = np.squeeze(mask, axis=channel_axis)
+        channel_axis = -1
 
     # Detect the edges and interiors
     new_mask = np.zeros(mask.shape)

--- a/deepcell/utils/transform_utils.py
+++ b/deepcell/utils/transform_utils.py
@@ -55,86 +55,70 @@ def pixelwise_transform(mask, dilation_radius=None, data_format=None,
             if not separate_edge_classes: [cell_edge, cell_interior, background]
             otherwise: [bg_cell_edge, cell_cell_edge, cell_interior, background]
     """
-    if data_format is None:
-        data_format = K.image_data_format()
-
-    if data_format == 'channels_first':
-        channel_axis = 1
-    else:
-        channel_axis = len(mask.shape) - 1
-
-    mask = np.squeeze(mask, axis=channel_axis)
 
     # Detect the edges and interiors
-    new_masks = np.zeros(mask.shape)
-    edges = np.zeros(mask.shape)
-    strel = ball(1) if mask.ndim > 3 else disk(1)
+    new_mask = np.zeros(mask.shape)
+    strel = ball(1) if mask.ndim > 2 else disk(1)
     for cell_label in np.unique(mask):
         if cell_label != 0:
-            for i in range(mask.shape[0]):
-                # get the cell interior
-                img = mask[i] == cell_label
-                img = binary_erosion(img, strel)
-                new_masks[i] += img
+            # get the cell interior
+            new_mask = mask == cell_label
+            new_mask = binary_erosion(new_mask, strel)
 
-    interiors = np.multiply(new_masks, mask)
-    edges = (mask - interiors > 0).astype('int')
-    interiors = (interiors > 0).astype('int')
+    interior = np.multiply(new_mask, mask)
+    edge = (mask - interior > 0).astype('int')
+    interior = (interior > 0).astype('int')
 
     if not separate_edge_classes:
         if dilation_radius:
-            dil_strel = ball(dilation_radius) if mask.ndim > 3 else disk(dilation_radius)
+            dil_strel = ball(dilation_radius) if mask.ndim > 2 else disk(dilation_radius)
             # Thicken cell edges to be more pronounced
-            for i in range(edges.shape[0]):
-                edges[i] = binary_dilation(edges[i], selem=dil_strel)
+            edge = binary_dilation(edge, selem=dil_strel)
 
             # Thin the augmented edges by subtracting the interior features.
-            edges = (edges - interiors > 0).astype('int')
+            edge = (edge - interior > 0).astype('int')
 
-        background = (1 - edges - interiors > 0)
+        background = (1 - edge - interior > 0)
         background = background.astype('int')
 
         all_stacks = [
-            edges,
-            interiors,
+            edge,
+            interior,
             background
         ]
 
-        return np.stack(all_stacks, axis=channel_axis)
+        return np.stack(all_stacks, axis=-1)
 
     # dilate the background masks and subtract from all edges for background-edges
-    dilated_background = np.zeros(mask.shape)
-    for i in range(mask.shape[0]):
-        background = (mask[i] == 0).astype('int')
-        dilated_background[i] = binary_dilation(background, strel)
+    background = (mask == 0).astype('int')
+    dilated_background = binary_dilation(background, strel)
 
-    background_edges = (edges - dilated_background > 0).astype('int')
+    background_edge = (edge - dilated_background > 0).astype('int')
 
     # edges that are not background-edges are interior-edges
-    interior_edges = (edges - background_edges > 0).astype('int')
+    interior_edge = (edge - background_edge > 0).astype('int')
 
     if dilation_radius:
-        dil_strel = ball(dilation_radius) if mask.ndim > 3 else disk(dilation_radius)
+        dil_strel = ball(dilation_radius) if mask.ndim > 2 else disk(dilation_radius)
         # Thicken cell edges to be more pronounced
-        for i in range(edges.shape[0]):
-            interior_edges[i] = binary_dilation(interior_edges[i], selem=dil_strel)
-            background_edges[i] = binary_dilation(background_edges[i], selem=dil_strel)
+        interior_edge = binary_dilation(interior_edge, selem=dil_strel)
+        background_edge = binary_dilation(background_edge, selem=dil_strel)
 
         # Thin the augmented edges by subtracting the interior features.
-        interior_edges = (interior_edges - interiors > 0).astype('int')
-        background_edges = (background_edges - interiors > 0).astype('int')
+        interior_edge = (interior_edge - interior > 0).astype('int')
+        background_edge = (background_edge - interior > 0).astype('int')
 
-    background = (1 - background_edges - interior_edges - interiors > 0)
+    background = (1 - background_edge - interior_edge - interior > 0)
     background = background.astype('int')
 
     all_stacks = [
-        background_edges,
-        interior_edges,
-        interiors,
+        background_edge,
+        interior_edge,
+        interior,
         background
     ]
 
-    return np.stack(all_stacks, axis=channel_axis)
+    return np.stack(all_stacks, axis=-1)
 
 
 def erode_edges(mask, erosion_width):

--- a/deepcell/utils/transform_utils_test.py
+++ b/deepcell/utils/transform_utils_test.py
@@ -59,6 +59,7 @@ class TransformUtilsTest(test.TestCase):
             # test single edge class
             for img in _generate_test_masks():
                 img = label(img)
+                img = np.squeeze(img)
                 pw_img = transform_utils.pixelwise_transform(
                     img, data_format=None, separate_edge_classes=False)
                 pw_img_dil = transform_utils.pixelwise_transform(
@@ -75,6 +76,7 @@ class TransformUtilsTest(test.TestCase):
             # test separate edge classes
             for img in _generate_test_masks():
                 img = label(img)
+                img = np.squeeze(img)
                 pw_img = transform_utils.pixelwise_transform(
                     img, data_format=None, separate_edge_classes=True)
                 pw_img_dil = transform_utils.pixelwise_transform(
@@ -108,6 +110,7 @@ class TransformUtilsTest(test.TestCase):
 
             for i in range(maskstack.shape[0]):
                 img = maskstack[i, ...]
+                img = np.squeeze(img)
                 pw_img = transform_utils.pixelwise_transform(
                     img, data_format=None, separate_edge_classes=False)
                 pw_img_dil = transform_utils.pixelwise_transform(
@@ -128,6 +131,7 @@ class TransformUtilsTest(test.TestCase):
 
             for i in range(maskstack.shape[0]):
                 img = maskstack[i, ...]
+                img = np.squeeze(img)
                 pw_img = transform_utils.pixelwise_transform(
                     img, data_format=None, separate_edge_classes=True)
                 pw_img_dil = transform_utils.pixelwise_transform(

--- a/deepcell/utils/transform_utils_test.py
+++ b/deepcell/utils/transform_utils_test.py
@@ -57,34 +57,36 @@ class TransformUtilsTest(test.TestCase):
         with self.cached_session():
             K.set_image_data_format('channels_last')
             # test single edge class
-            maskstack = np.array([label(i) for i in _generate_test_masks()])
-            pw_maskstack = transform_utils.pixelwise_transform(
-                maskstack, data_format=None, separate_edge_classes=False)
-            pw_maskstack_dil = transform_utils.pixelwise_transform(
-                maskstack, dilation_radius=1,
-                data_format='channels_last',
-                separate_edge_classes=False)
+            for img in _generate_test_masks():
+                img = label(img)
+                pw_img = transform_utils.pixelwise_transform(
+                    img, data_format=None, separate_edge_classes=False)
+                pw_img_dil = transform_utils.pixelwise_transform(
+                    img, dilation_radius=1,
+                    data_format='channels_last',
+                    separate_edge_classes=False)
 
-            self.assertEqual(pw_maskstack.shape[-1], 3)
-            self.assertEqual(pw_maskstack_dil.shape[-1], 3)
-            self.assertGreater(
-                pw_maskstack_dil[..., 0].sum() + pw_maskstack_dil[..., 1].sum(),
-                pw_maskstack[..., 0].sum() + pw_maskstack[..., 1].sum())
+                self.assertEqual(pw_img.shape[-1], 3)
+                self.assertEqual(pw_img_dil.shape[-1], 3)
+                self.assertGreater(
+                    pw_img_dil[..., 0].sum() + pw_img_dil[..., 1].sum(),
+                    pw_img[..., 0].sum() + pw_img[..., 1].sum())
 
             # test separate edge classes
-            maskstack = np.array([label(i) for i in _generate_test_masks()])
-            pw_maskstack = transform_utils.pixelwise_transform(
-                maskstack, data_format=None, separate_edge_classes=True)
-            pw_maskstack_dil = transform_utils.pixelwise_transform(
-                maskstack, dilation_radius=1,
-                data_format='channels_last',
-                separate_edge_classes=True)
+            for img in _generate_test_masks():
+                img = label(img)
+                pw_img = transform_utils.pixelwise_transform(
+                    img, data_format=None, separate_edge_classes=True)
+                pw_img_dil = transform_utils.pixelwise_transform(
+                    img, dilation_radius=1,
+                    data_format='channels_last',
+                    separate_edge_classes=True)
 
-            self.assertEqual(pw_maskstack.shape[-1], 4)
-            self.assertEqual(pw_maskstack_dil.shape[-1], 4)
-            self.assertGreater(
-                pw_maskstack_dil[..., 0].sum() + pw_maskstack_dil[..., 1].sum(),
-                pw_maskstack[..., 0].sum() + pw_maskstack[..., 1].sum())
+                self.assertEqual(pw_img.shape[-1], 4)
+                self.assertEqual(pw_img_dil.shape[-1], 4)
+                self.assertGreater(
+                    pw_img_dil[..., 0].sum() + pw_img_dil[..., 1].sum(),
+                    pw_img[..., 0].sum() + pw_img[..., 1].sum())
 
     def test_pixelwise_transform_3d(self):
         frames = 10

--- a/deepcell/utils/transform_utils_test.py
+++ b/deepcell/utils/transform_utils_test.py
@@ -105,34 +105,40 @@ class TransformUtilsTest(test.TestCase):
             batch_count = maskstack.shape[0] // frames
             new_shape = tuple([batch_count, frames] + list(maskstack.shape[1:]))
             maskstack = np.reshape(maskstack, new_shape)
-            pw_maskstack = transform_utils.pixelwise_transform(
-                maskstack, data_format=None, separate_edge_classes=False)
-            pw_maskstack_dil = transform_utils.pixelwise_transform(
-                maskstack, dilation_radius=2,
-                data_format='channels_last',
-                separate_edge_classes=False)
-            self.assertEqual(pw_maskstack.shape[-1], 3)
-            self.assertEqual(pw_maskstack_dil.shape[-1], 3)
-            self.assertGreater(
-                pw_maskstack_dil[..., 0].sum() + pw_maskstack_dil[..., 1].sum(),
-                pw_maskstack[..., 0].sum() + pw_maskstack[..., 1].sum())
+
+            for i in range(maskstack.shape[0]):
+                img = maskstack[i, ...]
+                pw_img = transform_utils.pixelwise_transform(
+                    img, data_format=None, separate_edge_classes=False)
+                pw_img_dil = transform_utils.pixelwise_transform(
+                    img, dilation_radius=2,
+                    data_format='channels_last',
+                    separate_edge_classes=False)
+                self.assertEqual(pw_img.shape[-1], 3)
+                self.assertEqual(pw_img_dil.shape[-1], 3)
+                self.assertGreater(
+                    pw_img_dil[..., 0].sum() + pw_img_dil[..., 1].sum(),
+                    pw_img[..., 0].sum() + pw_img[..., 1].sum())
 
             # test separate edge classes
             maskstack = np.vstack(img_list)
             batch_count = maskstack.shape[0] // frames
             new_shape = tuple([batch_count, frames] + list(maskstack.shape[1:]))
             maskstack = np.reshape(maskstack, new_shape)
-            pw_maskstack = transform_utils.pixelwise_transform(
-                maskstack, data_format=None, separate_edge_classes=True)
-            pw_maskstack_dil = transform_utils.pixelwise_transform(
-                maskstack, dilation_radius=2,
-                data_format='channels_last',
-                separate_edge_classes=True)
-            self.assertEqual(pw_maskstack.shape[-1], 4)
-            self.assertEqual(pw_maskstack_dil.shape[-1], 4)
-            self.assertGreater(
-                pw_maskstack_dil[..., 0].sum() + pw_maskstack_dil[..., 1].sum(),
-                pw_maskstack[..., 0].sum() + pw_maskstack[..., 1].sum())
+
+            for i in range(maskstack.shape[0]):
+                img = maskstack[i, ...]
+                pw_img = transform_utils.pixelwise_transform(
+                    img, data_format=None, separate_edge_classes=True)
+                pw_img_dil = transform_utils.pixelwise_transform(
+                    img, dilation_radius=2,
+                    data_format='channels_last',
+                    separate_edge_classes=True)
+                self.assertEqual(pw_img.shape[-1], 4)
+                self.assertEqual(pw_img_dil.shape[-1], 4)
+                self.assertGreater(
+                    pw_img_dil[..., 0].sum() + pw_img_dil[..., 1].sum(),
+                    pw_img[..., 0].sum() + pw_img[..., 1].sum())
 
     def test_erode_edges_2d(self):
         for img in _generate_test_masks():


### PR DESCRIPTION
The current implementation of the pixel transform first identifies all unique label IDs in all stacks of training images, then loops over each ID, then over each crop. 

The current implementation of the watershed transform instead first loops over each crop, then identifies the unique cell IDs within each crop, and then loops over each unique label ID.

The latter results in significant speed increases, as only the label IDs within each crop are iterated over. 

This PR refactors the pixel transform in the same style as watershed. 

Obviously a bug here would have far-reaching consequences, so please feel free to go over this with a fine-toothed comb. Happy to make any changes! 