### PR TITLE
Updated multiplex app and new postprocessing function

### DIFF
--- a/deepcell/applications/application.py
+++ b/deepcell/applications/application.py
@@ -54,6 +54,7 @@ class Application(object):
         Raises:
             ValueError: `Preprocessing_fn` must be a callable function
             ValueError: `Postprocessing_fn` must be a callable function
+            ValueError: `Model_output_fn` must be a callable function
         """
 
     def __init__(self,
@@ -62,6 +63,7 @@ class Application(object):
                  model_mpp=0.65,
                  preprocessing_fn=None,
                  postprocessing_fn=None,
+                 format_model_output_fn=None,
                  dataset_metadata=None,
                  model_metadata=None):
 
@@ -76,6 +78,7 @@ class Application(object):
         self.model_mpp = model_mpp
         self.preprocessing_fn = preprocessing_fn
         self.postprocessing_fn = postprocessing_fn
+        self.format_model_output_fn = format_model_output_fn
         self.dataset_metadata = dataset_metadata
         self.model_metadata = model_metadata
 
@@ -84,6 +87,8 @@ class Application(object):
             raise ValueError('Preprocessing_fn must be a callable function.')
         if self.postprocessing_fn is not None and not callable(self.postprocessing_fn):
             raise ValueError('Postprocessing_fn must be a callable function.')
+        if self.format_model_output_fn is not None and not callable(self.format_model_output_fn):
+            raise ValueError('Format_model_output_fn must be a callable function.')
 
     def predict(self, x):
         raise NotImplementedError
@@ -216,6 +221,24 @@ class Application(object):
 
         return output_images
 
+    def _format_model_output(self, output_images):
+        """Applies formatting function the output from the model if one was provided.
+        Otherwise, returns the model output unmodified
+
+        Args:
+            output_images: stack of untiled images to be reformatted
+
+        Returns:
+            dict or list: reformatted images stored as a dict, or input images stored as list
+                if no formatting function is specified
+        """
+
+        if self.format_model_output_fn is not None:
+            formatted_images = self.format_model_output_fn(output_images)
+            return formatted_images
+        else:
+            return output_images
+
     def _resize_output(self, image, original_shape):
         """Rescales input if the shape does not match the original shape
         excluding the batch and channel dimensions
@@ -273,7 +296,10 @@ class Application(object):
         # Untile images
         output_images = self._untile_output(output_tiles, tiles_info)
 
-        return output_images
+        # restructure outputs into a dict if function provided
+        formatted_images = self._format_model_output(output_images)
+
+        return formatted_images
 
     def _predict_segmentation(self,
                               image,

--- a/deepcell/applications/application.py
+++ b/deepcell/applications/application.py
@@ -50,6 +50,8 @@ class Application(object):
             postprocessing_fn (function, optional): Postprocessing function to apply
                 to data after prediction. Defaults to None.
                 Must accept an input of a list of arrays and then return a single array.
+            format_model_output_fn (function, optional): Convert model output from a list
+                of matrices to a dictionary with keys for each semantic head
 
         Raises:
             ValueError: `Preprocessing_fn` must be a callable function

--- a/deepcell/applications/application_test.py
+++ b/deepcell/applications/application_test.py
@@ -209,6 +209,24 @@ class TestApplication(test.TestCase):
         y = app._resize_output(x, original_shape)
         self.assertEqual(original_shape, y.shape)
 
+    def test_format_model_output(self):
+        def _format_model_output(Lx):
+            return {'inner-distance': Lx}
+
+        model = DummyModel()
+        x = np.random.rand(1, 30, 30, 1)
+
+        # No function
+        app = Application(model)
+        y = app._format_model_output(x)
+        self.assertAllEqual(x, y)
+
+        # single image
+        kwargs = {'format_model_output_fn': _format_model_output}
+        app = Application(model, **kwargs)
+        y = app._format_model_output(x)
+        self.assertAllEqual(x, y['inner-distance'])
+
     def test_run_model(self):
         model = DummyModel()
         app = Application(model)

--- a/deepcell/applications/multiplex_segmentation.py
+++ b/deepcell/applications/multiplex_segmentation.py
@@ -130,7 +130,7 @@ class MultiplexSegmentation(Application):
                 os.path.basename(WEIGHTS_PATH),
                 WEIGHTS_PATH,
                 cache_subdir='models',
-                md5_hash='66fec859eacc5222b5e7d2baa105f3e3'
+                md5_hash='a2f26a7b5cc9a86d68e65a7bd27c32d0'
             )
 
             model.load_weights(weights_path)
@@ -170,7 +170,7 @@ class MultiplexSegmentation(Application):
                 [whole-cell, nuclear, both]
             postprocess_kwargs_whole_cell (dict, optional): Kwargs to pass to postprocessing
                 function for whole_cell prediction. Defaults to {}.
-           postprocess_kwargs_nuclear (dict, optional): Kwargs to pass to postprocessing
+            postprocess_kwargs_nuclear (dict, optional): Kwargs to pass to postprocessing
                 function for nuclear prediction. Defaults to {}.
 
         Raises:

--- a/deepcell/applications/multiplex_segmentation.py
+++ b/deepcell/applications/multiplex_segmentation.py
@@ -39,8 +39,6 @@ from deepcell_toolbox.processing import phase_preprocess
 from deepcell.applications import Application
 from deepcell.model_zoo import PanopticNet
 
-import numpy as np
-
 
 WEIGHTS_PATH = ('https://deepcell-data.s3-us-west-1.amazonaws.com/'
                 'model-weights/Multiplex_Segmentation_20200714_subcellular.h5')

--- a/deepcell/applications/multiplex_segmentation.py
+++ b/deepcell/applications/multiplex_segmentation.py
@@ -203,11 +203,16 @@ class MultiplexSegmentation(Application):
                  use_pretrained_weights=True,
                  model_image_shape=(256, 256, 2)):
 
+        whole_cell_classes = [1, 1, 2, 3]
+        nuclear_classes = [1, 1, 2, 3]
+        num_semantic_classes = whole_cell_classes + nuclear_classes
+        num_semantic_heads = len(num_semantic_classes)
+
         model = PanopticNet('resnet50',
                             input_shape=model_image_shape,
                             norm_method=None,
-                            num_semantic_heads=8,
-                            num_semantic_classes=[1, 1, 2, 3, 1, 1, 2, 3],
+                            num_semantic_heads=num_semantic_heads,
+                            num_semantic_classes=num_semantic_classes,
                             location=True,
                             include_top=True,
                             use_imagenet=False)

--- a/deepcell/applications/multiplex_segmentation.py
+++ b/deepcell/applications/multiplex_segmentation.py
@@ -43,7 +43,7 @@ import numpy as np
 
 
 WEIGHTS_PATH = ('https://deepcell-data.s3-us-west-1.amazonaws.com/'
-                'model-weights/Multiplex_Segmentation_20200610_Adapt_Hist.h5')
+                'model-weights/Multiplex_Segmentation_20200714_subcellular.h5')
 
 
 class MultiplexSegmentation(Application):

--- a/deepcell/applications/multiplex_segmentation_test.py
+++ b/deepcell/applications/multiplex_segmentation_test.py
@@ -44,9 +44,28 @@ class TestMultiplexSegmentation(test.TestCase):
             # test output shape
             shape = app.model.output_shape
             self.assertIsInstance(shape, list)
-            self.assertEqual(len(shape), 4)
+            self.assertEqual(len(shape), 8)
 
-            # test predict
+            # test predict with default
             x = np.random.rand(1, 500, 500, 2)
             y = app.predict(x)
             self.assertEqual(x.shape[:-1], y.shape[:-1])
+
+            # test predict with nuclear compartment only
+            x = np.random.rand(1, 500, 500, 2)
+            y = app.predict(x, postprocess_kwargs={'compartment': 'nucleus'})
+            self.assertEqual(x.shape[:-1], y.shape[:-1])
+            self.assertEqual(y.shape[-1], 1)
+
+            # test predict with cell compartment only
+            x = np.random.rand(1, 500, 500, 2)
+            y = app.predict(x, postprocess_kwargs={'compartment': 'cell'})
+            self.assertEqual(x.shape[:-1], y.shape[:-1])
+            self.assertEqual(y.shape[-1], 1)
+
+            # test predict with both cell and nuclear compartments
+            x = np.random.rand(1, 500, 500, 2)
+            y = app.predict(x, postprocess_kwargs={'compartment': 'both'})
+            print("x shape is {}, y shape is {}".format(x.shape, y.shape))
+            self.assertEqual(x.shape[:-1], y.shape[:-1])
+            self.assertEqual(y.shape[-1], 2)

--- a/deepcell/applications/multiplex_segmentation_test.py
+++ b/deepcell/applications/multiplex_segmentation_test.py
@@ -53,19 +53,19 @@ class TestMultiplexSegmentation(test.TestCase):
 
             # test predict with nuclear compartment only
             x = np.random.rand(1, 500, 500, 2)
-            y = app.predict(x, postprocess_kwargs={'compartment': 'nucleus'})
+            y = app.predict(x, compartment='nuclear')
             self.assertEqual(x.shape[:-1], y.shape[:-1])
             self.assertEqual(y.shape[-1], 1)
 
             # test predict with cell compartment only
             x = np.random.rand(1, 500, 500, 2)
-            y = app.predict(x, postprocess_kwargs={'compartment': 'cell'})
+            y = app.predict(x, compartment='whole-cell')
             self.assertEqual(x.shape[:-1], y.shape[:-1])
             self.assertEqual(y.shape[-1], 1)
 
             # test predict with both cell and nuclear compartments
             x = np.random.rand(1, 500, 500, 2)
-            y = app.predict(x, postprocess_kwargs={'compartment': 'both'})
+            y = app.predict(x, compartment='both')
             print("x shape is {}, y shape is {}".format(x.shape, y.shape))
             self.assertEqual(x.shape[:-1], y.shape[:-1])
             self.assertEqual(y.shape[-1], 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ networkx>=2.1
 opencv-python>=3.4.2.17,<4
 pathlib==1.0.1
 deepcell-tracking>=0.2.4
-git+https://github.com/vanvalenlab/deepcell-toolbox.git@39dfe3122c65d9f7f8dabddbcb2f861583d204ba
+deepcell-toolbox>=0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ networkx>=2.1
 opencv-python>=3.4.2.17,<4
 pathlib==1.0.1
 deepcell-tracking>=0.2.4
-deepcell-toolbox>=0.5.0
+git+https://github.com/vanvalenlab/deepcell-toolbox.git@39dfe3122c65d9f7f8dabddbcb2f861583d204ba


### PR DESCRIPTION
## What
* Updates the multiplex_segmentation app to support models that predict multiple distinct cellular compartments. 

## Why
* To enable predicting both nuclear and whole-cell signal

## TODOs:
I put the new postprocessing function in here just to make it easier to review both together. Once you're both happy with the approach and implementation I'll migrate to a separate PR in deepcell-toolbox.

I changed some of the kw arguments in the postprocessing function because I think the ones we're currently using aren't that intuitive. However, if you think that is going to cause confusion I can switch them back to match the existing defaults. 

- [x] Update the weights file with the latest and greatest model once this is ready to be merged in
- [x] Update the hash. This closes #411 
