### PR TITLE
Build docker images for all published releases.

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -2,7 +2,7 @@ name: Build & Push Docker Image
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
 


### PR DESCRIPTION
## What
* Change the docker-image workflow to run on `published` releases, not `created` ones.

## Why
* `created` releases will not trigger if the release was first a draft. This is not ideal since we often draft releases well ahead of time.
