### PR TITLE
Add dependencies labels to Maintenance category

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,6 +18,7 @@ categories:
   - title: '🧰 Maintenance'
     labels:
       - 'chore'
+      - 'dependencies'
   - title: '📚️ Documentation'
     labels:
       - 'documentation'


### PR DESCRIPTION
## What
* Update the `release-drafter.yml` template to add the "dependencies" label to the Maintenace category.

## Why
* These are regularly labeled PRs and should get filed under maintenance.
