### PR TITLE
Fix build-args in docker-image workflow

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -39,7 +39,7 @@ jobs:
           ${{ github.repository }}:latest
           ${{ github.repository }}:${{ github.event.release.tag_name }}
         build-args: |
-          TF_VERSION=$TF_VERSION
+          TF_VERSION=${{ env.TF_VERSION }}
     
     - name: Image digest
       run: echo ${{ steps.docker_build_cpu.outputs.digest }}
@@ -55,7 +55,7 @@ jobs:
           ${{ github.repository }}:latest-gpu
           ${{ github.repository }}:${{ github.event.release.tag_name }}-gpu
         build-args: |
-          TF_VERSION=$TF_VERSION-gpu
+          TF_VERSION=${{ env.TF_VERSION }}-gpu
 
     - name: Image digest
       run: echo ${{ steps.docker_build_gpu.outputs.digest }}


### PR DESCRIPTION
## What
* Fix bug in defining `build-args` using the environment variable `TF_VERSION`.

## Why
* To enable proper tagging of released docker images.
