### PR TITLE
Fix typo setup.py deepcell-tracking version maximum.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,7 +10,6 @@ filterwarnings =
 
 # Do not run tests in the build folder
 norecursedirs=
-    .git,
     build,
     .ipynb_checkpoints,
     docs

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,6 +10,7 @@ filterwarnings =
 
 # Do not run tests in the build folder
 norecursedirs=
+    .git,
     build,
     .ipynb_checkpoints,
     docs

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'tensorflow==2.4.1',
         'jupyter>=1.0.0,<2',
         'opencv-python-headless<5',
-        'deepcell-tracking>=0.3.1,0.4.0',
+        'deepcell-tracking>=0.3.1,<0.4.0',
         'deepcell-toolbox>=0.9.0,<0.10.0'
     ],
     extras_require={


### PR DESCRIPTION
## What
* Added missing `<` character.

## Why
* Allow `pypi` to read `setup.py`.
