### PR TITLE
Upgrade deepcell_toolbox to account for swapped axes in Application.resize()

### DIFF
--- a/deepcell/applications/application.py
+++ b/deepcell/applications/application.py
@@ -240,8 +240,6 @@ class Application(object):
         if not same:
             # Resize function only takes the x,y dimensions for shape
             new_shape = original_shape[1:-1]
-            # Flip order of shape axes to prevent transpose of data
-            new_shape = new_shape[::-1]
             image = resize(image, new_shape,
                            data_format='channels_last',
                            labeled_image=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ opencv-python>=3.4.2.17,<4
 cython>=0.28
 pathlib==1.0.1
 deepcell-tracking>=0.2.4
-deepcell-toolbox>=0.4.0
+deepcell-toolbox>=0.4.1


### PR DESCRIPTION
## What
* Bump `deepcell_toolbox` to 0.4.1 to fix `resize()` bug where `cv2` would swap the x and y axes.
* Don't swap outputs of `Application.resize`

## Why
* Bug fixed upstream, no need to account for its errant behavior anymore.
