### PR TITLE
update URL for license, deepcell-tf not kiosk.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ All rights reserved.
 
 ## License
 
-This software is licensed under a modified [APACHE2](https://github.com/vanvalenlab/kiosk/blob/master/LICENSE). See [LICENSE](https://github.com/vanvalenlab/kiosk/blob/master/LICENSE) for full details.
+This software is licensed under a modified [APACHE2](https://github.com/vanvalenlab/deepcell-tf/blob/master/LICENSE). See [LICENSE](https://github.com/vanvalenlab/deepcell-tf/blob/master/LICENSE) for full details.
 
 ## Trademarks
 


### PR DESCRIPTION
## What
* Fix LICENCSE link pointing to the wrong repository.

## Why
* This is a bugfix due to a bad copy/paste.
