### PR TITLE
Update deepcell-toolbox and deepcell-tracking to latest versions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-numpy>=1.16.4
+numpy>=1.16.6,<1.20
 scipy>=1.1.0,<2
-scikit-image>=0.14.1,<=0.16.2
+scikit-image>=0.14.5,<0.17
 scikit-learn>=0.19.1,<1
 tensorflow==2.3.1
 jupyter>=1.0.0,<2
 opencv-python-headless<5
-deepcell-tracking==0.3.1
-git+https://github.com/vanvalenlab/deepcell-toolbox@numpy-ufunc-bug
+deepcell-tracking>=0.3.1
+deepcell-toolbox>=0.8.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ scikit-image>=0.14.1,<=0.16.2
 scikit-learn>=0.19.1,<1
 tensorflow==2.3.1
 jupyter>=1.0.0,<2
-opencv-python-headless<=3.4.9.31
-deepcell-tracking>=0.2.7
-deepcell-toolbox>=0.8.4
+opencv-python-headless<5
+deepcell-tracking>=0.3.1
+deepcell-toolbox>=0.8.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ tensorflow==2.3.1
 jupyter>=1.0.0,<2
 opencv-python-headless<5
 deepcell-tracking>=0.3.1
-deepcell-toolbox>=0.8.5
+deepcell-toolbox==0.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-numpy>=1.16.4,<1.19.0
+numpy>=1.16.4
 scipy>=1.1.0,<2
 scikit-image>=0.14.1,<=0.16.2
 scikit-learn>=0.19.1,<1
 tensorflow==2.3.1
 jupyter>=1.0.0,<2
 opencv-python-headless<5
-deepcell-tracking>=0.3.1
-deepcell-toolbox==0.8.4
+deepcell-tracking==0.3.1
+deepcell-toolbox==0.8.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ tensorflow==2.3.1
 jupyter>=1.0.0,<2
 opencv-python-headless<5
 deepcell-tracking==0.3.1
-deepcell-toolbox==0.8.5
+git+https://github.com/vanvalenlab/deepcell-toolbox@numpy-ufunc-bug

--- a/setup.py
+++ b/setup.py
@@ -60,15 +60,15 @@ setup(
     long_description=README,
     long_description_content_type='text/markdown',
     install_requires=[
-        'numpy>=1.16.4,<1.19.0',
+        'numpy>=1.16.6,<1.20.0',
         'scipy>=1.1.0,<2',
-        'scikit-image>=0.14.1,<=0.16.2',
+        'scikit-image>=0.14.5,<=0.17',
         'scikit-learn>=0.19.1,<1',
         'tensorflow==2.3.1',
         'jupyter>=1.0.0,<2',
         'opencv-python-headless<5',
         'deepcell-tracking>=0.3.1',
-        'deepcell-toolbox>=0.8.5'
+        'deepcell-toolbox>=0.8.6'
     ],
     extras_require={
         'tests': [

--- a/setup.py
+++ b/setup.py
@@ -66,9 +66,9 @@ setup(
         'scikit-learn>=0.19.1,<1',
         'tensorflow==2.3.1',
         'jupyter>=1.0.0,<2',
-        'opencv-python-headless<=3.4.9.31',
-        'deepcell-tracking>=0.2.7',
-        'deepcell-toolbox>=0.8.3'
+        'opencv-python-headless<5',
+        'deepcell-tracking>=0.3.1',
+        'deepcell-toolbox>=0.8.5'
     ],
     extras_require={
         'tests': [


### PR DESCRIPTION
## What
* Update minimum dependencies.

## Why
* Raise the floor for some older dependencies (numpy and opencv especially)
* Update to latest version of `deepcell-toolbox` and `deepcell-tracking` to get latest bugfixes.
