### PR TITLE
Add `pad_mode` as an argument to `CytoplasmSegmentation.predict`.

### DIFF
--- a/deepcell/applications/cytoplasm_segmentation.py
+++ b/deepcell/applications/cytoplasm_segmentation.py
@@ -118,6 +118,7 @@ class CytoplasmSegmentation(Application):
                 image,
                 batch_size=4,
                 image_mpp=None,
+                pad_mode='reflect',
                 preprocess_kwargs={},
                 postprocess_kwargs={}):
         """Generates a labeled image of the input running prediction with
@@ -133,6 +134,7 @@ class CytoplasmSegmentation(Application):
                 ``[batch, x, y, channel]``.
             batch_size (int): Number of images to predict on per batch.
             image_mpp (float): Microns per pixel for ``image``.
+            pad_mode (str): The padding mode, one of "constant" or "reflect".
             preprocess_kwargs (dict): Keyword arguments to pass to the
                 pre-processing function.
             postprocess_kwargs (dict): Keyword arguments to pass to the
@@ -152,5 +154,6 @@ class CytoplasmSegmentation(Application):
             image,
             batch_size=batch_size,
             image_mpp=image_mpp,
+            pad_mode=pad_mode,
             preprocess_kwargs=preprocess_kwargs,
             postprocess_kwargs=postprocess_kwargs)


### PR DESCRIPTION
Enables overriding the default `pad_mode` to use "reflect" by default.

## What
* Add `pad_mode` as a new argument to `CytoplasmSegmentation.predict` with default value `"reflect"`.

## Why
* Allows overriding the padding mode for tiling the input. Prevents edge effects for models not trained on zero-padded data.
