### PR TITLE
Update .travis.yml with TensorFlow2 versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ git:
 language: python
 
 python:
-  - 2.7
   - 3.6
   - 3.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ python:
   - 3.7
 
 env:
-  - TF_VERSION=1.14.0
-  - TF_VERSION=1.15.0
+  - TF_VERSION=2.1.1
+  - TF_VERSION=2.2.0
 
 install:
   # code below is taken from https://github.com/keras-team/keras/blob/master/.travis.yml
@@ -73,7 +73,7 @@ jobs:
   include:
     - stage: deploy
       if: tag IS present
-      env: TF_VERSION=1.14.0
+      env: TF_VERSION=2.2.0
       python: 3.6
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/deepcell/callbacks_test.py
+++ b/deepcell/callbacks_test.py
@@ -61,8 +61,8 @@ class CallbacksTest(keras_parameterized.TestCase):
                 input_shape=(INPUT_DIM,),
                 num_classes=NUM_CLASSES)
 
-            y_test = keras.utils.to_categorical(y_test)
-            y_train = keras.utils.to_categorical(y_train)
+            y_test = keras.utils.np_utils.to_categorical(y_test)
+            y_train = keras.utils.np_utils.to_categorical(y_train)
             model = keras.models.Sequential()
             model.add(
                 keras.layers.Dense(

--- a/deepcell/callbacks_test.py
+++ b/deepcell/callbacks_test.py
@@ -36,7 +36,7 @@ import numpy as np
 from tensorflow.python import keras
 from tensorflow.python.platform import test
 from tensorflow.python.keras import keras_parameterized
-from tensorflow.keras import testing_utils
+from tensorflow.python.keras import testing_utils
 
 from deepcell.callbacks import RedirectModel
 

--- a/deepcell/callbacks_test.py
+++ b/deepcell/callbacks_test.py
@@ -35,7 +35,7 @@ import numpy as np
 
 from tensorflow.python import keras
 from tensorflow.python.platform import test
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 from tensorflow.keras import testing_utils
 
 from deepcell.callbacks import RedirectModel

--- a/deepcell/initializers_test.py
+++ b/deepcell/initializers_test.py
@@ -30,7 +30,7 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow.keras import backend as K
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.initializers import PriorProbability
 

--- a/deepcell/layers/convolutional_recurrent_test.py
+++ b/deepcell/layers/convolutional_recurrent_test.py
@@ -7,7 +7,7 @@ from __future__ import division
 from absl.testing import parameterized
 import numpy as np
 
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 
 from tensorflow.python import keras
 

--- a/deepcell/layers/filter_detections_test.py
+++ b/deepcell/layers/filter_detections_test.py
@@ -30,7 +30,7 @@ from __future__ import division
 
 import numpy as np
 from tensorflow.keras import backend as K
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.platform import test
 
 from deepcell import layers

--- a/deepcell/layers/location_test.py
+++ b/deepcell/layers/location_test.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils

--- a/deepcell/layers/normalization_test.py
+++ b/deepcell/layers/normalization_test.py
@@ -30,7 +30,7 @@ from __future__ import division
 
 import numpy as np
 from tensorflow.python import keras
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils

--- a/deepcell/layers/padding_test.py
+++ b/deepcell/layers/padding_test.py
@@ -33,7 +33,7 @@ import numpy as np
 
 # from tensorflow.python import keras
 # from tensorflow.python.eager import context
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils

--- a/deepcell/layers/pooling_test.py
+++ b/deepcell/layers/pooling_test.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils

--- a/deepcell/layers/resize_test.py
+++ b/deepcell/layers/resize_test.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils

--- a/deepcell/layers/retinanet_test.py
+++ b/deepcell/layers/retinanet_test.py
@@ -30,7 +30,7 @@ from __future__ import division
 
 import numpy as np
 from tensorflow.keras import backend as K
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils

--- a/deepcell/layers/tensor_product_test.py
+++ b/deepcell/layers/tensor_product_test.py
@@ -31,7 +31,7 @@ from __future__ import division
 import numpy as np
 
 from tensorflow.python import keras
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils

--- a/deepcell/layers/upsample_test.py
+++ b/deepcell/layers/upsample_test.py
@@ -30,7 +30,7 @@ from __future__ import division
 
 import numpy as np
 from tensorflow.keras import backend as K
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.platform import test
 
 from deepcell.utils import testing_utils

--- a/deepcell/losses_test.py
+++ b/deepcell/losses_test.py
@@ -57,6 +57,20 @@ ALL_LOSSES = [
 ]
 
 
+class _MSEMAELoss(object):
+    """Loss function with internal state, for testing serialization code."""
+
+    def __init__(self, mse_fraction):
+        self.mse_fraction = mse_fraction
+
+    def __call__(self, y_true, y_pred, sample_weight=None):
+        return (self.mse_fraction * keras.losses.mean_squared_error(y_true, y_pred) +
+                (1 - self.mse_fraction) * keras.losses.mean_absolute_error(y_true, y_pred))
+
+    def get_config(self):
+        return {'mse_fraction': self.mse_fraction}
+
+
 class KerasLossesTest(test.TestCase):
 
     def test_objective_shapes_3d(self):

--- a/deepcell/losses_test.py
+++ b/deepcell/losses_test.py
@@ -57,20 +57,6 @@ ALL_LOSSES = [
 ]
 
 
-class _MSEMAELoss(object):
-    """Loss function with internal state, for testing serialization code."""
-
-    def __init__(self, mse_fraction):
-        self.mse_fraction = mse_fraction
-
-    def __call__(self, y_true, y_pred, sample_weight=None):
-        return (self.mse_fraction * keras.losses.mean_squared_error(y_true, y_pred) +
-                (1 - self.mse_fraction) * keras.losses.mean_absolute_error(y_true, y_pred))
-
-    def get_config(self):
-        return {'mse_fraction': self.mse_fraction}
-
-
 class KerasLossesTest(test.TestCase):
 
     def test_objective_shapes_3d(self):
@@ -79,8 +65,7 @@ class KerasLossesTest(test.TestCase):
             y_b = keras.backend.variable(np.random.random((5, 6, 7)))
             for obj in ALL_LOSSES:
                 objective_output = obj(y_a, y_b)
-                print(obj)
-                self.assertListEqual(objective_output.get_shape().as_list(), [5, 6])
+                self.assertListEqual(objective_output.shape.as_list(), [5, 6])
 
     def test_objective_shapes_2d(self):
         with self.cached_session():
@@ -88,66 +73,7 @@ class KerasLossesTest(test.TestCase):
             y_b = keras.backend.variable(np.random.random((6, 7)))
             for obj in ALL_LOSSES:
                 objective_output = obj(y_a, y_b)
-                print(obj)
-                self.assertListEqual(objective_output.get_shape().as_list(), [6])
-
-    def test_cce_one_hot(self):
-        with self.cached_session():
-            y_a = keras.backend.variable(np.random.randint(0, 7, (5, 6)))
-            y_b = keras.backend.variable(np.random.random((5, 6, 7)))
-            objective_output = keras.losses.sparse_categorical_crossentropy(y_a, y_b)
-            self.assertEqual(keras.backend.eval(objective_output).shape, (5, 6))
-
-            y_a = keras.backend.variable(np.random.randint(0, 7, (6,)))
-            y_b = keras.backend.variable(np.random.random((6, 7)))
-            objective_output = keras.losses.sparse_categorical_crossentropy(y_a, y_b)
-            self.assertEqual(keras.backend.eval(objective_output).shape, (6,))
-
-    def test_serialization(self):
-        fn = keras.losses.get('mse')
-        config = keras.losses.serialize(fn)
-        new_fn = keras.losses.deserialize(config)
-        self.assertEqual(fn, new_fn)
-
-    def test_categorical_hinge(self):
-        y_pred = keras.backend.variable(np.array([[0.3, 0.2, 0.1], [0.1, 0.2, 0.7]]))
-        y_true = keras.backend.variable(np.array([[0, 1, 0], [1, 0, 0]]))
-        expected_loss = ((0.3 - 0.2 + 1) + (0.7 - 0.1 + 1)) / 2.0
-        loss = keras.backend.eval(keras.losses.categorical_hinge(y_true, y_pred))
-        self.assertAllClose(expected_loss, np.mean(loss))
-
-    def test_serializing_loss_class(self):
-        orig_loss_class = _MSEMAELoss(0.3)
-        with keras.utils.custom_object_scope({'_MSEMAELoss': _MSEMAELoss}):
-            serialized = keras.losses.serialize(orig_loss_class)
-
-        with keras.utils.custom_object_scope({'_MSEMAELoss': _MSEMAELoss}):
-            deserialized = keras.losses.deserialize(serialized)
-        self.assertIsInstance(deserialized, _MSEMAELoss)
-        self.assertEqual(deserialized.mse_fraction, 0.3)
-
-    def test_serializing_model_with_loss_class(self):
-        tmpdir = self.get_temp_dir()
-        self.addCleanup(shutil.rmtree, tmpdir)
-        model_filename = os.path.join(tmpdir, 'custom_loss.h5')
-
-        with self.cached_session():
-            with keras.utils.custom_object_scope({'_MSEMAELoss': _MSEMAELoss}):
-                loss = _MSEMAELoss(0.3)
-                inputs = keras.layers.Input((2,))
-                outputs = keras.layers.Dense(1, name='model_output')(inputs)
-                model = keras.models.Model(inputs, outputs)
-                model.compile(optimizer='sgd', loss={'model_output': loss})
-                model.fit(np.random.rand(256, 2), np.random.rand(256, 1))
-
-                if h5py is None:
-                    return
-
-                model.save(model_filename)
-
-            with keras.utils.custom_object_scope({'_MSEMAELoss': _MSEMAELoss}):
-                loaded_model = keras.models.load_model(model_filename)
-                loaded_model.predict(np.random.rand(128, 2))
+                self.assertListEqual(objective_output.shape.as_list(), [6])
 
 
 if __name__ == '__main__':

--- a/deepcell/model_zoo/featurenet_test.py
+++ b/deepcell/model_zoo/featurenet_test.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 from absl.testing import parameterized
 
 from tensorflow.keras import backend as K
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.model_zoo import featurenet
 

--- a/deepcell/model_zoo/panopticnet_test.py
+++ b/deepcell/model_zoo/panopticnet_test.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 from absl.testing import parameterized
 
 from tensorflow.keras import backend as K
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.model_zoo import PanopticNet
 

--- a/deepcell/model_zoo/retinamask_test.py
+++ b/deepcell/model_zoo/retinamask_test.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 from absl.testing import parameterized
 
 from tensorflow.keras import backend as K
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.model_zoo import RetinaMask
 

--- a/deepcell/model_zoo/retinanet_test.py
+++ b/deepcell/model_zoo/retinanet_test.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 from absl.testing import parameterized
 
 from tensorflow.keras import backend as K
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.platform import test
 
 from deepcell.model_zoo import RetinaNet


### PR DESCRIPTION
## What
* Testing 2.1.1 and 2.2.0
* Removed unsupported python2.7

## Why
* To be able to test TF2 migration branch with travis.

---

Some outstanding issues with TF2 migration:

- `ConvGRU` layer
- Invalid Data tests for data generators
- `RetinaMovie` data generator
- `RetinaMask` tests are failing