### PR TITLE
Update cytoplasmic data in DeepCell Datasets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing guidelines
+
+We hope this library will be broadly useful to those in the life sciences. For that to be the case, we intend to facilitate and foster a lively development community. To help you get started, please review the following:
+
+## Pull Request Checklist
+
+Before sending your pull requests, make sure you have followed this list.
+
+- Read the guidelines below and ensure your changes are consistent with them.
+- Read and abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+- Ensure your changes are consistent with the coding style.
+- Run the existing tests and write new tests for your code.
+
+## How to become a contributor and submit new code
+
+### Contributing code
+
+If you have improvements to deepcell-tf, please send us your pull requests! If you are new to the process, Github has a
+[how-to](https://help.github.com/articles/using-pull-requests/).
+
+If you want to contribute, start working through the codebase. Navigate to the
+[Github "issues" tab](https://github.com/vanvalenlab/deepcell-tf/issues) and start
+looking through interesting issues. If you are not sure of where to start, look for one of the smaller/easier issues here i.e.
+[issues with the "good first issue" label](https://github.com/vanvalenlab/deepcell-tf/labels/good%20first%20issue)
+and then take a look at the
+[issues with the "contributions welcome" label](https://github.com/vanvalenlab/deepcell-tf/labels/stat%3Acontributions%20welcome).
+These are issues that we believe are well suited for outside contributions. If you decide to start on an issue, leave a comment so that other people know that you're working on it. If you want to help out, but not alone, use the issue comment thread to coordinate.
+
+### Contribution guidelines and standards
+
+Before sending your pull request for
+[review](https://github.com/vanvalenlab/deepcell-tf/pulls),
+make sure your changes are consistent with the guidelines and follow the
+DeepCell coding style.
+
+#### General guidelines and philosophy for contribution
+
+*   Include unit tests when you contribute new features, as they help to a)
+    prove that your code works correctly, and b) guard against future breaking
+    changes to lower the maintenance cost.
+*   Bug fixes also generally require unit tests, because the presence of bugs
+    usually indicates insufficient test coverage.
+*   When you contribute a new feature to deepcell-tf, the maintenance burden is
+    (by default) transferred to the DeepCell team. This means that the benefit
+    of the contribution must be compared against the cost of maintaining the
+    feature.
+*   As every PR requires CI/CD testing, we discourage
+    submitting PRs to fix one typo, one warning,etc. We recommend fixing the
+    same issue at the file level at least (e.g.: fix all typos in a file, fix
+    all compiler warning in a file, etc.)
+
+#### Python coding style
+
+Changes to DeepCell should conform to our style. As our library uses TensorFlow, we follow [Google's Python Style Guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md)
+
+Use `pylint` to check your Python changes. To install `pylint` and check a file
+with `pylint` against our custom style definition:
+
+```bash
+pip install pylint
+pylint --rcfile=deepcell-tf/.pylintrc myfile.py
+```
+
+Note `pylint --rcfile=deepcell-tf/.pylintrc` should run from the
+top level directory.
+
+#### Running tests
+
+Use the following commands to run all tests locally:
+
+```bash
+pip install -r requirements.txt
+pip install -r requirements-test.txt
+
+pytest --cov=deepcell --pep8
+```

--- a/deepcell/datasets/cytoplasm.py
+++ b/deepcell/datasets/cytoplasm.py
@@ -84,7 +84,7 @@ nih_3t3 = Dataset(
 )
 
 
-A549 = Dataset(
+a549 = Dataset(
     path='A549-cytoplasm.npz',
     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/A549-cytoplasm_fixed.npz',
     file_hash='b5934b2424d2c0e91aedb577883bb0e5',
@@ -92,7 +92,7 @@ A549 = Dataset(
 )
 
 
-CHO = Dataset(
+cho = Dataset(
     path='CHO-cytoplasm.npz',
     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/CHO-cytoplasm_fixed.npz',
     file_hash='949c1259d1383feb088f4cecdbc9a655',
@@ -100,7 +100,7 @@ CHO = Dataset(
 )
 
 
-HeLa_S3 = Dataset(
+hela_s3 = Dataset(
     path='hela_s3-cytoplasm.npz',
     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/hela_s3-cytoplasm_fixed.npz',
     file_hash='a2571357f5c2b238ed2ca9ec1329d8ea',
@@ -108,7 +108,7 @@ HeLa_S3 = Dataset(
 )
 
 
-HeLa = Dataset(
+hela = Dataset(
     path='hela-cytoplasm.npz',
     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/hela-cytoplasm_fixed.npz',
     file_hash='40f301ffb315dab17491c06afbfdf641',
@@ -116,7 +116,7 @@ HeLa = Dataset(
 )
 
 
-PC3 = Dataset(
+pc3 = Dataset(
     path='pc3-cytoplasm.npz',
     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/pc3-cytoplasm_fixed.npz',
     file_hash='636a280367c52bc9b57eebed23661295',

--- a/deepcell/datasets/cytoplasm.py
+++ b/deepcell/datasets/cytoplasm.py
@@ -23,7 +23,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Builtin Datasets"""
+"""Built-in Datasets"""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -67,56 +67,63 @@ methods = {
         'and phase as well as a z-stack of phase images.'
 }
 
-all_cells = Dataset(
-    path='20190903_all_fluorescent_cyto_512.npz',
-    url='https://deepcell-data.s3-us-west-1.amazonaws.com/cytoplasm/fluorescent/20190903_all_fluorescent_cyto_512.npz',
-    file_hash='810f8180185dea6169f01470126fae4e38511645267fe92115d592ca11e1835e',
+all_cells_phase = Dataset(
+    path='20190813_all_phase_512_contrast_adjusted_curated.npz',
+    url='https://deepcell-data.s3-us-west-1.amazonaws.com/cytoplasm/brightfield/20190813_all_phase_512_contrast_adjusted_curated.npz',
+    file_hash='20d6a99216e7c966182e79eef4eaf937',
     metadata={'methods': methods}
 )
 
-nih_3t3 = Dataset(
-    path='nih_3t3-cytoplasm.npz',
-    url='https://deepcell-data.s3-us-west-1.amazonaws.com/cytoplasm/fluorescent/AM_3T3_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
-    file_hash='d04630d87835d27f11d80c123eac3d77684c57dadf783158c44084b11fac1fb3',
+all_cells_fluo = Dataset(
+    path='20190903_all_fluorescent_cyto_512_contrast_adjusted_curated.npz',
+    url='https://deepcell-data.s3-us-west-1.amazonaws.com/cytoplasm/fluorescent/20190903_all_fluorescent_cyto_512_contrast_adjusted_curated.npz',
+    file_hash='28b9b637d0f0c9ceb3045620e17cc100',
     metadata={'methods': methods}
 )
 
-
-A549 = Dataset(
-    path='A549-cytoplasm.npz',
-    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/AM_A549_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
-    file_hash='33741ff643b1c8c017269663978ab8d52f833bfb65156fb66defa325e5316e74',
-    metadata={'methods': methods}
-)
-
-
-CHO = Dataset(
-    path='CHO-cytoplasm.npz',
-    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/AM_CHO_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
-    file_hash='d56029039a94c3c5ffaf926796108b87d2f12792b30010af52136ef4281dbbff',
-    metadata={'methods': methods}
-)
+# nih_3t3 = Dataset(
+#     path='nih_3t3-cytoplasm.npz',
+#     url='https://deepcell-data.s3-us-west-1.amazonaws.com/cytoplasm/fluorescent/AM_3T3_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
+#     file_hash='d04630d87835d27f11d80c123eac3d77684c57dadf783158c44084b11fac1fb3',
+#     metadata={'methods': methods}
+# )
 
 
-hela_s3 = Dataset(
-    path='hela_s3-cytoplasm.npz',
-    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/AM_HeLa-S3_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
-    file_hash='1ed6c47db02687e64a34d305a30677ad0a286106227c6d8992e23ca27ce6e098',
-    metadata={'methods': methods}
-)
+# A549 = Dataset(
+#     path='A549-cytoplasm.npz',
+#     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/AM_A549_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
+#     file_hash='33741ff643b1c8c017269663978ab8d52f833bfb65156fb66defa325e5316e74',
+#     metadata={'methods': methods}
+# )
 
 
-hela = Dataset(
-    path='hela-cytoplasm.npz',
-    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/AM_HeLa_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
-    file_hash='8dc76a2d4a5f384727e31daa9f25b6d861e64bd1775aec7ee42bea2cdf2b0527',
-    metadata={'methods': methods}
-)
+# CHO = Dataset(
+#     path='CHO-cytoplasm.npz',
+#     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/AM_CHO_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
+#     file_hash='d56029039a94c3c5ffaf926796108b87d2f12792b30010af52136ef4281dbbff',
+#     metadata={'methods': methods}
+# )
 
 
-pc3 = Dataset(
-    path='pc3-cytoplasm.npz',
-    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/AM_PC3_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
-    file_hash='194016feb25e97bdf0b1e335acab3c217d14ae2679a7ac7d3f6204ce4a864560',
-    metadata={'methods': methods}
-)
+# hela_s3 = Dataset(
+#     path='hela_s3-cytoplasm.npz',
+#     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/AM_HeLa-S3_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
+#     file_hash='1ed6c47db02687e64a34d305a30677ad0a286106227c6d8992e23ca27ce6e098',
+#     metadata={'methods': methods}
+# )
+
+
+# hela = Dataset(
+#     path='hela-cytoplasm.npz',
+#     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/AM_HeLa_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
+#     file_hash='8dc76a2d4a5f384727e31daa9f25b6d861e64bd1775aec7ee42bea2cdf2b0527',
+#     metadata={'methods': methods}
+# )
+
+
+# pc3 = Dataset(
+#     path='pc3-cytoplasm.npz',
+#     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/AM_PC3_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
+#     file_hash='194016feb25e97bdf0b1e335acab3c217d14ae2679a7ac7d3f6204ce4a864560',
+#     metadata={'methods': methods}
+# )

--- a/deepcell/datasets/cytoplasm.py
+++ b/deepcell/datasets/cytoplasm.py
@@ -67,63 +67,56 @@ methods = {
         'and phase as well as a z-stack of phase images.'
 }
 
-all_cells_phase = Dataset(
-    path='20190813_all_phase_512_contrast_adjusted_curated.npz',
-    url='https://deepcell-data.s3-us-west-1.amazonaws.com/cytoplasm/brightfield/20190813_all_phase_512_contrast_adjusted_curated.npz',
-    file_hash='20d6a99216e7c966182e79eef4eaf937',
-    metadata={'methods': methods}
-)
-
-all_cells_fluo = Dataset(
+all_cells = Dataset(
     path='20190903_all_fluorescent_cyto_512_contrast_adjusted_curated.npz',
     url='https://deepcell-data.s3-us-west-1.amazonaws.com/cytoplasm/fluorescent/20190903_all_fluorescent_cyto_512_contrast_adjusted_curated.npz',
-    file_hash='28b9b637d0f0c9ceb3045620e17cc100',
+    file_hash='a4e671a2c08e102f158903b288e88fff',
     metadata={'methods': methods}
 )
 
-# nih_3t3 = Dataset(
-#     path='nih_3t3-cytoplasm.npz',
-#     url='https://deepcell-data.s3-us-west-1.amazonaws.com/cytoplasm/fluorescent/AM_3T3_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
-#     file_hash='d04630d87835d27f11d80c123eac3d77684c57dadf783158c44084b11fac1fb3',
-#     metadata={'methods': methods}
-# )
+nih_3t3 = Dataset(
+    path='nih_3t3-cytoplasm.npz',
+    url='https://deepcell-data.s3-us-west-1.amazonaws.com/cytoplasm/fluorescent/nih_3t3-cytoplasm_fixed.npz',
+    file_hash='a4e671a2c08e102f158903b288e88fff',
+    metadata={'methods': methods}
+)
 
 
-# A549 = Dataset(
-#     path='A549-cytoplasm.npz',
-#     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/AM_A549_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
-#     file_hash='33741ff643b1c8c017269663978ab8d52f833bfb65156fb66defa325e5316e74',
-#     metadata={'methods': methods}
-# )
+A549 = Dataset(
+    path='A549-cytoplasm.npz',
+    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/A549-cytoplasm_fixed.npz',
+    file_hash='b5934b2424d2c0e91aedb577883bb0e5',
+    metadata={'methods': methods}
+)
 
 
-# CHO = Dataset(
-#     path='CHO-cytoplasm.npz',
-#     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/AM_CHO_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
-#     file_hash='d56029039a94c3c5ffaf926796108b87d2f12792b30010af52136ef4281dbbff',
-#     metadata={'methods': methods}
-# )
+CHO = Dataset(
+    path='CHO-cytoplasm.npz',
+    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/CHO-cytoplasm_fixed.npz',
+    file_hash='949c1259d1383feb088f4cecdbc9a655',
+    metadata={'methods': methods}
+)
 
 
-# hela_s3 = Dataset(
-#     path='hela_s3-cytoplasm.npz',
-#     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/AM_HeLa-S3_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
-#     file_hash='1ed6c47db02687e64a34d305a30677ad0a286106227c6d8992e23ca27ce6e098',
-#     metadata={'methods': methods}
-# )
+HeLa_S3 = Dataset(
+    path='hela_s3-cytoplasm.npz',
+    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/hela_s3-cytoplasm_fixed.npz',
+    file_hash='a2571357f5c2b238ed2ca9ec1329d8ea',
+    metadata={'methods': methods}
+)
 
 
-# hela = Dataset(
-#     path='hela-cytoplasm.npz',
-#     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/AM_HeLa_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
-#     file_hash='8dc76a2d4a5f384727e31daa9f25b6d861e64bd1775aec7ee42bea2cdf2b0527',
-#     metadata={'methods': methods}
-# )
+HeLa = Dataset(
+    path='hela-cytoplasm.npz',
+    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/hela-cytoplasm_fixed.npz',
+    file_hash='40f301ffb315dab17491c06afbfdf641',
+    metadata={'methods': methods}
+)
 
 
-# pc3 = Dataset(
-#     path='pc3-cytoplasm.npz',
-#     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/AM_PC3_s0_fluorescent_cyto_medium_stitched_2D_512.npz',
-#     file_hash='194016feb25e97bdf0b1e335acab3c217d14ae2679a7ac7d3f6204ce4a864560',
-#     metadata={'methods': methods}
-# )
+PC3 = Dataset(
+    path='pc3-cytoplasm.npz',
+    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/fluorescent/pc3-cytoplasm_fixed.npz',
+    file_hash='636a280367c52bc9b57eebed23661295',
+    metadata={'methods': methods}
+)

--- a/deepcell/datasets/cytoplasm.py
+++ b/deepcell/datasets/cytoplasm.py
@@ -67,12 +67,14 @@ methods = {
         'and phase as well as a z-stack of phase images.'
 }
 
+
 all_cells = Dataset(
     path='20190903_all_fluorescent_cyto_512_contrast_adjusted_curated.npz',
     url='https://deepcell-data.s3-us-west-1.amazonaws.com/cytoplasm/fluorescent/20190903_all_fluorescent_cyto_512_contrast_adjusted_curated.npz',
     file_hash='a4e671a2c08e102f158903b288e88fff',
     metadata={'methods': methods}
 )
+
 
 nih_3t3 = Dataset(
     path='nih_3t3-cytoplasm.npz',

--- a/deepcell/datasets/phase.py
+++ b/deepcell/datasets/phase.py
@@ -54,55 +54,55 @@ methods = {
 }
 
 all_cells = Dataset(
-    path='20190813_all_phase_512.npz',
-    url='https://deepcell-data.s3-us-west-1.amazonaws.com/cytoplasm/brightfield/20190813_all_phase_512.npz',
-    file_hash='1b10bb58175461bc45ccddeaa4dc8195cc25c0a7c0ba55e25541531830a75d91',
+    path='20190813_all_phase_512_contrast_adjusted_curated.npz',
+    url='https://deepcell-data.s3-us-west-1.amazonaws.com/cytoplasm/brightfield/20190813_all_phase_512_contrast_adjusted_curated.npz',
+    file_hash='20d6a99216e7c966182e79eef4eaf937',
     metadata={'methods': methods}
 )
 
 nih_3t3 = Dataset(
     path='nih_3t3-phase.npz',
-    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/AM_3T3_s0_phase_medium_stitched_2D_512.npz',
-    file_hash='b0dc7fa28d6ec4dec25150187b9629330689372da40f730042f8e0824df4da2e',
+    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/nih_3t3-phase_fixed.npz',
+    file_hash='d1a3b5a548300ef8389cee8021f53957',
     metadata={'methods': methods}
 )
 
 
 A549 = Dataset(
     path='A549-phase.npz',
-    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/AM_A549_s0_phase_medium_stitched_2D_512.npz',
-    file_hash='4e2a17ed2083ffa7e9b64824c27591bf776257bae2b07639226aa2b9900fbb33',
+    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/A549-phase_fixed.npz',
+    file_hash='d1820a7057079a774a9def8ae4634e74',
     metadata={'methods': methods}
 )
 
 
 CHO = Dataset(
     path='CHO-phase.npz',
-    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/AM_CHO_s0_phase_medium_stitched_2D_512.npz',
-    file_hash='39aad99486825a856da14d87b48ac9b00dd176b7e54c9fc928489ee464828bcd',
+    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/CHO-phase_fixed.npz',
+    file_hash='0d059506a9500e155d0fbfee64c43e21',
     metadata={'methods': methods}
 )
 
 
 HeLa_S3 = Dataset(
     path='HeLa_S3-phase.npz',
-    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/AM_HeLa-S3_s0_phase_medium_stitched_2D_512.npz',
-    file_hash='505c42d89005186d0eb4d76740bb829c13220b6a96b0bfdc3980eaf95a359293',
+    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/HeLa_S3-phase_fixed.npz',
+    file_hash='8ee318c32e41c9ff0fccf40bcd9d993d',
     metadata={'methods': methods}
 )
 
 
 HeLa = Dataset(
     path='HeLa-phase.npz',
-    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/AM_HeLa_s0_phase_medium_stitched_2D_512.npz',
-    file_hash='e4e92e2611cd4bf087d8489db6fed35c893566f0d3fe859e366511f087a3f64c',
+    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/HeLa-phase_fixed.npz',
+    file_hash='f16c22201d63d1ab856f066811b3dcfa',
     metadata={'methods': methods}
 )
 
 
 PC3 = Dataset(
     path='PC3-phase.npz',
-    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/AM_PC3_s0_phase_medium_stitched_2D_512.npz',
-    file_hash='3d2d5106e1d1437e4874c6c49c773dbacc2437d5556212f7c2d532a820e5a03e',
+    url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/PC3-phase_fixed.npz',
+    file_hash='1be17d9f6dbb009eed542f56f8282edd',
     metadata={'methods': methods}
 )

--- a/deepcell/datasets/phase.py
+++ b/deepcell/datasets/phase.py
@@ -23,7 +23,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Builtin Datasets"""
+"""Built-in Datasets"""
 
 from __future__ import absolute_import
 from __future__ import division

--- a/deepcell/datasets/phase.py
+++ b/deepcell/datasets/phase.py
@@ -53,12 +53,14 @@ methods = {
         'images.'
 }
 
+
 all_cells = Dataset(
     path='20190813_all_phase_512_contrast_adjusted_curated.npz',
     url='https://deepcell-data.s3-us-west-1.amazonaws.com/cytoplasm/brightfield/20190813_all_phase_512_contrast_adjusted_curated.npz',
     file_hash='20d6a99216e7c966182e79eef4eaf937',
     metadata={'methods': methods}
 )
+
 
 nih_3t3 = Dataset(
     path='nih_3t3-phase.npz',

--- a/deepcell/datasets/phase.py
+++ b/deepcell/datasets/phase.py
@@ -70,7 +70,7 @@ nih_3t3 = Dataset(
 )
 
 
-A549 = Dataset(
+a549 = Dataset(
     path='A549-phase.npz',
     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/A549-phase_fixed.npz',
     file_hash='d1820a7057079a774a9def8ae4634e74',
@@ -78,7 +78,7 @@ A549 = Dataset(
 )
 
 
-CHO = Dataset(
+cho = Dataset(
     path='CHO-phase.npz',
     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/CHO-phase_fixed.npz',
     file_hash='0d059506a9500e155d0fbfee64c43e21',
@@ -86,7 +86,7 @@ CHO = Dataset(
 )
 
 
-HeLa_S3 = Dataset(
+hela_s3 = Dataset(
     path='HeLa_S3-phase.npz',
     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/HeLa_S3-phase_fixed.npz',
     file_hash='8ee318c32e41c9ff0fccf40bcd9d993d',
@@ -94,7 +94,7 @@ HeLa_S3 = Dataset(
 )
 
 
-HeLa = Dataset(
+hela = Dataset(
     path='HeLa-phase.npz',
     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/HeLa-phase_fixed.npz',
     file_hash='f16c22201d63d1ab856f066811b3dcfa',
@@ -102,7 +102,7 @@ HeLa = Dataset(
 )
 
 
-PC3 = Dataset(
+pc3 = Dataset(
     path='PC3-phase.npz',
     url='https://deepcell-data.s3.amazonaws.com/cytoplasm/brightfield/PC3-phase_fixed.npz',
     file_hash='1be17d9f6dbb009eed542f56f8282edd',

--- a/deepcell/datasets/tracked.py
+++ b/deepcell/datasets/tracked.py
@@ -23,7 +23,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Builtin Datasets"""
+"""Built-in Datasets"""
 
 from __future__ import absolute_import
 from __future__ import division


### PR DESCRIPTION
## What
* Swap out the current pointers to the cytoplasmic data to new files that have been computationally curated. There are 2 new files (one fluorescent and one phase). Each file is composed of many cell lines. 

## Why
* Necessary updates to data with more accurate annotations.
* Fixes #296
* Fixes #298
* Fixes #309 
