### PR TITLE
Patches for deepcell.applications

### DIFF
--- a/deepcell/applications/application.py
+++ b/deepcell/applications/application.py
@@ -217,7 +217,7 @@ class Application(object):
             # Restore channel dimension if not already there
             if len(image.shape) == self.required_rank - 1:
                 image = np.expand_dims(image, axis=-1)
-            
+
             self.logger.debug('Post-processed results with %s in %s s',
                               self.postprocessing_fn.__name__,
                               timeit.default_timer() - t)

--- a/deepcell/applications/application.py
+++ b/deepcell/applications/application.py
@@ -30,6 +30,7 @@ from __future__ import division
 from __future__ import print_function
 
 import logging
+import timeit
 
 import numpy as np
 

--- a/deepcell/applications/cytoplasm_segmentation.py
+++ b/deepcell/applications/cytoplasm_segmentation.py
@@ -31,13 +31,12 @@ from __future__ import print_function
 
 import os
 
-from tensorflow.keras.utils import get_file
+import tensorflow as tf
 
+from deepcell_toolbox.processing import normalize
 from deepcell_toolbox.deep_watershed import deep_watershed
-from deepcell_toolbox.processing import phase_preprocess
 
 from deepcell.applications import Application
-from deepcell.model_zoo import PanopticNet
 
 
 MODEL_PATH = ('https://deepcell-data.s3-us-west-1.amazonaws.com/'
@@ -84,9 +83,9 @@ class CytoplasmSegmentation(Application):
 
     #: Metadata for the model and training process
     model_metadata = {
-        'batch_size': 2,
+        'batch_size': 16,
         'lr': 1e-4,
-        'lr_decay': 0.95,
+        'lr_decay': 0.9,
         'training_seed': 0,
         'n_epochs': 8,
         'training_steps_per_epoch': 7899 // 2,

--- a/deepcell/applications/cytoplasm_segmentation_test.py
+++ b/deepcell/applications/cytoplasm_segmentation_test.py
@@ -32,6 +32,7 @@ from __future__ import print_function
 from tensorflow.python.platform import test
 import numpy as np
 
+from deepcell.model_zoo import PanopticNet
 from deepcell.applications import CytoplasmSegmentation
 
 

--- a/deepcell/applications/cytoplasm_segmentation_test.py
+++ b/deepcell/applications/cytoplasm_segmentation_test.py
@@ -39,7 +39,18 @@ class TestCytoplasmSegmentation(test.TestCase):
 
     def test_cytoplasm_app(self):
         with self.cached_session():
-            app = CytoplasmSegmentation(use_pretrained_weights=False)
+            model = PanopticNet(
+                'resnet50',
+                input_shape=(128, 128, 1),
+                norm_method='whole_image',
+                num_semantic_heads=2,
+                num_semantic_classes=[1, 1],
+                location=True,
+                include_top=True,
+                lite=True,
+                use_imagenet=False,
+                interpolation='bilinear')
+            app = NuclearSegmentation(model)
 
             # test output shape
             shape = app.model.output_shape

--- a/deepcell/applications/cytoplasm_segmentation_test.py
+++ b/deepcell/applications/cytoplasm_segmentation_test.py
@@ -51,7 +51,7 @@ class TestCytoplasmSegmentation(test.TestCase):
                 lite=True,
                 use_imagenet=False,
                 interpolation='bilinear')
-            app = NuclearSegmentation(model)
+            app = CytoplasmSegmentation(model)
 
             # test output shape
             shape = app.model.output_shape

--- a/deepcell/applications/nuclear_segmentation.py
+++ b/deepcell/applications/nuclear_segmentation.py
@@ -33,7 +33,7 @@ import os
 
 import tensorflow as tf
 
-from deepcell_toolbox.processing import histogram_normalization
+from deepcell_toolbox.processing import normalize
 from deepcell_toolbox.deep_watershed import deep_watershed
 
 from deepcell.applications import Application
@@ -107,7 +107,7 @@ class NuclearSegmentation(Application):
             model,
             model_image_shape=model.input_shape[1:],
             model_mpp=0.65,
-            preprocessing_fn=histogram_normalization,
+            preprocessing_fn=normalize,
             postprocessing_fn=deep_watershed,
             dataset_metadata=self.dataset_metadata,
             model_metadata=self.model_metadata)
@@ -149,9 +149,7 @@ class NuclearSegmentation(Application):
             numpy.array: Labeled image
         """
         if preprocess_kwargs is None:
-            preprocess_kwargs = {
-                'kernel_size': 64
-            }
+            preprocess_kwargs = {}
 
         if postprocess_kwargs is None:
             postprocess_kwargs = {


### PR DESCRIPTION
## What
* Add basic logging to the base class `Application`.
* Change the `NuclearSegmentation` preprocessing from `histogram_normalization` to `normalize`.
* Update the `CytoplasmSegmentation` to use a new TensorFlow 2 based model.

## Why
* Logging makes the pre and post-processing steps and performance more visible (for use in downstream applications like the `kiosk-redis-consumer`.
* The `NuclearSegmentation` model was trained with `histogram_normalization` but not on padded data. Because `Application._tile_input` pads all around the edge (zero-paddings by default) the performance of `histogram_normalization` is quantitatively worse than `normalize`. In future versions, we will train on zero-padded and reflection padded data which should resolve this inconsistency.
* The `CytoplasmSegmentation` model is not perfect but it is now a TensorFlow 2 SavedModel, which makes the model more portable and decoupled from the version of `deepcell` used to train the model.
