### PR TITLE
Use headless openCV for faster builds and smaller images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,7 @@ ARG TF_VERSION=2.3.1-gpu
 FROM tensorflow/tensorflow:${TF_VERSION}
 
 # System maintenance
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    libxext6 \
-    libxrender-dev \
-    libsm6 && \
-    rm -rf /var/lib/apt/lists/* && \
-    /usr/bin/python3 -m pip install --upgrade pip
+RUN /usr/bin/python3 -m pip install --upgrade pip
 
 WORKDIR /notebooks
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ docker run --gpus '"device=0"' -it --rm \
     -p 8888:8888 \
     -v $PWD/notebooks:/notebooks \
     -v $PWD/data:/data \
-    vanvalenlab/deepcell-tf:0.8.0-gpu
+    vanvalenlab/deepcell-tf:0.8.3-gpu
 ```
 
 This will spin up a docker container with `deepcell-tf` installed and start a jupyter session using the default port 8888. This command also mounts a data folder (`$PWD/data`) and a scripts folder (`$PWD/scripts`) to the docker container so it can access data and Juyter notebooks stored on the host workstation. For any saved data or models to persist once the container is shut down, or be accessible outside of the container in general, it must be saved in these mounted directories. The default port can be changed to any non-reserved port by updating `-p 8888:8888` to, e.g., `-p 8080:8888`. If you run across any errors getting started, you should either refer to the `deepcell-tf` for developers section or raise an issue on GitHub.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ scikit-image>=0.14.1,<=0.16.2
 scikit-learn>=0.19.1,<1
 tensorflow==2.3.1
 jupyter>=1.0.0,<2
-opencv-python<=3.4.9.31
 deepcell-tracking>=0.2.4
 deepcell-toolbox>=0.8.2
+opencv-python-headless<=3.4.9.31

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ scikit-image>=0.14.1,<=0.16.2
 scikit-learn>=0.19.1,<1
 tensorflow==2.3.1
 jupyter>=1.0.0,<2
-deepcell-tracking>=0.2.4
-deepcell-toolbox>=0.8.2
 opencv-python-headless<=3.4.9.31
+deepcell-tracking>=0.2.7
+deepcell-toolbox>=0.8.3

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         'scikit-learn>=0.19.1,<1',
         'tensorflow==2.3.1',
         'jupyter>=1.0.0,<2',
-        'opencv-python<=3.4.9.31',
+        'opencv-python-headless<=3.4.9.31',
         'deepcell-tracking>=0.2.4',
         'deepcell-toolbox>=0.8.2'
     ],

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ with open(os.path.join(here, 'README.md'), 'r', 'utf-8') as f:
 
 
 NAME = 'DeepCell'
-VERSION = '0.8.2'
+VERSION = '0.8.3'
 AUTHOR = 'Van Valen Lab'
 AUTHOR_EMAIL = 'vanvalenlab@gmail.com'
 URL = 'https://github.com/vanvalenlab/deepcell-tf'
@@ -67,8 +67,8 @@ setup(
         'tensorflow==2.3.1',
         'jupyter>=1.0.0,<2',
         'opencv-python-headless<=3.4.9.31',
-        'deepcell-tracking>=0.2.4',
-        'deepcell-toolbox>=0.8.2'
+        'deepcell-tracking>=0.2.7',
+        'deepcell-toolbox>=0.8.3'
     ],
     extras_require={
         'tests': [


### PR DESCRIPTION
## What
* Replace `opencv-python` with `opencv-python-headless`
* Update `deepcell-toolbox` to 0.8.3
* Update `deepcell-tracking` to 0.2.7

## Why
* `opencv-python` installs Qt and other GUI dependencies for the GUI, while `opencv-python-headless` does not.
* The docker image no longer needs to install `libsm6`, `libxrender-dev`, or `libxext6`, leading to faster build times and smaller images.
