### PR TITLE
Update toolbox to 0.9.x and pin tracking to 0.3.x.

### DIFF
--- a/deepcell/_version.py
+++ b/deepcell/_version.py
@@ -27,7 +27,7 @@
 __title__ = 'DeepCell'
 __description__ = 'Deep learning for single cell image segmentation'
 __url__ = 'https://github.com/vanvalenlab/deepcell-tf'
-__version__ = '0.8.6'
+__version__ = '0.9.0'
 __download_url__ = '{}/tarball/{}'.format(__url__, __version__)
 __author__ = 'The Van Valen Lab'
 __author_email__ = 'vanvalen@caltech.edu'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ scikit-image>=0.14.5
 scikit-learn>=0.20.4
 tensorflow==2.4.1
 jupyter>=1.0.0,<2
-deepcell-tracking>=0.3.1
-deepcell-toolbox>=0.8.6
+deepcell-tracking>=0.3.1,<0.4.0
+deepcell-toolbox>=0.9.0,<0.10.0

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,8 @@ setup(
         'tensorflow==2.4.1',
         'jupyter>=1.0.0,<2',
         'opencv-python-headless<5',
-        'deepcell-tracking>=0.3.1',
-        'deepcell-toolbox>=0.8.6'
+        'deepcell-tracking>=0.3.1,0.4.0',
+        'deepcell-toolbox>=0.9.0,<0.10.0'
     ],
     extras_require={
         'tests': [


### PR DESCRIPTION
## What
* Update `deepcell` version to 0.9.0.
* Pin `deepcell-toolbox` to 0.9.x.
* Pin `deepcell-tracking` to 0.3.x.

## Why
* Update `deepcell-toolbox` to the latest version but prevent upgrading to future breaking changes.
