### PR TITLE
Only save the best model weights in training.py functions.

### DIFF
--- a/deepcell/training.py
+++ b/deepcell/training.py
@@ -404,7 +404,6 @@ def train_model_conv(model,
         validation_steps=val_data.y.shape[0] // batch_size,
         callbacks=train_callbacks)
 
-    model.save_weights(model_path)
     np.savez(loss_path, loss_history=loss_history.history)
 
     return model
@@ -543,7 +542,6 @@ def train_model_siamese_daughter(model,
         validation_steps=total_test_pairs // batch_size,
         callbacks=train_callbacks)
 
-    model.save_weights(model_path)
     np.savez(loss_path, loss_history=loss_history.history)
 
     return model
@@ -812,7 +810,6 @@ def train_model_retinanet(model,
         validation_steps=val_data.y.shape[0] // batch_size,
         callbacks=train_callbacks)
 
-    model.save_weights(model_path)
     np.savez(loss_path, loss_history=loss_history.history)
 
     if compute_map:


### PR DESCRIPTION
## What
* Instead of saving the final model weights, rely on the ModelCheckpoint callback to save the best weights.

## Why
* Saving the final model weights may overwrite better model weights from a previous epoch.
* Closes #290 
