### PR TITLE
Application._resize_output handles both single and multiple tensor inputs.

### DIFF
--- a/deepcell/applications/application.py
+++ b/deepcell/applications/application.py
@@ -257,7 +257,7 @@ class Application(object):
 
     def _resize_output(self, image, original_shape):
         """Rescales input if the shape does not match the original shape
-        excluding the batch and channel dimensions
+        excluding the batch and channel dimensions.
 
         Args:
             image (numpy.array): Image to be rescaled to original shape
@@ -266,22 +266,31 @@ class Application(object):
         Returns:
             array: Rescaled image
         """
+        if not isinstance(image, list):
+            image = [image]
 
-        # Compare x,y based on rank of image
-        if len(image.shape) == 4:
-            same = image.shape[1:-1] == original_shape[1:-1]
-        elif len(image.shape) == 3:
-            same = image.shape[1:] == original_shape[1:-1]
-        else:
-            same = image.shape == original_shape[1:-1]
+        for i in range(len(image)):
+            img = image[i]
+            # Compare x,y based on rank of image
+            if len(img.shape) == 4:
+                same = img.shape[1:-1] == original_shape[1:-1]
+            elif len(img.shape) == 3:
+                same = img.shape[1:] == original_shape[1:-1]
+            else:
+                same = img.shape == original_shape[1:-1]
 
-        # Resize if same is false
-        if not same:
-            # Resize function only takes the x,y dimensions for shape
-            new_shape = original_shape[1:-1]
-            image = resize(image, new_shape,
-                           data_format='channels_last',
-                           labeled_image=True)
+            # Resize if same is false
+            if not same:
+                # Resize function only takes the x,y dimensions for shape
+                new_shape = original_shape[1:-1]
+                img = resize(img, new_shape,
+                             data_format='channels_last',
+                             labeled_image=True)
+            image[i] = img
+
+        if len(image) == 1:
+            image = image[0]
+
         return image
 
     def _run_model(self,

--- a/deepcell/applications/application_test.py
+++ b/deepcell/applications/application_test.py
@@ -225,7 +225,6 @@ class TestApplication(test.TestCase):
         for y_sub in y:
             self.assertEqual(original_shape, y_sub.shape)
 
-
     def test_format_model_output(self):
         def _format_model_output(Lx):
             return {'inner-distance': Lx}

--- a/deepcell/applications/application_test.py
+++ b/deepcell/applications/application_test.py
@@ -209,6 +209,23 @@ class TestApplication(test.TestCase):
         y = app._resize_output(x, original_shape)
         self.assertEqual(original_shape, y.shape)
 
+        # test multiple outputs are also resized
+        x_list = [x, x]
+
+        # x.shape = original_shape --> no resize
+        y = app._resize_output(x_list, x.shape)
+        self.assertIsInstance(y, list)
+        for y_sub in y:
+            self.assertEqual(x.shape, y_sub.shape)
+
+        # x.shape != original_shape --> resize
+        original_shape = (1, 500, 500, 1)
+        y = app._resize_output(x_list, original_shape)
+        self.assertIsInstance(y, list)
+        for y_sub in y:
+            self.assertEqual(original_shape, y_sub.shape)
+
+
     def test_format_model_output(self):
         def _format_model_output(Lx):
             return {'inner-distance': Lx}


### PR DESCRIPTION
## What
* `Application._resize_output` wraps the input in a list if its a single tensor, and resizes every tensor in the output

## Why
* Allow output from postprocessing with multiple outputs to be resized properly (e.g. if `postprocess_function=None`).
