### PR TITLE
Allow preprocessing_fn and postprocessing_fn to be overridden.

### DIFF
--- a/deepcell/applications/cytoplasm_segmentation.py
+++ b/deepcell/applications/cytoplasm_segmentation.py
@@ -92,7 +92,9 @@ class CytoplasmSegmentation(Application):
         'validation_steps_per_epoch': 1973 // 2
     }
 
-    def __init__(self, model=None):
+    def __init__(self, model=None,
+                 preprocessing_fn=normalize,
+                 postprocessing_fn=deep_watershed):
 
         if model is None:
             archive_path = tf.keras.utils.get_file(
@@ -107,8 +109,8 @@ class CytoplasmSegmentation(Application):
             model,
             model_image_shape=model.input_shape[1:],
             model_mpp=0.65,
-            preprocessing_fn=normalize,
-            postprocessing_fn=deep_watershed,
+            preprocessing_fn=preprocessing_fn,
+            postprocessing_fn=postprocessing_fn,
             dataset_metadata=self.dataset_metadata,
             model_metadata=self.model_metadata)
 

--- a/deepcell/applications/nuclear_segmentation.py
+++ b/deepcell/applications/nuclear_segmentation.py
@@ -92,7 +92,9 @@ class NuclearSegmentation(Application):
         'validation_steps_per_epoch': 15627
     }
 
-    def __init__(self, model=None):
+    def __init__(self, model=None,
+                 preprocessing_fn=normalize,
+                 postprocessing_fn=deep_watershed):
 
         if model is None:
             archive_path = tf.keras.utils.get_file(
@@ -107,8 +109,8 @@ class NuclearSegmentation(Application):
             model,
             model_image_shape=model.input_shape[1:],
             model_mpp=0.65,
-            preprocessing_fn=normalize,
-            postprocessing_fn=deep_watershed,
+            preprocessing_fn=preprocessing_fn,
+            postprocessing_fn=postprocessing_fn,
             dataset_metadata=self.dataset_metadata,
             model_metadata=self.model_metadata)
 


### PR DESCRIPTION
## What
* Set `preprocessing_fn` and `postprocessing_fn` as arguments to `init` to allow them to be overridden when creating applications.

## Why
* This allows the applications to be more flexible and prevents users from subclassing the Application when they use a different preprocessing function.
