### PR TITLE
Faster pixelwise transform

### DIFF
--- a/deepcell/utils/transform_utils.py
+++ b/deepcell/utils/transform_utils.py
@@ -34,7 +34,8 @@ from scipy import ndimage
 from skimage.measure import label
 from skimage.measure import regionprops
 from skimage.morphology import ball, disk
-from skimage.morphology import binary_erosion, binary_dilation
+from skimage.morphology import binary_dilation
+from skimage.segmentation import find_boundaries
 from tensorflow.python.keras import backend as K
 
 from deepcell_toolbox import erode_edges
@@ -66,19 +67,10 @@ def pixelwise_transform(mask, dilation_radius=None, data_format=None,
         channel_axis = -1
 
     # Detect the edges and interiors
-    new_mask = np.zeros(mask.shape)
+    edge = find_boundaries(mask, mode='inner').astype('int')
+    interior = np.logical_and(edge == 0, mask > 0).astype('int')
+
     strel = ball(1) if mask.ndim > 2 else disk(1)
-    for cell_label in np.unique(mask):
-        if cell_label != 0:
-            # get the cell interior
-            img = mask == cell_label
-            img = binary_erosion(img, strel)
-            new_mask += img
-
-    interior = np.multiply(new_mask, mask)
-    edge = (mask - interior > 0).astype('int')
-    interior = (interior > 0).astype('int')
-
     if not separate_edge_classes:
         if dilation_radius:
             dil_strel = ball(dilation_radius) if mask.ndim > 2 else disk(dilation_radius)


### PR DESCRIPTION
## What
* Switches behavior in pixelwise transform to match new functionality in vanvalenlab/deepcell-toolbox#46 for the other transforms
## Why
* Results in much faster augmentation during preprocessing

Closes #403 

Combined with the changes to erode_edges, this takes the preprocessing time from ~80 minutes to 6 minutes for the current multiplex dataset. 

Shown here is the amount of time for each transform:

![image](https://user-images.githubusercontent.com/13770365/87623431-36a25580-c6da-11ea-9f29-4df4b5ea6c74.png)

The first set of times is for whole-cell annotations, and the second is for nuclear annotations. Because not all of the cells have an observed nucleus, there are fewer annotations in the second loop. 
There are 211377 cells in the whole-cell annotations, and 155603 annotations in the nuclear annotations. 

The two transforms that are now taking up the bulk of the remaining time, the inner- and outer-distance transforms, have a clear dependence on the number of unique cells. This is because of the for loop that they each have, which loops over regionprops. Is there anything further we can do to optimize those, or is this not worth pursuing further?
