### PR TITLE
Change panoptic upsampling method to reduce memory and speed consumption

### DIFF
--- a/deepcell/model_zoo/fpn.py
+++ b/deepcell/model_zoo/fpn.py
@@ -84,7 +84,8 @@ def create_pyramid_level(backbone_input,
     acceptable_upsample = {'upsamplelike', 'upsampling2d', 'upsampling3d'}
     if upsample_type not in acceptable_upsample:
         raise ValueError(
-            'Upsample method not supported. Choose from [\'upsamplelike\',\'upsampling2d\',\'upsampling3d\']')
+            'Upsample method not supported. Choose from [\'upsamplelike\','
+            '\'upsampling2d\',\'upsampling3d\']')
 
     reduced_name = 'C{}_reduced'.format(level)
     upsample_name = 'P{}_upsampled'.format(level)
@@ -161,7 +162,8 @@ def __create_pyramid_features(backbone_dict,
     acceptable_upsample = {'upsamplelike', 'upsampling2d', 'upsampling3d'}
     if upsample_type not in acceptable_upsample:
         raise ValueError(
-            'Upsample method not supported. Choose from [\'upsamplelike\',\'upsampling2d\',\'upsampling3d\']')
+            'Upsample method not supported. Choose from [\'upsamplelike\','
+            '\'upsampling2d\',\'upsampling3d\']')
 
     # Get names of the backbone levels and place in ascending order
     backbone_names = get_sorted_keys(backbone_dict)

--- a/deepcell/model_zoo/fpn.py
+++ b/deepcell/model_zoo/fpn.py
@@ -62,7 +62,7 @@ def create_pyramid_level(backbone_input,
         addition_input (layer): Optional layer to add to
             pyramid layer after convolution and upsampling.
         upsample_type (str, optional): Choice of upsampling methods
-            from ['upsamplelike','upsampling2d'], defaults to 'upsamplelike'.
+            from ['upsamplelike','upsampling2d','upsampling3d'], defaults to 'upsamplelike'.
         level (int): Level to use in layer names, defaults to 5.
         feature_size (int):Number of filters for
             convolutional layer, defaults to 256.
@@ -74,17 +74,17 @@ def create_pyramid_level(backbone_input,
 
     Raises:
         ValueError: ndim is not 2 or 3
-        ValueError: upsample_type not ['upsamplelike','upsampling2d']
+        ValueError: upsample_type not ['upsamplelike','upsampling2d','upsampling3d']
     """
 
     acceptable_ndims = {2, 3}
     if ndim not in acceptable_ndims:
         raise ValueError('Only 2 and 3 dimensional networks are supported')
 
-    acceptable_upsample = {'upsamplelike', 'upsampling2d'}
+    acceptable_upsample = {'upsamplelike', 'upsampling2d', 'upsampling3d'}
     if upsample_type not in acceptable_upsample:
         raise ValueError(
-            'Upsample method not supported. Choose from [\'upsamplelike\',\'upsampling2d\']')
+            'Upsample method not supported. Choose from [\'upsamplelike\',\'upsampling2d\',\'upsampling3d\']')
 
     reduced_name = 'C{}_reduced'.format(level)
     upsample_name = 'P{}_upsampled'.format(level)
@@ -102,12 +102,6 @@ def create_pyramid_level(backbone_input,
     # Add and then 3x3 conv
     if addition_input is not None:
         pyramid = Add(name=addition_name)([pyramid, addition_input])
-
-# Select appropriate upsample based on upsample_type and ndim
-    if upsample_type == 'upsamplelike':
-        upsampling = UpsampleLike
-    else:
-        upsampling = UpSampling2D if ndim == 2 else UpSampling3D
 
     # Upsample pyramid input
     if upsamplelike_input is not None:
@@ -142,7 +136,7 @@ def __create_pyramid_features(backbone_dict,
         backbone_dict (dictionary): A dictionary of the backbone layers, with
             the names as keys, e.g. {'C0': C0, 'C1': C1, 'C2': C2, ...}
         upsample_type (str, optional): Choice of upsampling methods
-            from ['upsamplelike','upsamling2d'], defaults to 'upsamplelike'.
+            from ['upsamplelike','upsamling2d','upsampling3d'], defaults to 'upsamplelike'.
         feature_size (int): Defaults to 256. The feature size to use
             for the resulting feature levels.
         include_final_layers (bool): Add two coarser pyramid levels
@@ -157,17 +151,17 @@ def __create_pyramid_features(backbone_dict,
 
     Raises:
         ValueError: ndim is not 2 or 3
-        ValueError: upsample_type not ['upsamplelike','upsampling2d']
+        ValueError: upsample_type not ['upsamplelike','upsampling2d','upsampling3d']
     """
 
     acceptable_ndims = [2, 3]
     if ndim not in acceptable_ndims:
         raise ValueError('Only 2 and 3 dimensional networks are supported')
 
-    acceptable_upsample = {'upsamplelike', 'upsampling2d'}
+    acceptable_upsample = {'upsamplelike', 'upsampling2d', 'upsampling3d'}
     if upsample_type not in acceptable_upsample:
         raise ValueError(
-            'Upsample method not supported. Choose from [\'upsamplelike\',\'upsampling2d\']')
+            'Upsample method not supported. Choose from [\'upsamplelike\',\'upsampling2d\',\'upsampling3d\']')
 
     # Get names of the backbone levels and place in ascending order
     backbone_names = get_sorted_keys(backbone_dict)

--- a/deepcell/model_zoo/panopticnet.py
+++ b/deepcell/model_zoo/panopticnet.py
@@ -293,7 +293,9 @@ def PanopticNet(backbone,
     backbone_dict_reduced = {k: backbone_dict[k] for k in backbone_dict
                              if k in backbone_levels}
 
-    pyramid_dict = create_pyramid_features(backbone_dict_reduced, ndim=2)
+    pyramid_dict = create_pyramid_features(backbone_dict_reduced,
+                                           upsample_type='upsampling2d',
+                                           ndim=2)
 
     semantic_levels = [int(re.findall(r'\d+', k)[0]) for k in pyramid_dict]
     target_level = min(semantic_levels)

--- a/deepcell/model_zoo/panopticnet.py
+++ b/deepcell/model_zoo/panopticnet.py
@@ -217,7 +217,7 @@ def __create_semantic_head(pyramid_dict,
     # Final upsampling
     min_level = int(re.findall(r'\d+', semantic_names[-1])[0])
     n_upsample = min_level
-    x = semantic_upsample_prototype(semantic_sum, n_upsample, ndim=ndim)
+    x = semantic_upsample(semantic_sum, n_upsample, ndim=ndim)
 
     # First tensor product
     x = TensorProduct(n_dense)(x)
@@ -292,7 +292,7 @@ def PanopticNet(backbone,
     Returns:
         tensorflow.keras.Model: Panoptic model with a backbone.
     """
-        channel_axis = 1 if K.image_data_format() == 'channels_first' else -1
+    channel_axis = 1 if K.image_data_format() == 'channels_first' else -1
 
     if inputs is None:
         if frames_per_batch > 1:

--- a/deepcell/model_zoo/panopticnet.py
+++ b/deepcell/model_zoo/panopticnet.py
@@ -195,22 +195,6 @@ def __create_semantic_head(pyramid_dict,
     pyramid_names.reverse()
     pyramid_features.reverse()
 
-    semantic_features = []
-    semantic_names = []
-
-    # for N, P in zip(pyramid_names, pyramid_features):
-
-    #     # Get level and determine how much to upsample
-    #     level = int(re.findall(r'\d+', N)[0])
-    #     n_upsample = level - target_level
-
-    #     # Use semantic upsample to get semantic map
-    #     semantic_features.append(semantic_upsample_prototype(P, n_upsample, ndim=ndim))
-    #     semantic_names.append('Q{}'.format(level))
-
-    # # Add all the semantic layers
-    # semantic_sum = Add()(semantic_features)
-
     semantic_sum = pyramid_features[-1]
     semantic_names = pyramid_names[-1]
 


### PR DESCRIPTION
## What
* Add an option to `deepcell.model_zoo.fpn.create_pyramid_levels` that enables choosing between `UpsampleLike` and `Upsampling2D`
* Use `Upsampling2D` in panoptic models instead of `UpsampleLike`
* In `deepcell.model_zoo.panoptic.semantic_upsample` use only the final layer of the pyramid network to blow up to final image size instead of adding together all layers in the pyramid.

## Why
* These changes to upsampling procedures reduces the overall memory footprint of the model and speeds up computation time. The lower memory profile means that this model will be more compatible with hosting multiple models through tf-serving.