### PR TITLE
Split PyTest and Coveralls stages & conditionally skip Coveralls if token is unset.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,6 +45,7 @@ jobs:
         pytest --cov deepcell --pep8
 
     - name: Coveralls
+      if: env.COVERALLS_REPO_TOKEN != null
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
@@ -59,6 +60,9 @@ jobs:
     steps:
     - name: Coveralls Finished
       uses: coverallsapp/github-action@master
+      if: env.COVERALLS_REPO_TOKEN != null
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         parallel-finished: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,13 +40,16 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements-test.txt
 
-    - name: Run PyTest and Coveralls
+    - name: PyTest
+      run: |
+        pytest --cov deepcell --pep8
+
+    - name: Coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
         COVERALLS_PARALLEL: true
       run: |
-        pytest --cov deepcell --pep8
         coveralls
 
   coveralls:


### PR DESCRIPTION
## What
* Split PyTest and Coveralls into separate build stages (which was not supported when GitHub Actions was originally adopted).
* Conditionally run Coveralls steps only if `COVERALLS_REPO_TOKEN` is set.

## Why
* This allows forked PRs to be submitted without failing due to a missing `COVERALLS_REPO_TOKEN`.
