### PR TITLE
fix pixel transform bug

### DIFF
--- a/deepcell/utils/transform_utils.py
+++ b/deepcell/utils/transform_utils.py
@@ -69,8 +69,9 @@ def pixelwise_transform(mask, dilation_radius=None, data_format=None,
     for cell_label in np.unique(mask):
         if cell_label != 0:
             # get the cell interior
-            new_mask = mask == cell_label
-            new_mask = binary_erosion(new_mask, strel)
+            img = mask == cell_label
+            img = binary_erosion(img, strel)
+            new_mask += img
 
     interior = np.multiply(new_mask, mask)
     edge = (mask - interior > 0).astype('int')

--- a/deepcell/utils/transform_utils_test.py
+++ b/deepcell/utils/transform_utils_test.py
@@ -69,6 +69,7 @@ class TransformUtilsTest(test.TestCase):
 
                 self.assertEqual(pw_img.shape[-1], 3)
                 self.assertEqual(pw_img_dil.shape[-1], 3)
+                assert(np.all(np.equal(pw_img[..., 0] + pw_img[..., 1], img > 0)))
                 self.assertGreater(
                     pw_img_dil[..., 0].sum() + pw_img_dil[..., 1].sum(),
                     pw_img[..., 0].sum() + pw_img[..., 1].sum())
@@ -86,6 +87,7 @@ class TransformUtilsTest(test.TestCase):
 
                 self.assertEqual(pw_img.shape[-1], 4)
                 self.assertEqual(pw_img_dil.shape[-1], 4)
+                assert(np.all(np.equal(pw_img[..., 0] + pw_img[..., 1] + pw_img[..., 2], img > 0)))
                 self.assertGreater(
                     pw_img_dil[..., 0].sum() + pw_img_dil[..., 1].sum(),
                     pw_img[..., 0].sum() + pw_img[..., 1].sum())
@@ -119,6 +121,7 @@ class TransformUtilsTest(test.TestCase):
                     separate_edge_classes=False)
                 self.assertEqual(pw_img.shape[-1], 3)
                 self.assertEqual(pw_img_dil.shape[-1], 3)
+                assert(np.all(np.equal(pw_img[..., 0] + pw_img[..., 1], img > 0)))
                 self.assertGreater(
                     pw_img_dil[..., 0].sum() + pw_img_dil[..., 1].sum(),
                     pw_img[..., 0].sum() + pw_img[..., 1].sum())
@@ -140,6 +143,7 @@ class TransformUtilsTest(test.TestCase):
                     separate_edge_classes=True)
                 self.assertEqual(pw_img.shape[-1], 4)
                 self.assertEqual(pw_img_dil.shape[-1], 4)
+                assert(np.all(np.equal(pw_img[..., 0] + pw_img[..., 1] + pw_img[..., 2], img > 0)))
                 self.assertGreater(
                     pw_img_dil[..., 0].sum() + pw_img_dil[..., 1].sum(),
                     pw_img[..., 0].sum() + pw_img[..., 1].sum())


### PR DESCRIPTION
When I modified the pixel transform for #286, I accidentally removed two layers of the for loop. I should have just removed the first. This resulted in only the last cell in each crop being transformed, rather than every cell in the crop. Closes #294 