### PR TITLE
Pin opencv-python<=3.4.9.31 to maintain compatibility with older Python distributions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ nbformat>=4.4.0,<5
 keras-applications==1.0.8
 keras-preprocessing<=1.1.0
 networkx>=2.1
-opencv-python>=3.4.2.17,<4
+opencv-python<=3.4.9.31
 pathlib==1.0.1
 deepcell-tracking>=0.2.4
 deepcell-toolbox>=0.6.0


### PR DESCRIPTION
## What
* Pin `opencv-python<=3.4.9.31` instead of `<4`.

## Why
* This was the last version that supports Python2.7. We will abandon support, but this fix allows us to maintain compatibility until then.
