### PR TITLE
pin skimage to 0.16.2 at most to fix #385

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pandas>=0.23.3,<1
 numpy>=1.16.4,<2
 scipy>=1.1.0,<2
-scikit-image>=0.14.1,<1
+scikit-image>=0.14.1,<=0.16.2
 scikit-learn>=0.19.1,<1
 tensorflow>=1.14.0,<2
 jupyter>=1.0.0,<2


### PR DESCRIPTION
## What
* Pin the highest version of `skimage` to 0.16.2.

## Why
* `skimage` 0.17.0 and up have moved / removed the `external` module.
* Fixes #385 
