### PR TITLE
Graph tracking model architecture changes

### DIFF
--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -310,49 +310,25 @@ class GNNTrackingModel(object):
         # Create model
         self.training_model, self.inference_model = self.get_models()
 
-    def get_embedding_temporal_merge_model(self, merge_type='lstm'):
+    def get_embedding_temporal_merge_model(self):
         inputs = Input(shape=(None, None, self.encoder_dim),
                        name='embedding_temporal_merge_input')
 
-        if merge_type == 'lstm':
-            x = inputs
-            x = TemporalMerge(name='merge_emb_tm')([x, inputs])
-            x = LSTM(self.encoder_dim, return_sequences=True, name='lstm_tm')(x)
-            x = TemporalUnmerge(name='unmerge_emb_tm')([x, inputs])
-
-        elif merge_type == 'cnn':
-            x = inputs
-            x = Conv2D(self.encoder_dim, (self.time_window, 1),
-                       padding='SAME', name='conv2d_tm')(x)
-            x = BatchNormalization(axis=-1, name='bn_tm')(x)
-            x = Activation('relu', name='relu_tm')(x)
-
-        else:
-            raise ValueError('merge_type "{}" not supported. '
-                             'Choose from lstm or cnn.'.format(merge_type))
+        x = inputs
+        x = TemporalMerge(name='merge_emb_tm')([x, inputs])
+        x = LSTM(self.encoder_dim, return_sequences=True, name='lstm_tm')(x)
+        x = TemporalUnmerge(name='unmerge_emb_tm')([x, inputs])
 
         return Model(inputs=inputs, outputs=x, name='embedding_temporal_merge')
 
-    def get_delta_temporal_merge_model(self, merge_type='lstm'):
+    def get_delta_temporal_merge_model(self):
         inputs = Input(shape=(None, None, self.encoder_dim),
                        name='centroid_temporal_merge_input')
 
-        if merge_type == 'lstm':
-            x = inputs
-            x = TemporalMerge(name='merge_delta_tm')([x, inputs])
-            x = LSTM(self.encoder_dim, return_sequences=True, name='lstm_delta')(x)
-            x = TemporalUnmerge(name='unmerge_delta_tm')([x, inputs])
-
-        elif merge_type == 'cnn':
-            x = inputs
-            x = Conv2D(self.encoder_dim, (self.time_window, 1),
-                       padding='SAME', name='conv2d_delta')(x)
-            x = BatchNormalization(axis=-1, name='bn_delta')(x)
-            x = Activation('relu', name='relu_delta')(x)
-
-        else:
-            raise ValueError('merge_type "{}" not supported. '
-                             'Choose from lstm or cnn.'.format(merge_type))
+        x = inputs
+        x = TemporalMerge(name='merge_delta_tm')([x, inputs])
+        x = LSTM(self.encoder_dim, return_sequences=True, name='lstm_delta')(x)
+        x = TemporalUnmerge(name='unmerge_delta_tm')([x, inputs])
 
         return Model(inputs=inputs, outputs=x, name='delta_temporal_merge')
 


### PR DESCRIPTION
## What
* Create keras layer `Unmerge` used to unmerge embeddings and centroids.
* Change default `merge_type` for `get_embedding_temporal_merge_model` and `get_delta_temporal_merge_model` to lstm instead of cnn
* Remove residual connections in `get_tracking_decoder` 

## Why
* Nicer to have a keras layer than use Lambda layers
* Merging the embeddings depends only on timepoints in the present and past, and thus do not have information from future embeddings. Cnn's use information from future timepoints, resulting in temporal information being leaked. Lstm's only use information from the current and old embeddings (which is what we want).
* Adding the residual connections does not help with accuracy
