### PR TITLE
Upgrade TensorFlow to 1.15.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ git:
 language: python
 
 python:
-  - 2.7
   - 3.5
   - 3.6
   - 3.7
@@ -36,9 +35,6 @@ install:
 
   - travis_retry conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-
-  # upgrade pip
-  - travis_retry pip install --upgrade pip
 
   # install TensorFlow (CPU version).
   - travis_retry pip install tensorflow==$TF_VERSION --progress-bar off

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ language: python
 
 python:
   - 2.7
+  - 3.5
   - 3.6
   - 3.7
 
 env:
-  - TF_VERSION=1.14.0
-  - TF_VERSION=1.15.0
+  - TF_VERSION=1.15.4
 
 install:
   # code below is taken from https://github.com/keras-team/keras/blob/master/.travis.yml
@@ -73,8 +73,8 @@ jobs:
   include:
     - stage: deploy
       if: tag IS present
-      env: TF_VERSION=1.14.0
-      python: 3.6
+      env: TF_VERSION=1.15.4
+      python: 3.7
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         # build an image with the CPU TensorFlow base image

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ install:
   - travis_retry conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
 
+  # upgrade pip
+  - travis_retry pip install --upgrade pip
+
   # install TensorFlow (CPU version).
   - travis_retry pip install tensorflow==$TF_VERSION --progress-bar off
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use tensorflow/tensorflow as the base image
 # Change the build arg to edit the tensorflow version.
 # Only supporting python3.
-ARG TF_VERSION=1.14.0-gpu
+ARG TF_VERSION=1.15.4-gpu
 
 FROM tensorflow/tensorflow:${TF_VERSION}-py3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.16.4,<2
 scipy>=1.1.0,<2
 scikit-image>=0.14.1,<=0.16.2
 scikit-learn>=0.19.1,<1
-tensorflow>=1.14.0,<2
+tensorflow>=1.15.4,<2
 jupyter>=1.0.0,<2
 nbformat>=4.4.0,<5
 keras-applications==1.0.8


### PR DESCRIPTION
## What
* Upgrade TensorFlow version to 1.15.4 (latest patch)

## Why
* A number of moderate- to high-severity CVEs are fixed in the latest version.
  * GHSA-mxjj-953w-2c2v
  * GHSA-x9j7-x98r-r4w2
  * GHSA-cvpc-8phh-8f45
  * GHSA-q4qf-3fc6-8x34
  * GHSA-h6fg-mjxg-hqq4
  * GHSA-w5gh-2wr2-pm6g
  * GHSA-q8gv-q7wr-9jf8
  * GHSA-g7p5-5759-qv46
  * GHSA-xmq7-7fxm-rr79
  * GHSA-63xm-rx5p-xvqr
  * GHSA-9mqp-7v2h-2382
  * GHSA-4g9f-63rx-5cw4






