### PR TITLE
Improvements to the simplify-transforms branch

### DIFF
--- a/deepcell/image_generators/__init__.py
+++ b/deepcell/image_generators/__init__.py
@@ -90,7 +90,7 @@ def _transform_masks(y, transform, data_format=None, **kwargs):
     if isinstance(transform, str):
         transform = transform.lower()
 
-    if transform not in valid_transforms:
+    if transform not in valid_transforms and transform is not None:
         raise ValueError('`{}` is not a valid transform'.format(transform))
 
     if transform in {'pixelwise', 'deepcell'}:

--- a/deepcell/utils/transform_utils.py
+++ b/deepcell/utils/transform_utils.py
@@ -181,7 +181,7 @@ def outer_distance_transform_3d(mask, bins=None, erosion_width=None,
     Uses scipy's distance_transform_edt
 
     Args:
-        maskstack (numpy.array): A z-stack of label masks (y data).
+        mask (numpy.array): A z-stack of label masks (y data).
         bins (int): The number of transformed distance classes.
             Defaults to None.
         erosion_width (int): Number of pixels to erode edges of each labels.
@@ -292,9 +292,11 @@ def inner_distance_transform_2d(mask, bins=None, erosion_width=None,
 
     Returns:
         numpy.array: a mask of same shape as input mask,
-            with each label being a distance class from 1 to bins
-    """
+            with each label being a distance class from 1 to bins.
 
+    Raises:
+        ValueError: alpha is a string but not set to "auto".
+    """
     # Check input to alpha
     if isinstance(alpha, str):
         if alpha.lower() != 'auto':
@@ -356,12 +358,16 @@ def inner_distance_transform_3d(mask, bins=None,
             area. Defaults to 0.1.
         beta (float): Scale parameter that is used when alpha is set to auto.
             Defaults to 1.
+        sampling (list): Spacing of pixels along each dimension.
+            Defaults to [0.5, 0.217, 0.217].
 
     Returns:
         numpy.array: A mask of same shape as input mask,
             with each label being a distance class from 1 to bins.
-    """
 
+    Raises:
+        ValueError: alpha is a string but not set to "auto".
+    """
     # Check input to alpha
     if isinstance(alpha, str):
         if alpha.lower() != 'auto':
@@ -416,13 +422,19 @@ def inner_distance_transform_movie(mask, bins=None, erosion_width=None,
         mask (numpy.array): A label mask (y data).
         bins (int): The number of transformed distance classes.
             Defaults to None.
-        erosion_width (int): Number of pixels to erode edges of each labels
-        alpha (float): Coefficent to reduce the magnitude of the distance
-            value.
+        erosion_width (int): Number of pixels to erode edges of each labels.
+        alpha (float, str): Coefficent to reduce the magnitude of the distance
+            value. If 'auto', determines alpha for each cell based on the cell
+            area. Defaults to 0.1.
+        beta (float): Scale parameter that is used when alpha is set to auto.
+            Defaults to 1.
 
     Returns:
         numpy.array: A mask of same shape as input mask,
-            with each label being a distance class from 1 to bins
+            with each label being a distance class from 1 to bins.
+
+    Raises:
+        ValueError: alpha is a string but not set to "auto".
     """
     inner_distances = []
 

--- a/deepcell/utils/transform_utils.py
+++ b/deepcell/utils/transform_utils.py
@@ -153,11 +153,10 @@ def outer_distance_transform_2d(mask, bins=None, erosion_width=None,
     distance = ndimage.distance_transform_edt(mask)
     distance = distance.astype(K.floatx())  # normalized distances are floats
 
-    # uniquely label each cell and normalize the distance values
-    # by that cells maximum distance value
-    label_matrix = label(mask)
-
     if normalize:
+        # uniquely label each cell and normalize the distance values
+        # by that cells maximum distance value
+        label_matrix = label(mask)
         for prop in regionprops(label_matrix):
             labeled_distance = distance[label_matrix == prop.label]
             normalized_distance = labeled_distance / np.amax(labeled_distance)
@@ -201,11 +200,12 @@ def outer_distance_transform_3d(mask, bins=None, erosion_width=None,
     distance = ndimage.distance_transform_edt(maskstack, sampling=sampling)
 
     # normalize by maximum distance
-    for cell_label in np.unique(maskstack):
-        if cell_label == 0:  # distance is only found for non-zero regions
-            continue
-        index = np.nonzero(maskstack == cell_label)
-        distance[index] = distance[index] / np.amax(distance[index])
+    if normalize:
+        for cell_label in np.unique(maskstack):
+            if cell_label == 0:  # distance is only found for non-zero regions
+                continue
+            index = np.nonzero(maskstack == cell_label)
+            distance[index] = distance[index] / np.amax(distance[index])
 
     if bins is None:
         return distance

--- a/deepcell/utils/transform_utils.py
+++ b/deepcell/utils/transform_utils.py
@@ -164,15 +164,15 @@ def outer_distance_transform_2d(mask, bins=None, erosion_width=None,
 
     if bins is None:
         return distance
-    else:
-        # bin each distance value into a class from 1 to bins
-        min_dist = np.amin(distance)
-        max_dist = np.amax(distance)
-        distance_bins = np.linspace(min_dist - K.epsilon(),
-                                    max_dist + K.epsilon(),
-                                    num=bins + 1)
-        distance = np.digitize(distance, distance_bins, right=True) - 1
-        return distance  # minimum distance should be 0, not 1
+
+    # bin each distance value into a class from 1 to bins
+    min_dist = np.amin(distance)
+    max_dist = np.amax(distance)
+    distance_bins = np.linspace(min_dist - K.epsilon(),
+                                max_dist + K.epsilon(),
+                                num=bins + 1)
+    distance = np.digitize(distance, distance_bins, right=True)
+    return distance - 1  # minimum distance should be 0, not 1
 
 
 def outer_distance_transform_3d(mask, bins=None, erosion_width=None,
@@ -209,15 +209,15 @@ def outer_distance_transform_3d(mask, bins=None, erosion_width=None,
 
     if bins is None:
         return distance
-    else:
-        # divide into bins
-        min_dist = np.amin(distance.flatten())
-        max_dist = np.amax(distance.flatten())
-        distance_bins = np.linspace(min_dist - K.epsilon(),
-                                    max_dist + K.epsilon(),
-                                    num=bins + 1)
-        distance = np.digitize(distance, distance_bins, right=True) - 1
-        return distance  # minimum distance should be 0, not 1
+
+    # divide into bins
+    min_dist = np.amin(distance.flatten())
+    max_dist = np.amax(distance.flatten())
+    distance_bins = np.linspace(min_dist - K.epsilon(),
+                                max_dist + K.epsilon(),
+                                num=bins + 1)
+    distance = np.digitize(distance, distance_bins, right=True)
+    return distance - 1  # minimum distance should be 0, not 1
 
 
 def outer_distance_transform_movie(mask, bins=None, erosion_width=None,
@@ -329,16 +329,15 @@ def inner_distance_transform_2d(mask, bins=None, erosion_width=None,
 
     if bins is None:
         return inner_distance
-    else:
-        # divide into bins
-        min_dist = np.amin(inner_distance.flatten())
-        max_dist = np.amax(inner_distance.flatten())
-        distance_bins = np.linspace(min_dist - K.epsilon(),
-                                    max_dist + K.epsilon(),
-                                    num=bins + 1)
-        inner_distance = np.digitize(inner_distance, distance_bins,
-                                     right=True) - 1
-        return inner_distance  # minimum distance should be 0, not 1
+
+    # divide into bins
+    min_dist = np.amin(inner_distance.flatten())
+    max_dist = np.amax(inner_distance.flatten())
+    distance_bins = np.linspace(min_dist - K.epsilon(),
+                                max_dist + K.epsilon(),
+                                num=bins + 1)
+    inner_distance = np.digitize(inner_distance, distance_bins, right=True)
+    return inner_distance - 1  # minimum distance should be 0, not 1
 
 
 def inner_distance_transform_3d(mask, bins=None,
@@ -402,15 +401,15 @@ def inner_distance_transform_3d(mask, bins=None,
 
     if bins is None:
         return inner_distance
-    else:
-        # divide into bins
-        min_dist = np.amin(inner_distance.flatten())
-        max_dist = np.amax(inner_distance.flatten())
-        distance_bins = np.linspace(min_dist - K.epsilon(),
-                                    max_dist + K.epsilon(),
-                                    num=bins + 1)
-        inner_distance = np.digitize(inner_distance, distance_bins, right=True)
-        return inner_distance - 1  # minimum distance should be 0, not 1
+
+    # divide into bins
+    min_dist = np.amin(inner_distance.flatten())
+    max_dist = np.amax(inner_distance.flatten())
+    distance_bins = np.linspace(min_dist - K.epsilon(),
+                                max_dist + K.epsilon(),
+                                num=bins + 1)
+    inner_distance = np.digitize(inner_distance, distance_bins, right=True)
+    return inner_distance - 1  # minimum distance should be 0, not 1
 
 
 def inner_distance_transform_movie(mask, bins=None, erosion_width=None,


### PR DESCRIPTION
## What
* Updated documentation
* DRYed out the `*_movie` functions to just use the 2d on each frame (same code).
* Support old transform names but use a `DeprecationWarning`.

## Why
* Get the simplify-transforms branch in good shape.
