### PR TITLE
Refactor GNNTrackingModel for time-axis first data. 

### DIFF
--- a/deepcell/data/tracking.py
+++ b/deepcell/data/tracking.py
@@ -118,7 +118,7 @@ def random_translate(X, y, range=512):
 
 def prepare_dataset(track_info, batch_size=32, buffer_size=256,
                     seed=None, track_length=8, rotation_range=0,
-                    translation_range=512, val_split=0.2):
+                    translation_range=0, val_split=0.2):
     """Build and prepare the tracking dataset.
 
     Args:

--- a/deepcell/losses.py
+++ b/deepcell/losses.py
@@ -128,7 +128,7 @@ def wce_for_adj_mat(y_true, y_pred):
     y_pred = tf.reshape(y_pred, new_shape)
 
     # Mask out the padded cells
-    good_loc = tf.reshape(tf.where(K.not_equal(y_true, -1)), (-1,))
+    good_loc = tf.where(K.not_equal(y_true[:, 0], -1))[:, 0]
 
     y_true = tf.gather(y_true, good_loc, axis=0)
     y_pred = tf.gather(y_pred, good_loc, axis=0)

--- a/deepcell/losses.py
+++ b/deepcell/losses.py
@@ -128,7 +128,7 @@ def wce_for_adj_mat(y_true, y_pred):
     y_pred = tf.reshape(y_pred, new_shape)
 
     # Mask out the padded cells
-    good_loc = tf.where(y_true != -1)
+    good_loc = tf.reshape(tf.where(K.not_equal(y_true, -1)), (-1,))
 
     y_true = tf.gather(y_true, good_loc, axis=0)
     y_pred = tf.gather(y_pred, good_loc, axis=0)

--- a/deepcell/losses.py
+++ b/deepcell/losses.py
@@ -123,7 +123,7 @@ def wce_for_adj_mat(y_true, y_pred):
     y_true = K.cast(y_true, y_pred.dtype)
 
     n_classes = tf.shape(y_true)[-1]
-    new_shape = [-1, n_classes]
+    new_shape = (-1, n_classes)
     y_true = tf.reshape(y_true, new_shape)
     y_pred = tf.reshape(y_pred, new_shape)
 
@@ -133,13 +133,10 @@ def wce_for_adj_mat(y_true, y_pred):
     y_true = tf.gather(y_true, good_loc, axis=0)
     y_pred = tf.gather(y_pred, good_loc, axis=0)
 
-    # Manual computation of crossentropy (change to match above)
-    _epsilon = tf.convert_to_tensor(K.epsilon(), y_pred.dtype.base_dtype)
-    y_pred = tf.clip_by_value(y_pred, _epsilon, 1. - _epsilon)
-    total_sum = K.sum(y_true)
-    class_sum = K.sum(y_true, axis=0, keepdims=True)
-    class_weights = 1.0 / K.cast_to_floatx(n_classes) * tf.divide(total_sum, class_sum + 1e-5)
-    return - K.sum((y_true * K.log(y_pred) * class_weights), axis=-1)
+    return weighted_categorical_crossentropy(
+        y_true, y_pred,
+        n_classes=n_classes,
+        axis=1)
 
 
 def sample_categorical_crossentropy(y_true,

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -494,7 +494,7 @@ class GNNTrackingModel(object):
         new_adj_shape = [-1, self.adj_shape[1], self.adj_shape[2]]
         reshaped_adj_input = Lambda(lambda t: tf.reshape(t, new_adj_shape),
                                     name='reshaped_adj_matrices')(adj_input)
-        
+
         reshaped_inputs = [
             reshaped_app_input,
             reshaped_morph_input,

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -548,7 +548,9 @@ class GNNTrackingModel(object):
                                  name='future_embeddings')
         future_centroids = Input(shape=(1, None, self.centroid_shape[-1]),
                                  name='future_centroids')
-        inputs = [current_embedding, current_centroids, future_embedding, future_centroids]
+
+        inputs = [current_embedding, current_centroids,
+                  future_embedding, future_centroids]
 
         # Embeddings - Integrate temporal information
         x_current = self.embedding_temporal_merge_model(current_embedding)

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -642,7 +642,6 @@ class GNNTrackingModel(object):
         inference_inputs = self.inference_branch.input
 
         # Apply decoder
-        # tracking_decoder = TrackingDecoder()
         training_output = self.tracking_decoder(self.training_branch.output)
         inference_output = self.tracking_decoder(self.inference_branch.output)
 

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -594,13 +594,13 @@ class GNNTrackingModel(object):
 
         # Centroids - Get deltas across frames
         centroid_current_end = Lambda(lambda t: t[:, -1:])(current_centroids)
-        centroid_current_end = Lambda(lambda t: tf.expand_dims(t, 2))(centroid_current_end)
-        centroid_future = Lambda(lambda t: tf.expand_dims(t, 1))(future_centroids)
+        centroid_current_end = Lambda(lambda t: tf.expand_dims(t, 3))(centroid_current_end)
+        centroid_future = Lambda(lambda t: tf.expand_dims(t, 2))(future_centroids)
         deltas_future = Subtract()([centroid_future, centroid_current_end])
         deltas_future = Activation(tf.math.abs, name='act_df_ib')(deltas_future)
         deltas_future = self.delta_across_frames_encoder(deltas_future)
 
-        deltas_current = Lambda(lambda t: tf.expand_dims(t, 2))(deltas_current)
+        deltas_current = Lambda(lambda t: tf.expand_dims(t, 1))(deltas_current)
         deltas_current = Lambda(self._delta_reshape,
                                 name='delta_reshape')([deltas_current, future_centroids])
 

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -350,35 +350,19 @@ class GNNTrackingModel(object):
         inputs = [app_input, morph_input, centroid_input, adj_input]
 
         # Merge batch and temporal dimensions
-        new_app_shape = [-1,
-                         self.appearance_shape[1],
-                         self.appearance_shape[2],
-                         self.appearance_shape[3],
-                         self.appearance_shape[4]]
-        # transposed_app_input = Lambda(lambda t: tf.transpose(t,
-        #                                                      perm=(0, 2, 1, 3, 4, 5)))(app_input)
+        new_app_shape = tuple([-1] + list(self.appearance_shape)[1:])
         reshaped_app_input = Lambda(lambda t: tf.reshape(t, new_app_shape),
                                     name='reshaped_appearances')(app_input)
 
-        new_morph_shape = [-1,
-                           self.morphology_shape[1],
-                           self.morphology_shape[2]]
-        # transposed_morph_input = Lambda(lambda t: tf.transpose(t, perm=(0, 2, 1, 3)))(morph_input)
+        new_morph_shape = tuple([-1] + list(self.morphology_shape)[1:])
         reshaped_morph_input = Lambda(lambda t: tf.reshape(t, new_morph_shape),
                                       name='reshaped_morphologies')(morph_input)
 
-        new_centroid_shape = [-1,
-                              self.centroid_shape[1],
-                              self.centroid_shape[2]]
-        # transposed_cent_input = Lambda(lambda t: tf.transpose(t,
-        #                                                       perm=(0, 2, 1, 3)))(centroid_input)
+        new_centroid_shape = tuple([-1] + list(self.centroid_shape)[1:])
         reshaped_centroid_input = Lambda(lambda t: tf.reshape(t, new_centroid_shape),
                                          name='reshaped_centroids')(centroid_input)
 
-        new_adj_shape = [-1,
-                         self.adj_shape[1],
-                         self.adj_shape[2]]
-        # transposed_adj_input = Lambda(lambda t: tf.transpose(t, perm=(0, 3, 1, 2)))(adj_input)
+        new_adj_shape = [-1, self.adj_shape[1], self.adj_shape[2]]
         reshaped_adj_input = Lambda(lambda t: tf.reshape(t, new_adj_shape),
                                     name='reshaped_adj_matrices')(adj_input)
 
@@ -390,10 +374,7 @@ class GNNTrackingModel(object):
         return Model(inputs=inputs, outputs=outputs)
 
     def get_appearance_encoder(self):
-        app_shape = [None,
-                     self.appearance_shape[2],
-                     self.appearance_shape[3],
-                     self.appearance_shape[4]]
+        app_shape = tuple([None] + list(self.appearance_shape)[2:])
         inputs = Input(shape=app_shape, name='encoder_app_input')
 
         x = inputs
@@ -416,7 +397,7 @@ class GNNTrackingModel(object):
         return Model(inputs=inputs, outputs=x)
 
     def get_morphology_encoder(self):
-        morph_shape = [None, self.morphology_shape[2]]
+        morph_shape = (None, self.morphology_shape[-1])
         inputs = Input(shape=morph_shape, name='encoder_morph_input')
         x = inputs
         x = Dense(self.encoder_dim, name='dense_me')(x)
@@ -425,7 +406,7 @@ class GNNTrackingModel(object):
         return Model(inputs=inputs, outputs=x)
 
     def get_centroid_encoder(self):
-        centroid_shape = [None, self.centroid_shape[2]]
+        centroid_shape = (None, self.centroid_shape[-1])
         inputs = Input(shape=centroid_shape, name='encoder_centroid_input')
         x = inputs
         x = Dense(self.encoder_dim, name='dense_ce')(x)

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -294,7 +294,7 @@ class GNNTrackingModel(object):
 
         elif merge_type == 'cnn':
             x = inputs
-            x = Conv2D(self.encoder_dim, (1, self.time_window),
+            x = Conv2D(self.encoder_dim, (self.time_window, 1),
                        padding='SAME', name='conv2d_tm')(x)
             x = BatchNormalization(axis=-1, name='bn_tm')(x)
             x = Activation('relu', name='relu_tm')(x)
@@ -317,7 +317,7 @@ class GNNTrackingModel(object):
 
         elif merge_type == 'cnn':
             x = inputs
-            x = Conv2D(self.encoder_dim, (1, self.time_window),
+            x = Conv2D(self.encoder_dim, (self.time_window, 1),
                        padding='SAME', name='conv2d_delta')(x)
             x = BatchNormalization(axis=-1, name='bn_delta')(x)
             x = Activation('relu', name='relu_delta')(x)

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -485,7 +485,7 @@ class GNNTrackingModel(object):
 
         new_morph_shape = tuple([-1] + list(self.morphology_shape)[1:])
         reshaped_morph_input = Lambda(lambda t: tf.reshape(t, new_morph_shape),
-                                      name='reshaped_{}')(morph_input)
+                                      name='reshaped_morphologies')(morph_input)
 
         new_centroid_shape = tuple([-1] + list(self.centroid_shape)[1:])
         reshaped_centroid_input = Lambda(lambda t: tf.reshape(t, new_centroid_shape),

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -330,13 +330,11 @@ class GNNTrackingModel(object):
     def _unmerge_embeddings(self, x):
         new_shape = [-1, self.track_length, self.appearance_shape[1], self.embedding_dim]
         new_x = tf.reshape(x, new_shape)
-        # new_x = tf.transpose(new_x, perm=(0, 2, 1, 3))
         return new_x
 
     def _unmerge_centroids(self, x):
         new_shape = [-1, self.track_length, self.centroid_shape[1], self.centroid_shape[2]]
         new_x = tf.reshape(x, new_shape)
-        # new_x = tf.transpose(new_x, perm=(0, 2, 1, 3))
         return new_x
 
     def get_appearance_encoder(self):

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -526,7 +526,7 @@ class GNNTrackingModel(object):
 
         deltas_current = Lambda(lambda t: t[:, 0:-1])(deltas_current)
         deltas_current = self.delta_temporal_merge_model(deltas_current)
-        deltas_current = Lambda(lambda t: tf.expand_dims(t, 2))(deltas_current)
+        deltas_current = Lambda(lambda t: tf.expand_dims(t, 3))(deltas_current)
         multiples = [1, 1, self.centroid_shape[1], 1, 1]
         deltas_current = Lambda(lambda t: tf.tile(t, multiples))(deltas_current)
 

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -533,7 +533,7 @@ class GNNTrackingModel(object):
         deltas_current = Lambda(lambda t: t[:, 0:-1])(deltas_current)
         deltas_current = self.delta_temporal_merge_model(deltas_current)
         deltas_current = Lambda(lambda t: tf.expand_dims(t, 3))(deltas_current)
-        multiples = [1, 1, self.centroid_shape[1], 1, 1]
+        multiples = [1, 1, 1, self.centroid_shape[1], 1]
         deltas_current = Lambda(lambda t: tf.tile(t, multiples))(deltas_current)
 
         deltas = Concatenate(axis=-1)([deltas_current, deltas_future])


### PR DESCRIPTION
## What
* Update several layers for using (batch, time, node, channels) as input data rather than (batch, node, time, channels).
* Updated the loss to have the expected output shape.
* Pull out some methods as custom classes `Comparison` and `DeltaReshape`.

## Why
* The time axis is required to be first to avoid data leaks in the reshapes (for the neighborhood encoder).
* Using custom layers prevents the need for loading a model with `custom_objects`.
