### PR TITLE
Pin keras-preprocessing to <= 1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ tensorflow>=1.14.0,<2
 jupyter>=1.0.0,<2
 nbformat>=4.4.0,<5
 keras-applications==1.0.8
+keras-preprocessing<=1.1.0
 networkx>=2.1
 opencv-python>=3.4.2.17,<4
 cython>=0.28


### PR DESCRIPTION
## What
* A new `keras-preprocessing` release has broken the tests for `ImageDataGenerators`.

## Why
* Pinning the version fixes the issues and restores expected behavior.
