### PR TITLE
Allow Applications to override default padding mode in _tile_input.

### DIFF
--- a/deepcell/applications/application.py
+++ b/deepcell/applications/application.py
@@ -178,7 +178,8 @@ class Application(object):
         # Otherwise tile images larger than model size
         else:
             # Tile images, needs 4d
-            tiles, tiles_info = tile_image(image, model_input_shape=self.model_image_shape)
+            tiles, tiles_info = tile_image(image, model_input_shape=self.model_image_shape,
+                                           stride_ratio=0.75, pad_mode='reflect')
 
         return tiles, tiles_info
 

--- a/deepcell/applications/nuclear_segmentation.py
+++ b/deepcell/applications/nuclear_segmentation.py
@@ -116,6 +116,7 @@ class NuclearSegmentation(Application):
                 image,
                 batch_size=4,
                 image_mpp=None,
+                pad_mode='reflect',
                 preprocess_kwargs=None,
                 postprocess_kwargs=None):
         """Generates a labeled image of the input running prediction with
@@ -131,6 +132,7 @@ class NuclearSegmentation(Application):
                 ``[batch, x, y, channel]``.
             batch_size (int): Number of images to predict on per batch.
             image_mpp (float): Microns per pixel for ``image``.
+            pad_mode (str): The padding mode, one of "constant" or "reflect".
             preprocess_kwargs (dict): Keyword arguments to pass to the
                 pre-processing function.
             postprocess_kwargs (dict): Keyword arguments to pass to the
@@ -164,5 +166,6 @@ class NuclearSegmentation(Application):
             image,
             batch_size=batch_size,
             image_mpp=image_mpp,
+            pad_mode=pad_mode,
             preprocess_kwargs=preprocess_kwargs,
             postprocess_kwargs=postprocess_kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ tensorflow==2.3.1
 jupyter>=1.0.0,<2
 opencv-python-headless<=3.4.9.31
 deepcell-tracking>=0.2.7
-deepcell-toolbox>=0.8.3
+deepcell-toolbox>=0.8.4


### PR DESCRIPTION
## What
* Update `deepcell-toolbox` to 0.8.4.
* Add optional `pad_mode` argument to `Application._predict_segmentation` and other methods to allow overriding the default padding mode of `"constant"`.

## Why
* The `NuclearSegmentation` application has much better performance with `"reflect"` padding mode, and this allows future applications to easily change their padding mode.
