### PR TITLE
Move custom layers into `layers/temporal.py` and add tests.

### DIFF
--- a/deepcell/layers/__init__.py
+++ b/deepcell/layers/__init__.py
@@ -44,7 +44,7 @@ from deepcell.layers.normalization import ImageNormalization3D
 from deepcell.layers.pooling import DilatedMaxPool2D
 from deepcell.layers.pooling import DilatedMaxPool3D
 from deepcell.layers.temporal import Comparison, DeltaReshape, Unmerge
-from deepcell.layers.temporal import TemporalMerge, TemporalUnmerge
+from deepcell.layers.temporal import TemporalMerge
 from deepcell.layers.tensor_product import TensorProduct
 from deepcell.layers.padding import ReflectionPadding2D
 from deepcell.layers.padding import ReflectionPadding3D

--- a/deepcell/layers/__init__.py
+++ b/deepcell/layers/__init__.py
@@ -43,6 +43,7 @@ from deepcell.layers.normalization import ImageNormalization2D
 from deepcell.layers.normalization import ImageNormalization3D
 from deepcell.layers.pooling import DilatedMaxPool2D
 from deepcell.layers.pooling import DilatedMaxPool3D
+from deepcell.layers.temporal import Comparison, DeltaReshape, Unmerge
 from deepcell.layers.temporal import TemporalMerge, TemporalUnmerge
 from deepcell.layers.tensor_product import TensorProduct
 from deepcell.layers.padding import ReflectionPadding2D

--- a/deepcell/layers/temporal.py
+++ b/deepcell/layers/temporal.py
@@ -32,6 +32,58 @@ import tensorflow as tf
 from tensorflow.keras.layers import Layer
 
 
+class Comparison(Layer):
+    """Layer for comparing two sequences of inputs."""
+    def call(self, inputs):
+        x = inputs[0]
+        y = inputs[1]
+
+        x = tf.expand_dims(x, 3)
+        multiples = [1, 1, 1, tf.shape(y)[2], 1]
+        x = tf.tile(x, multiples)
+
+        y = tf.expand_dims(y, 2)
+        multiples = [1, 1, tf.shape(x)[2], 1, 1]
+        y = tf.tile(y, multiples)
+
+        return tf.concat([x, y], axis=-1)
+
+
+class DeltaReshape(Layer):
+    """Reshape changes between current and future frames"""
+    def call(self, inputs):
+        current = inputs[0]
+        future = inputs[1]
+        current = tf.expand_dims(current, axis=3)
+        multiples = [1, 1, 1, tf.shape(future)[2], 1]
+        output = tf.tile(current, multiples)
+        return output
+
+
+class Unmerge(Layer):
+    """Unmerge temporal inputs"""
+    def __init__(self, track_length, max_cells, embedding_dim, **kwargs):
+        super(Unmerge, self).__init__(**kwargs)
+        self.track_length = track_length
+        self.max_cells = max_cells
+        self.embedding_dim = embedding_dim
+
+    def call(self, inputs):
+        new_shape = [-1, self.track_length, self.max_cells, self.embedding_dim]
+        output = tf.reshape(inputs, new_shape)
+
+        return output
+
+    def get_config(self):
+        config = {
+            'track_length': self.track_length,
+            'max_cells': self.max_cells,
+            'embedding_dim': self.embedding_dim
+        }
+        base_config = super(Unmerge, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
 class TemporalMerge(Layer):
     """Layer for merging the time dimension of a Tensor.
 
@@ -47,6 +99,13 @@ class TemporalMerge(Layer):
         b = inputs[1]
         new_shape = [-1, tf.shape(b)[2], self.encoder_dim]
         return tf.reshape(a, new_shape)
+
+    def get_config(self):
+        config = {
+            'encoder_dim': self.encoder_dim,
+        }
+        base_config = super(TemporalMerge, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
 
 
 class TemporalUnmerge(Layer):
@@ -64,3 +123,10 @@ class TemporalUnmerge(Layer):
         b = inputs[1]
         new_shape = [-1, tf.shape(b)[1], tf.shape(b)[2], self.encoder_dim]
         return tf.reshape(a, new_shape)
+
+    def get_config(self):
+        config = {
+            'encoder_dim': self.encoder_dim,
+        }
+        base_config = super(TemporalUnmerge, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/deepcell/layers/temporal.py
+++ b/deepcell/layers/temporal.py
@@ -71,7 +71,6 @@ class Unmerge(Layer):
     def call(self, inputs):
         new_shape = [-1, self.track_length, self.max_cells, self.embedding_dim]
         output = tf.reshape(inputs, new_shape)
-
         return output
 
     def get_config(self):

--- a/deepcell/layers/temporal_test.py
+++ b/deepcell/layers/temporal_test.py
@@ -1,0 +1,120 @@
+# Copyright 2016-2021 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/deepcell-tf/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the upsampling layers"""
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+
+import numpy as np
+from tensorflow.keras import backend as K
+from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.keras import testing_utils
+from tensorflow.keras.utils import custom_object_scope
+from tensorflow.python.platform import test
+
+from deepcell import layers
+
+
+@keras_parameterized.run_all_keras_modes
+class TestComparison(keras_parameterized.TestCase):
+    def test_simple(self):
+        # create simple Comparison layer
+        comparison_layer = layers.Comparison()
+
+        # create input before
+        before_objs = 7
+        before_chan = 2
+        before = np.zeros((1, 5, before_objs, before_chan), dtype=K.floatx())
+        before = K.variable(before)
+        after_objs = 8
+        after_chan = 3
+        after = np.zeros((1, 5, after_objs, after_chan), dtype=K.floatx())
+        after = K.variable(after)
+
+        target_chan = before_chan + after_chan
+        target_shape = tuple(list(before.shape[:-1]) + [after_objs, target_chan])
+        target = np.zeros(target_shape, dtype=K.floatx())
+        expected = target
+        target = K.variable(target)
+
+        # compute output
+        computed_shape = comparison_layer.compute_output_shape(
+            [before.shape, after.shape])
+
+        actual = comparison_layer.call([before, after])
+        actual = K.get_value(actual)
+
+        self.assertEqual(actual.shape, computed_shape)
+        self.assertAllEqual(actual, expected)
+
+
+@keras_parameterized.run_all_keras_modes
+class TestDeltaReshape(keras_parameterized.TestCase):
+    def test_simple(self):
+        # create simple DeltaReshape layer
+        delta_reshape_layer = layers.DeltaReshape()
+
+        # create input before
+        before_objs = 7
+        before = np.zeros((3, 5, before_objs, 1), dtype=K.floatx())
+        before = K.variable(before)
+        after_objs = 8
+        after = np.zeros((1, 1, after_objs, 1), dtype=K.floatx())
+        after = K.variable(after)
+
+        target_shape = tuple(list(before.shape[:-1]) + list(after.shape[-2:]))
+        target = np.zeros(target_shape, dtype=K.floatx())
+        expected = target
+        target = K.variable(target)
+
+        # compute output
+        computed_shape = delta_reshape_layer.compute_output_shape(
+            [before.shape, after.shape])
+
+        actual = delta_reshape_layer.call([before, after])
+        actual = K.get_value(actual)
+
+        self.assertEqual(actual.shape, computed_shape)
+        self.assertAllEqual(actual, expected)
+
+
+@keras_parameterized.run_all_keras_modes
+class TestUnmerge(keras_parameterized.TestCase):
+
+    def test_unmerge(self):
+        track_length = 5
+        max_cells = 10
+        embedding_dim = 64
+
+        custom_objects = {'Unmerge': layers.Unmerge}
+        with self.cached_session():
+            with custom_object_scope(custom_objects):
+                testing_utils.layer_test(
+                    layers.Unmerge,
+                    kwargs={'track_length': track_length,
+                            'max_cells': max_cells,
+                            'embedding_dim': embedding_dim},
+                    input_shape=(None, track_length * max_cells, embedding_dim))

--- a/deepcell/layers/temporal_test.py
+++ b/deepcell/layers/temporal_test.py
@@ -118,3 +118,20 @@ class TestUnmerge(keras_parameterized.TestCase):
                             'max_cells': max_cells,
                             'embedding_dim': embedding_dim},
                     input_shape=(None, track_length * max_cells, embedding_dim))
+
+
+@keras_parameterized.run_all_keras_modes
+class TestTemporalMerge(keras_parameterized.TestCase):
+
+    def test_temporal_merge(self):
+        track_length = 5
+        max_cells = 7
+        encoder_dim = 32
+
+        custom_objects = {'TemporalMerge': layers.TemporalMerge}
+        with self.cached_session():
+            with custom_object_scope(custom_objects):
+                testing_utils.layer_test(
+                    layers.TemporalMerge,
+                    kwargs={'encoder_dim': encoder_dim},
+                    input_shape=(None, track_length, max_cells, encoder_dim))

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -45,8 +45,7 @@ from tensorflow.keras.layers import BatchNormalization, Lambda
 from tensorflow.keras.regularizers import l2
 
 from deepcell.layers import ImageNormalization2D
-from deepcell.layers import Comparison, DeltaReshape, Unmerge
-from deepcell.layers import TemporalMerge, TemporalUnmerge
+from deepcell.layers import Comparison, DeltaReshape, Unmerge, TemporalMerge
 
 from spektral.layers import GCSConv
 # from spektral.layers import GCNConv, GATConv
@@ -266,11 +265,7 @@ class GNNTrackingModel(object):
         inputs = Input(shape=(None, None, self.encoder_dim),
                        name='embedding_temporal_merge_input')
 
-        x = inputs
-        x = TemporalMerge(name='merge_emb_tm')([x, inputs])
-        x = LSTM(self.encoder_dim, return_sequences=True, name='lstm_tm')(x)
-        x = TemporalUnmerge(name='unmerge_emb_tm')([x, inputs])
-
+        x = TemporalMerge(name='emb_tm')(inputs)
         return Model(inputs=inputs, outputs=x, name='embedding_temporal_merge')
 
     def get_delta_temporal_merge_model(self):
@@ -278,10 +273,7 @@ class GNNTrackingModel(object):
                        name='centroid_temporal_merge_input')
 
         x = inputs
-        x = TemporalMerge(name='merge_delta_tm')([x, inputs])
-        x = LSTM(self.encoder_dim, return_sequences=True, name='lstm_delta')(x)
-        x = TemporalUnmerge(name='unmerge_delta_tm')([x, inputs])
-
+        x = TemporalMerge(name='delta_tm')(inputs)
         return Model(inputs=inputs, outputs=x, name='delta_temporal_merge')
 
     def get_appearance_encoder(self):

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -265,7 +265,7 @@ class GNNTrackingModel(object):
         inputs = Input(shape=(None, None, self.encoder_dim),
                        name='embedding_temporal_merge_input')
 
-        x = TemporalMerge(name='emb_tm')(inputs)
+        x = TemporalMerge(self.encoder_dim, name='emb_tm')(inputs)
         return Model(inputs=inputs, outputs=x, name='embedding_temporal_merge')
 
     def get_delta_temporal_merge_model(self):
@@ -273,7 +273,7 @@ class GNNTrackingModel(object):
                        name='centroid_temporal_merge_input')
 
         x = inputs
-        x = TemporalMerge(name='delta_tm')(inputs)
+        x = TemporalMerge(self.encoder_dim, name='delta_tm')(inputs)
         return Model(inputs=inputs, outputs=x, name='delta_temporal_merge')
 
     def get_appearance_encoder(self):

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -539,6 +539,12 @@ class GNNTrackingModel(object):
         embedding = BatchNormalization(axis=-1, name='bn_td0')(embedding)
         embedding = Activation('relu', name='relu_td0')(embedding)
 
+        for i in range(self.n_layers):
+            res = Dense(self.n_filters, name='dense_td{}'.format(i + 1))(embedding)
+            res = BatchNormalization(axis=-1, name='bn_td{}'.format(i + 1))(res)
+            res = Activation('relu', name='relu_td{}'.format(i + 1))(res)
+            embedding = Add()([embedding, res])
+
         # TODO: set to n_classes
         embedding = Dense(3, name='dense_outembed')(embedding)
 


### PR DESCRIPTION
## What
* Move new custom layers from `model_zoo` to `layers/temporal.py`
* Add tests for moved layers.
* Merge `TemporalMerge` and `TemporalUnmerge` with the LSTM layer.
* Add back in the fully connected layers. Training is much improved (6 correct -> 18 correct)
* Remove `time_window` and allow user to pass `appearance_shape`. Appearance encoder convolutions are defined by `log(app_shape[0], 2)`.

## Why
* Staying organized and improving coverage.
* Resolve hard-coded values
* DRY out the model zoo.
