### PR TITLE
Fixed typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ This will spin up a docker container with `deepcell-tf` installed and start a ju
 
 For examples of how to train models with the `deepcell-tf` library, check out the following notebooks:
 
-- [Training a segmentation model](https://deepcell.readthedocs.io/en/master/Training-Segmentation.html)
-- [Training a tracking model](https://deepcell.readthedocs.io/en/master/Training-Tracking.html)
+- [Training a segmentation model](https://deepcell.readthedocs.io/en/master/notebooks/Training-Segmentation.html)
+- [Training a tracking model](https://deepcell.readthedocs.io/en/master/notebooks/Training-Tracking.html)
 
 ## DeepCell Applications and DeepCell Datasets
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ docker run --gpus '"device=0"' -it --rm \
     -p 8888:8888 \
     -v $PWD/notebooks:/notebooks \
     -v $PWD/data:/data \
-    vanvalenlab/deepcell-tf:0.4.0-gpu
+    vanvalenlab/deepcell-tf:0.5.0-gpu
 ```
 
 This will spin up a docker container with `deepcell-tf` installed and start a jupyter session using the default port 8888. This command also mounts a data folder (`$PWD/data`) and a scripts folder (`$PWD/scripts`) to the docker container so it can access data and Juyter notebooks stored on the host workstation. For any saved data or models to persist once the container is shut down, or be accessible outside of the container in general, it must be saved in these mounted directories. The default port can be changed to any non-reserved port by updating `-p 8888:8888` to, e.g., `-p 81:8888`. If you run across any errors getting started, you should either refer to the `deepcell-tf` for developers section or raise an issue on GitHub.


### PR DESCRIPTION
Typos caused some confusion via #400

## What
* Fixed notebook URLs.
* Updated latest version to 0.5.0

## Why
* Fixes the docs.
