### PR TITLE
Remove scikit-image version upper bound

### DIFF
--- a/deepcell/utils/io_utils.py
+++ b/deepcell/utils/io_utils.py
@@ -39,7 +39,9 @@ from tensorflow.keras import backend as K
 
 
 def get_image(file_name):
-    """Read image from file and returns it as a tensor
+    """DEPRECATED. Use ``skimage.io.imread`` instead.
+    
+    Read image from file and returns it as a tensor.
 
     Args:
         file_name (str): path to image file
@@ -47,9 +49,6 @@ def get_image(file_name):
     Returns:
         numpy.array: numpy array of image data
     """
-    ext = os.path.splitext(file_name.lower())[-1]
-    if ext == '.tif' or ext == '.tiff':
-        return np.float32(TiffFile(file_name).asarray())
     return np.float32(imread(file_name))
 
 

--- a/deepcell/utils/io_utils.py
+++ b/deepcell/utils/io_utils.py
@@ -32,8 +32,7 @@ from __future__ import division
 import os
 
 import numpy as np
-from skimage.io import imread
-from skimage.external import tifffile as tiff
+from skimage.io import imread, imsave
 from skimage.external.tifffile import TiffFile
 from tensorflow.keras import backend as K
 
@@ -105,5 +104,5 @@ def save_model_output(output,
                     cnnout_name = '{}_{}'.format(feature_name, cnnout_name)
 
                 out_file_path = os.path.join(output_dir, batch_dir, cnnout_name)
-                tiff.imsave(out_file_path, feature.astype('int32'))
+                imsave(out_file_path, feature.astype('int32'), check_contrast=False)
         print('Saved {} frames to {}'.format(output.shape[1], output_dir))

--- a/deepcell/utils/io_utils.py
+++ b/deepcell/utils/io_utils.py
@@ -39,7 +39,7 @@ from tensorflow.keras import backend as K
 
 def get_image(file_name):
     """DEPRECATED. Use ``skimage.io.imread`` instead.
-    
+
     Read image from file and returns it as a tensor.
 
     Args:

--- a/deepcell/utils/io_utils_test.py
+++ b/deepcell/utils/io_utils_test.py
@@ -33,9 +33,8 @@ import shutil
 
 import numpy as np
 from tensorflow.keras import backend as K
-from tensorflow.keras.preprocessing.image import array_to_img
 from tensorflow.python.platform import test
-from skimage.external import tifffile as tiff
+from skimage.io import imsave
 
 from deepcell.utils import io_utils
 
@@ -44,27 +43,27 @@ def _write_image(filepath, img_w=30, img_h=30):
     bias = np.random.rand(img_w, img_h, 1) * 64
     variance = np.random.rand(img_w, img_h, 1) * (255 - 64)
     imarray = np.random.rand(img_w, img_h, 1) * variance + bias
-    if filepath.lower().endswith('tif') or filepath.lower().endswith('tiff'):
-        tiff.imsave(filepath, imarray[:, :, 0])
-    else:
-        img = array_to_img(imarray, scale=False, data_format='channels_last')
-        img.save(filepath)
+    imsave(filepath, imarray[..., 0], check_contrast=False)
 
 
 class TestIOUtils(test.TestCase):
 
     def test_get_image(self):
+        image = 255 * np.random.random(size=(300, 300, 1)).astype('float32')
         temp_dir = self.get_temp_dir()
         # test tiff files
         test_img_path = os.path.join(temp_dir, 'phase.tif')
-        _write_image(test_img_path, 300, 300)
+        imsave(test_img_path, image, check_contrast=False)
         test_img = io_utils.get_image(test_img_path)
-        self.assertEqual(np.asarray(test_img).shape, (300, 300))
+        self.assertAllEqual(image, test_img)
         # test png files
+        # pngs are integer only and don't have a channel axis.
         test_img_path = os.path.join(temp_dir, 'feature_0.png')
-        _write_image(test_img_path, 400, 400)
+        image = image.astype('uint8')
+        imsave(test_img_path, image, check_contrast=False)
         test_img = io_utils.get_image(test_img_path)
-        self.assertEqual(np.asarray(test_img).shape, (400, 400))
+        test_img = np.expand_dims(test_img, axis=-1)
+        self.assertAllClose(image, test_img)
 
     def test_save_model_output(self):
         temp_dir = self.get_temp_dir()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.16.6,<1.20
 scipy>=1.2.3,<2
-scikit-image>=0.14.5,<0.17
+scikit-image>=0.14.5
 scikit-learn>=0.20.4,<1
 tensorflow==2.4.1
 jupyter>=1.0.0,<2

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     install_requires=[
         'numpy>=1.16.6,<1.20.0',
         'scipy>=1.2.3,<2',
-        'scikit-image>=0.14.5,<=0.17',
+        'scikit-image>=0.14.5',
         'scikit-learn>=0.20.4,<1',
         'tensorflow==2.4.1',
         'jupyter>=1.0.0,<2',


### PR DESCRIPTION
## What
* Updated `io_utils.py` to be compatible with new versions of `scikit-image`.

## Why
* `scikit-image` was previously pinned to `<17` which is several major versions behind.
