### PR TITLE
Update sed target to fix package name in deepcell-cpu deployment script.

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: Build a source distribution
       run: |
         sed -i "s/tensorflow/tensorflow-cpu/g" setup.py
-        sed -i -e "/NAME =/ s/= .*/= 'DeepCell-CPU'/" setup.py
+        sed -i -e "/__title__ =/ s/= .*/= 'DeepCell-CPU'/" deepcell/_version.py
         python setup.py sdist
 
     - name: Publish distribution 📦 to PyPI

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ docker run --gpus '"device=0"' -it --rm \
     -p 8888:8888 \
     -v $PWD/notebooks:/notebooks \
     -v $PWD/data:/data \
-    vanvalenlab/deepcell-tf:0.8.5-gpu
+    vanvalenlab/deepcell-tf:0.8.6-gpu
 ```
 
 This will spin up a docker container with `deepcell-tf` installed and start a jupyter session using the default port 8888. This command also mounts a data folder (`$PWD/data`) and a scripts folder (`$PWD/scripts`) to the docker container so it can access data and Juyter notebooks stored on the host workstation. For any saved data or models to persist once the container is shut down, or be accessible outside of the container in general, it must be saved in these mounted directories. The default port can be changed to any non-reserved port by updating `-p 8888:8888` to, e.g., `-p 8080:8888`. If you run across any errors getting started, you should either refer to the `deepcell-tf` for developers section or raise an issue on GitHub.

--- a/deepcell/_version.py
+++ b/deepcell/_version.py
@@ -27,7 +27,7 @@
 __title__ = 'DeepCell'
 __description__ = 'Deep learning for single cell image segmentation'
 __url__ = 'https://github.com/vanvalenlab/deepcell-tf'
-__version__ = '0.8.5'
+__version__ = '0.8.6'
 __download_url__ = '{}/tarball/{}'.format(__url__, __version__)
 __author__ = 'The Van Valen Lab'
 __author_email__ = 'vanvalen@caltech.edu'


### PR DESCRIPTION
## What
* Change the `sed` command in the `deploy-cpu` PyPI build stage.

## Why
* #482 changed the location of the package name from `setup.py` to `deepcell/_version.py` but did not change the deployment script, causing the PyPI release to fail.
