### PR TITLE
InferenceTimer callback to measure inference time during training.

### DIFF
--- a/deepcell/callbacks.py
+++ b/deepcell/callbacks.py
@@ -31,6 +31,8 @@ from __future__ import division
 
 import timeit
 
+import numpy as np
+
 import tensorflow as tf
 from tensorflow.keras import backend as K
 
@@ -58,5 +60,5 @@ class InferenceTimer(tf.keras.callbacks.Callback):
     def on_epoch_end(self, epoch, logs=None):
         avg = np.mean(self._batch_times)
         std = np.std(self._batch_times)
-        print('Finished epoch {} with an average speed of {}s ± {}s.'.format(
-            epoch, avg, std))
+        print('Epoch %05d: average batch inference speed: %0.5fs ± %0.5fs.' %
+              (epoch + 1, avg, std))

--- a/deepcell/callbacks.py
+++ b/deepcell/callbacks.py
@@ -38,9 +38,8 @@ from tensorflow.keras import backend as K
 class InferenceTimer(tf.keras.callbacks.Callback):
     """Callback to log inference speed per epoch."""
 
-    def __init__(self, batch_size):
+    def __init__(self):
         super(InferenceTimer, self).__init__()
-        self.batch_size = int(batch_size)
         self._batch_times = []
         self._timer = None
         # best_weights to store the weights at which the minimum loss occurs.

--- a/deepcell/callbacks.py
+++ b/deepcell/callbacks.py
@@ -69,6 +69,6 @@ class InferenceTimer(tf.keras.callbacks.Callback):
               (self._samples_seen, avg, std))
 
     def on_epoch_end(self, epoch, logs=None):
-        shape = tuple([samples] + list(self.model.input_shape[1:]))
+        shape = tuple([self._samples] + list(self.model.input_shape[1:]))
         test_batch = np.random.random(shape)
         self.model.predict(test_batch, callbacks=self, batch_size=batch_size)

--- a/deepcell/callbacks.py
+++ b/deepcell/callbacks.py
@@ -65,8 +65,9 @@ class InferenceTimer(tf.keras.callbacks.Callback):
     def on_predict_end(self, logs=None):
         avg = np.mean(self._batch_times)
         std = np.std(self._batch_times)
-        print('Average inference speed for %s samples: %0.5fs ± %0.5fs.' %
-              (self._samples_seen, avg, std))
+        print('Average inference speed per batch for %s batches '
+              '(%s samples total): %0.5fs ± %0.5fs.' %
+              (len(self._batch_times), self._samples_seen, avg, std))
 
     def on_epoch_end(self, epoch, logs=None):
         shape = tuple([self._samples] + list(self.model.input_shape[1:]))

--- a/deepcell/callbacks.py
+++ b/deepcell/callbacks.py
@@ -71,4 +71,4 @@ class InferenceTimer(tf.keras.callbacks.Callback):
     def on_epoch_end(self, epoch, logs=None):
         shape = tuple([self._samples] + list(self.model.input_shape[1:]))
         test_batch = np.random.random(shape)
-        self.model.predict(test_batch, callbacks=self, batch_size=batch_size)
+        self.model.predict(test_batch, callbacks=self)

--- a/deepcell/callbacks.py
+++ b/deepcell/callbacks.py
@@ -59,4 +59,4 @@ class InferenceTimer(tf.keras.callbacks.Callback):
         avg = np.mean(self._batch_times)
         std = np.std(self._batch_times)
         print('Finished epoch {} with an average speed of {}s ± {}s.'.format(
-            epoch, avg, std)
+            epoch, avg, std))

--- a/deepcell/callbacks_test.py
+++ b/deepcell/callbacks_test.py
@@ -1,0 +1,64 @@
+# Copyright 2016-2021 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/deepcell-tf/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Custom Callbacks for DeepCell"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+
+import sys
+
+import tensorflow as tf
+from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.keras import testing_utils
+from tensorflow.python.framework import test_util as tf_test_util
+
+from deepcell import callbacks
+
+
+class TestInferenceTimer(keras_parameterized.TestCase):
+    """Callback to log inference speed per epoch."""
+
+    @keras_parameterized.run_all_keras_modes
+    def test_inference_time_logging(self):
+        model = tf.keras.models.Sequential()
+        model.add(tf.keras.layers.Dense(1))
+        model.compile(
+            'sgd',
+            loss='mse',
+            run_eagerly=testing_utils.should_run_eagerly())
+
+        x = tf.ones((200, 3))
+        y = tf.zeros((200, 2))
+        dataset = tf.data.Dataset.from_tensor_slices((x, y)).batch(10)
+        expected_log = r'(.*Average inference.*)+'
+
+        cbks = [callbacks.InferenceTimer()]
+
+        with self.captureWritesToStream(sys.stdout) as printed:
+            y = model.call(x)
+            model.fit(dataset, epochs=2, steps_per_epoch=10, callbacks=cbks)
+            self.assertRegex(printed.contents(), expected_log)


### PR DESCRIPTION
## What
* Add new `InferenceTimer` callback to measure inference time for a pre-defined number of samples:

```
Average inference speed per sample for 100 total samples: 0.00204s ± 0.00158s.
```

## Why
* Fixes #275 
