### PR TITLE
Fix create_semantic_head to ignore n_filters in final semantic_upsample

### DIFF
--- a/deepcell/model_zoo/fpn.py
+++ b/deepcell/model_zoo/fpn.py
@@ -518,7 +518,8 @@ def __create_semantic_head(pyramid_dict,
     # n_upsample = min_level - target_level
     n_upsample = target_level
     x = semantic_upsample(semantic_sum, n_upsample,
-                          n_filters=n_filters, target=input_target, ndim=ndim,
+                          # n_filters=n_filters,  # TODO: uncomment and retrain
+                          target=input_target, ndim=ndim,
                           upsample_type=upsample_type, semantic_id=semantic_id,
                           interpolation=interpolation)
 


### PR DESCRIPTION
## What
* Removed `n_filters` from the final `semantic_upsample` call in `fpn.__create_semantic_head`.

## Why
* This was passed through erroneously and made the previous model version unusable.
