### PR TITLE
Update hash for MultiplexSegmentation model and use file_hash instead of md5_hash.

### DIFF
--- a/deepcell/applications/cell_tracking.py
+++ b/deepcell/applications/cell_tracking.py
@@ -67,7 +67,7 @@ def CellTrackingModel(input_shape=(32, 32, 1),
             'CellTrackingModel.h5',
             WEIGHTS_PATH,
             cache_subdir='models',
-            md5_hash='3349b363fdad0266a1845ba785e057a6')
+            file_hash='3349b363fdad0266a1845ba785e057a6')
 
         model.load_weights(weights_path)
 

--- a/deepcell/applications/cytoplasm_segmentation.py
+++ b/deepcell/applications/cytoplasm_segmentation.py
@@ -123,7 +123,7 @@ class CytoplasmSegmentation(Application):
                 os.path.basename(WEIGHTS_PATH),
                 WEIGHTS_PATH,
                 cache_subdir='models',
-                md5_hash='104a7d7884c80c37d2bce6d1c3a17c7a'
+                file_hash='104a7d7884c80c37d2bce6d1c3a17c7a'
             )
 
             model.load_weights(weights_path, by_name=True)

--- a/deepcell/applications/label_detection.py
+++ b/deepcell/applications/label_detection.py
@@ -103,7 +103,7 @@ def LabelDetectionModel(input_shape=(None, None, 1),
                 local_name,
                 MOBILENETV2_WEIGHTS_PATH,
                 cache_subdir='models',
-                md5_hash='14d4b2f7c77d334c958d2dde79972e6e')
+                file_hash='14d4b2f7c77d334c958d2dde79972e6e')
         else:
             raise ValueError('Backbone %s does not have a weights file.' %
                              backbone)

--- a/deepcell/applications/multiplex_segmentation.py
+++ b/deepcell/applications/multiplex_segmentation.py
@@ -128,7 +128,7 @@ class MultiplexSegmentation(Application):
                 os.path.basename(WEIGHTS_PATH),
                 WEIGHTS_PATH,
                 cache_subdir='models',
-                md5_hash='ff24e821c6056cf847e58e8e52916814'
+                file_hash='ff24e821c6056cf847e58e8e52916814'
             )
 
             model.load_weights(weights_path)

--- a/deepcell/applications/multiplex_segmentation.py
+++ b/deepcell/applications/multiplex_segmentation.py
@@ -128,7 +128,7 @@ class MultiplexSegmentation(Application):
                 os.path.basename(WEIGHTS_PATH),
                 WEIGHTS_PATH,
                 cache_subdir='models',
-                md5_hash='a2f26a7b5cc9a86d68e65a7bd27c32d0'
+                md5_hash='ff24e821c6056cf847e58e8e52916814'
             )
 
             model.load_weights(weights_path)

--- a/deepcell/applications/nuclear_segmentation.py
+++ b/deepcell/applications/nuclear_segmentation.py
@@ -123,7 +123,7 @@ class NuclearSegmentation(Application):
                 os.path.basename(WEIGHTS_PATH),
                 WEIGHTS_PATH,
                 cache_subdir='models',
-                md5_hash='42ca0ebe4b7b0f782eaa4733cdddad88'
+                file_hash='42ca0ebe4b7b0f782eaa4733cdddad88'
             )
 
             model.load_weights(weights_path, by_name=True)

--- a/deepcell/applications/scale_detection.py
+++ b/deepcell/applications/scale_detection.py
@@ -102,7 +102,7 @@ def ScaleDetectionModel(input_shape=(None, None, 1),
                 local_name,
                 MOBILENETV2_WEIGHTS_PATH,
                 cache_subdir='models',
-                md5_hash='aa78e6b9a4551289dd967f1f5ca83fed')
+                file_hash='aa78e6b9a4551289dd967f1f5ca83fed')
         else:
             raise ValueError('Backbone %s does not have a weights file.' %
                              backbone)


### PR DESCRIPTION
## What
* Update the hash for the `MultiplexSegmentation` application.
* Change applications from using the deprecated argument `md5_hash` to `file_hash`.

## Why
* Prevent redundant downloads of the model weights.
* `md5_hash` is deprecated.
