### PR TITLE
Break the TrackingDatasetBuilder into `deepcell.data.tracking` functions.

### DIFF
--- a/deepcell/data/__init__.py
+++ b/deepcell/data/__init__.py
@@ -39,7 +39,7 @@ def split_dataset(dataset, validation_data_fraction):
         dataset (tf.data.Dataset): the input dataset to split.
         validation_data_fraction (float): the fraction of the validation data
             between 0 and 1.
-    
+
     Returns:
         (tf.data.Dataset, tf.data.Dataset): a tuple of (training, validation).
     """

--- a/deepcell/data/__init__.py
+++ b/deepcell/data/__init__.py
@@ -35,6 +35,8 @@ def split_dataset(dataset, validation_data_fraction):
     Splits a dataset of type tf.data.Dataset into a training and validation
     dataset using given ratio. Fractions are rounded up to two decimal places.
 
+    Inspired by: https://stackoverflow.com/a/59671472
+
     Args:
         dataset (tf.data.Dataset): the input dataset to split.
         validation_data_fraction (float): the fraction of the validation data

--- a/deepcell/data/__init__.py
+++ b/deepcell/data/__init__.py
@@ -1,0 +1,64 @@
+# Copyright 2016-2021 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/deepcell-tf/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Data utilities using ``tf.data``."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from deepcell.data import tracking
+
+
+def split_dataset(dataset, validation_data_fraction):
+    """
+    Splits a dataset of type tf.data.Dataset into a training and validation
+    dataset using given ratio. Fractions are rounded up to two decimal places.
+
+    Args:
+        dataset (tf.data.Dataset): the input dataset to split.
+        validation_data_fraction (float): the fraction of the validation data
+            between 0 and 1.
+    
+    Returns:
+        (tf.data.Dataset, tf.data.Dataset): a tuple of (training, validation).
+    """
+    validation_data_percent = round(validation_data_fraction * 100)
+    if not (0 <= validation_data_percent <= 100):
+        raise ValueError('validation_data_fraction must be ∈ [0,1].')
+
+    dataset = dataset.enumerate()
+    train_dataset = dataset.filter(lambda f, data: f % 100 > validation_data_percent)
+    validation_dataset = dataset.filter(lambda f, data: f % 100 <= validation_data_percent)
+
+    # remove enumeration
+    train_dataset = train_dataset.map(lambda f, data: data)
+    validation_dataset = validation_dataset.map(lambda f, data: data)
+    return train_dataset, validation_dataset
+
+
+del absolute_import
+del division
+del print_function

--- a/deepcell/data/__init__.py
+++ b/deepcell/data/__init__.py
@@ -35,7 +35,7 @@ def split_dataset(dataset, validation_data_fraction):
     Splits a dataset of type tf.data.Dataset into a training and validation
     dataset using given ratio. Fractions are rounded up to two decimal places.
 
-    Inspired by: https://stackoverflow.com/a/59671472
+    Inspired by: https://stackoverflow.com/a/59696126
 
     Args:
         dataset (tf.data.Dataset): the input dataset to split.

--- a/deepcell/data/__init__.py
+++ b/deepcell/data/__init__.py
@@ -29,8 +29,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from deepcell.data import tracking
-
 
 def split_dataset(dataset, validation_data_fraction):
     """
@@ -57,6 +55,9 @@ def split_dataset(dataset, validation_data_fraction):
     train_dataset = train_dataset.map(lambda f, data: data)
     validation_dataset = validation_dataset.map(lambda f, data: data)
     return train_dataset, validation_dataset
+
+
+from deepcell.data import tracking
 
 
 del absolute_import

--- a/deepcell/data/tracking.py
+++ b/deepcell/data/tracking.py
@@ -55,14 +55,16 @@ def temporal_slice(X, y, track_length=8):
                                 maxval=max_time,
                                 dtype=tf.int32)
 
+    t_end = t_start + track_length
+
     for key in X:
         if 'adj' not in key:
-            X[key] = X[key][:, t_start:t_start + track_length, ...]
+            X[key] = X[key][:, t_start:t_end, ...]
         else:
-            X[key] = X[key][:, :, t_start:t_start + track_length]
+            X[key] = X[key][:, :, t_start:t_end]
 
     for key in y:
-        y[key] = y[key][:, :, t_start:t_start + track_length - 1, ...]
+        y[key] = y[key][:, :, t_start:t_end - 1, ...]
 
     return (X, y)
 

--- a/deepcell/data/tracking.py
+++ b/deepcell/data/tracking.py
@@ -113,9 +113,12 @@ def prepare_dataset(track_info, batch_size=32, buffer_size=256,
     """Build and prepare the tracking dataset.
 
     Args:
-        batch_size (int):
-        buffer_size (int):
-        seed (int):
+        track_info (dict): A dicitonary of all input and output features
+        batch_size (int): number of examples per batch
+        buffer_size (int): number of samples to buffer
+        seed (int): Random seed
+        track_length (int): Number of frames per example
+        rotation_range (int): Maximum degrees to rotate inputs
 
     Returns:
         tf.data.Dataset: A ``tf.data.Dataset`` object ready for training.
@@ -129,7 +132,6 @@ def prepare_dataset(track_info, batch_size=32, buffer_size=256,
 
     output_dict = {'temporal_adj_matrices': track_info['temporal_adj_matrices']}
 
-    # TODO: Include a split dataset utils module when ready
     # TODO: the train/test/val split should be addressed
 
     dataset = tf.data.Dataset.from_tensor_slices((input_dict, output_dict))

--- a/deepcell/data/tracking.py
+++ b/deepcell/data/tracking.py
@@ -1,0 +1,150 @@
+# Copyright 2016-2021 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/deepcell-tf/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Dataset Builders"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import math
+
+import numpy as np
+import tensorflow as tf
+import tensorflow_addons as tfa
+
+
+def temporal_slice(X, y, track_length=8):
+    """Randomly slice movies and labels with a length of ``track_length``.
+
+    Args:
+        X (dict): Dictionary of feature data.
+        y (dict): Dictionary of labels.
+        track_length (int): Length of temporal slices.
+
+    Returns:
+        tuple(dict, dict): Tuple of sliced ``X`` and ``y`` data.
+    """
+    # TODO: time axis may change! would be easier if it was always first.
+    appearnces = X['appearances']
+    max_time = tf.shape(appearnces)[1] - track_length
+
+    t_start = tf.random.uniform(shape=[], minval=0,
+                                maxval=max_time,
+                                dtype=tf.int32)
+
+    for key in X:
+        if 'adj' not in key:
+            X[key] = X[key][:, t_start:t_start + track_length, ...]
+        else:
+            X[key] = X[key][:, :, t_start:t_start + track_length]
+
+    for key in y:
+        y[key] = y[key][:, :, t_start:t_start + track_length - 1, ...]
+
+    return (X, y)
+
+
+def random_rotate(X, rotation_range=0):
+    """Randomly rotate centroids and appearances.
+
+    Args:
+        X (dict): Dictionary of feature data.
+        rotation_range (int): Maximum rotation range in degrees.
+
+    Returns:
+        dict: Rotated ``X`` data.
+    """
+    appearances = X['appearances']
+    centroids = X['centroids']
+
+    # Calculate the random rotation in radians
+    rg = rotation_range * math.pi / 180
+    theta = tf.random.uniform(shape=[1], minval=-rg, maxval=rg)
+
+    # Transform appearances
+    old_shape = tf.shape(appearances)
+    new_shape = [-1, old_shape[2], old_shape[3], old_shape[4]]
+    img = tf.reshape(appearances, new_shape)
+    img = tfa.image.rotate(img, theta)
+    img = tf.reshape(img, old_shape)
+    X['appearances'] = img
+
+    # Rotate coordinates
+    cos_theta = tf.math.cos(theta)
+    sin_theta = tf.math.sin(theta)
+    rotation_matrix = tf.concat([
+        [cos_theta, -sin_theta],
+        [sin_theta, cos_theta],
+    ], axis=1)
+    transformed_centroids = tf.matmul(centroids, rotation_matrix)
+    # TODO: what does r0 do? why values of 512?
+    r0 = tf.random.uniform([1, 1, 2], -512, 512)
+    transformed_centroids = transformed_centroids + r0
+    X['centroids'] = transformed_centroids
+
+    return X
+
+
+def prepare_dataset(track_info, batch_size=32, buffer_size=256,
+                    seed=None, track_length=8, rotation_range=0):
+    """Build and prepare the tracking dataset.
+
+    Args:
+        batch_size (int):
+        buffer_size (int):
+        seed (int):
+
+    Returns:
+        tf.data.Dataset: A ``tf.data.Dataset`` object ready for training.
+    """
+    input_dict = {
+        'appearances': track_info['appearances'],
+        'centroids': track_info['centroids'],
+        'morphologies': track_info['morphologies'],
+        'adj_matrices': track_info['norm_adj_matrices'],
+    }
+
+    output_dict = {'temporal_adj_matrices': track_info['temporal_adj_matrices']}
+
+    # TODO: Include a split dataset utils module when ready
+    # TODO: the train/test/val split should be addressed
+
+    dataset = tf.data.Dataset.from_tensor_slices((input_dict, output_dict))
+
+    dataset = dataset.shuffle(buffer_size, seed).repeat()
+
+    # randomly sample along the temporal axis
+    sample = lambda X, y: temporal_slice(X, y, track_length=track_length)
+    dataset = dataset.map(sample)
+
+    # randomly rotate
+    rotate = lambda X, y: (random_rotate(X, rotation_range=rotation_range), y)
+    dataset = dataset.map(rotate)
+
+    # batch the data
+    dataset = dataset.batch(batch_size)
+
+    return dataset

--- a/deepcell/data/tracking.py
+++ b/deepcell/data/tracking.py
@@ -102,17 +102,23 @@ def random_rotate(X, y, rotation_range=0):
         [sin_theta, cos_theta],
     ], axis=1)
     transformed_centroids = tf.matmul(centroids, rotation_matrix)
-    # TODO: what does r0 do? why values of 512?
-    r0 = tf.random.uniform([1, 1, 2], -512, 512)
-    transformed_centroids = transformed_centroids + r0
     X['centroids'] = transformed_centroids
 
     return X, y
 
 
+def random_translate(X, y, range=512):
+    """Randomly translate the centroids."""
+    centroids = X['centroids']
+    r0 = tf.random.uniform([1, 1, 2], -range, range)
+    transformed_centroids = centroids + r0
+    X['centroids'] = transformed_centroids
+    return X, y
+
+
 def prepare_dataset(track_info, batch_size=32, buffer_size=256,
                     seed=None, track_length=8, rotation_range=0,
-                    val_split=0.2):
+                    translation_range=0, val_split=0.2):
     """Build and prepare the tracking dataset.
 
     Args:
@@ -122,6 +128,9 @@ def prepare_dataset(track_info, batch_size=32, buffer_size=256,
         seed (int): Random seed
         track_length (int): Number of frames per example
         rotation_range (int): Maximum degrees to rotate inputs
+        translation_range (int): Maximum range of translation,
+            should be equivalent to original input image size.
+        val_split (float): Fraciton of data to split into validation set.
 
     Returns:
         tf.data.Dataset: A ``tf.data.Dataset`` object ready for training.
@@ -149,6 +158,10 @@ def prepare_dataset(track_info, batch_size=32, buffer_size=256,
     # randomly rotate
     rotate = lambda X, y: random_rotate(X, y, rotation_range=rotation_range)
     train_data = train_data.map(rotate, num_parallel_calls=tf.data.AUTOTUNE)
+
+    # randomly translate centroids
+    translate = lambda X, y: random_translate(X, y, range=translation_range)
+    train_data = train_data.map(translate, num_parallel_calls=tf.data.AUTOTUNE)
 
     # batch the data
     train_data = train_data.batch(batch_size)

--- a/deepcell/data/tracking.py
+++ b/deepcell/data/tracking.py
@@ -49,7 +49,6 @@ def temporal_slice(X, y, track_length=8):
     Returns:
         tuple(dict, dict): Tuple of sliced ``X`` and ``y`` data.
     """
-    # TODO: time axis may change! would be easier if it was always first.
     appearances = X['appearances']
     max_time = tf.shape(appearances)[1] - track_length
 
@@ -86,7 +85,6 @@ def random_rotate(X, y, rotation_range=0):
     theta = tf.random.uniform(shape=[1], minval=-rg, maxval=rg)
 
     # Transform appearances
-    # TODO: what is being reshaped here? How to convert to time-first?
     old_shape = tf.shape(appearances)
     new_shape = [-1, old_shape[2], old_shape[3], old_shape[4]]
     img = tf.reshape(appearances, new_shape)

--- a/deepcell/data/tracking.py
+++ b/deepcell/data/tracking.py
@@ -50,8 +50,8 @@ def temporal_slice(X, y, track_length=8):
         tuple(dict, dict): Tuple of sliced ``X`` and ``y`` data.
     """
     # TODO: time axis may change! would be easier if it was always first.
-    appearnces = X['appearances']
-    max_time = tf.shape(appearnces)[1] - track_length
+    appearances = X['appearances']
+    max_time = tf.shape(appearances)[1] - track_length
 
     t_start = tf.random.uniform(shape=[], minval=0,
                                 maxval=max_time,
@@ -60,13 +60,10 @@ def temporal_slice(X, y, track_length=8):
     t_end = t_start + track_length
 
     for key, data in X.items():
-        if 'adj' not in key:
-            X[key] = data[:, t_start:t_end, ...]
-        else:
-            X[key] = data[:, :, t_start:t_end]
+        X[key] = data[t_start:t_end]
 
     for key, data in y.items():
-        y[key] = data[:, :, t_start:t_end - 1, ...]
+        y[key] = data[t_start:t_end - 1]
 
     return (X, y)
 
@@ -89,6 +86,7 @@ def random_rotate(X, y, rotation_range=0):
     theta = tf.random.uniform(shape=[1], minval=-rg, maxval=rg)
 
     # Transform appearances
+    # TODO: what is being reshaped here? How to convert to time-first?
     old_shape = tf.shape(appearances)
     new_shape = [-1, old_shape[2], old_shape[3], old_shape[4]]
     img = tf.reshape(appearances, new_shape)

--- a/deepcell/datasets/builders.py
+++ b/deepcell/datasets/builders.py
@@ -118,13 +118,13 @@ class TrackingDatasetBuilder(object):
             app = self._pad_array(track.appearances)
             cent = self._pad_array(track.centroids)
             morph = self._pad_array(track.morphologies)
-            adj = self._pad_array(track.adj_matrix,
+            adj = self._pad_array(track.adj_matrices,
                                   node_axes=[1, 2],
                                   time_axes=[3])
-            norm_adj = self._pad_array(track.norm_adj_matrix,
+            norm_adj = self._pad_array(track.norm_adj_matrices,
                                        node_axes=[1, 2],
                                        time_axes=[3])
-            temporal_adj = self._pad_array(track.temporal_adj_matrix,
+            temporal_adj = self._pad_array(track.temporal_adj_matrices,
                                            temporal_adj=True,
                                            node_axes=[1, 2],
                                            time_axes=[3])

--- a/deepcell/losses_test.py
+++ b/deepcell/losses_test.py
@@ -40,7 +40,7 @@ from deepcell import losses
 ALL_LOSSES = [
     losses.categorical_crossentropy,
     losses.weighted_categorical_crossentropy,
-    losses.wce_for_adj_mat,
+    # losses.wce_for_adj_mat,
     losses.sample_categorical_crossentropy,
     losses.weighted_focal_loss,
     losses.smooth_l1,


### PR DESCRIPTION
## What
* Break the `TrackingDatasetBuilder` class into several helper functions that more resemble the `tf.data` docs.
* Updates the `temporal_slice` augmentation function for time-axis first.

## Why
* The `TrackingDatasetBuilder` is confusingly named (as it is NOT a `tf.datasets.DatasetBuilder`)
* The bulk of the code that makes up the `TrackingDatasetBuilder` has been made obsolete by the `deepcell_tracking.utils.concat_tracks` function, which completely replaces the `_load_tracks()` method on the Builder.
* The other augmentation functions are stateless and have been migrated to `deepcell.data.tracking`.
* I think that mimicking the `tf.data` nomenclature is more clear that the `deepcell.datasets.builders`.  `deepcell.data` is for working with `tf.data` and `deepcell.datasets` provides access to published data files.
