### PR TITLE
Application batch prediction

### DIFF
--- a/deepcell/applications/application.py
+++ b/deepcell/applications/application.py
@@ -312,9 +312,7 @@ class Application(object):
 
         return image
 
-    def _batch_predict(self,
-                       tiles,
-                       batch_size):
+    def _batch_predict(self, tiles, batch_size):
         """Batch process tiles to generate model predictions.
 
         The built-in keras.predict function has support for batching, but loads the entire
@@ -324,7 +322,6 @@ class Application(object):
         Args:
             tiles: Tiled data which will be fed to model
             batch_size: Number of images to predict on per batch
-
 
         Returns:
             list: Model outputs
@@ -339,17 +336,17 @@ class Application(object):
         output_tiles = []
 
         # loop through each batch
-        for batch_index, (batch_start, batch_end) in enumerate(batches):
-            batch_inputs = tiles[batch_start:batch_end, ...]
+        for i in range(0, tiles.shape[0], batch_size):
+            batch_inputs = tiles[i:i + batch_size, ...]
 
             batch_outputs = self.model.predict(batch_inputs, batch_size=batch_size)
 
             # model with only a single output gets temporarily converted to a list
-            if type(batch_outputs) != list:
+            if not isinstance(batch_outputs, list):
                 batch_outputs = [batch_outputs]
 
             # initialize output list with empty arrays to hold all batches
-            if batch_index == 0:
+            if not output_tiles:
                 for batch_out in batch_outputs:
                     shape = (num_images,) + batch_out.shape[1:]
                     output_tiles.append(np.zeros(shape, dtype=tiles.dtype))

--- a/deepcell/applications/application.py
+++ b/deepcell/applications/application.py
@@ -321,7 +321,7 @@ class Application(object):
         model.predict function without soaking up GPU memory.
 
         Args:
-            tiles (np.array): Tiled data which will be fed to model
+            tiles (numpy.array): Tiled data which will be fed to model
             batch_size (int): Number of images to predict on per batch
 
         Returns:

--- a/deepcell/applications/application.py
+++ b/deepcell/applications/application.py
@@ -321,8 +321,8 @@ class Application(object):
         model.predict function without soaking up GPU memory.
 
         Args:
-            tiles: Tiled data which will be fed to model
-            batch_size: Number of images to predict on per batch
+            tiles (np.array): Tiled data which will be fed to model
+            batch_size (int): Number of images to predict on per batch
 
         Returns:
             list: Model outputs

--- a/deepcell/applications/application.py
+++ b/deepcell/applications/application.py
@@ -327,7 +327,7 @@ class Application(object):
 
 
         Returns:
-            np.array or list: Model outputs
+            list: Model outputs
         """
 
         num_images = tiles.shape[0]

--- a/deepcell/applications/application.py
+++ b/deepcell/applications/application.py
@@ -315,9 +315,10 @@ class Application(object):
     def _batch_predict(self, tiles, batch_size):
         """Batch process tiles to generate model predictions.
 
-        The built-in keras.predict function has support for batching, but loads the entire
-        image stack into GPU memory, which is prohibitive for large images. This function uses
-        similar code to the underlying model.predict function without soaking up GPU memory.
+        The built-in keras.predict function has support for batching, but
+        loads the entire image stack into GPU memory, which is prohibitive
+        for large images. This function uses similar code to the underlying
+        model.predict function without soaking up GPU memory.
 
         Args:
             tiles: Tiled data which will be fed to model
@@ -326,11 +327,6 @@ class Application(object):
         Returns:
             list: Model outputs
         """
-
-        num_images = tiles.shape[0]
-        num_batches = int(np.ceil(num_images / float(batch_size)))
-        batches = [(i * batch_size, min(num_images, (i + 1) * batch_size)) for i in
-                   range(0, num_batches)]
 
         # list to hold final output
         output_tiles = []
@@ -348,12 +344,12 @@ class Application(object):
             # initialize output list with empty arrays to hold all batches
             if not output_tiles:
                 for batch_out in batch_outputs:
-                    shape = (num_images,) + batch_out.shape[1:]
+                    shape = (tiles.shape[0],) + batch_out.shape[1:]
                     output_tiles.append(np.zeros(shape, dtype=tiles.dtype))
 
             # save each batch to corresponding index in output list
-            for i, batch_out in enumerate(batch_outputs):
-                output_tiles[i][batch_start:batch_end, ...] = batch_out
+            for j, batch_out in enumerate(batch_outputs):
+                output_tiles[j][i:i + batch_size, ...] = batch_out
 
         return output_tiles
 

--- a/deepcell/applications/application_test.py
+++ b/deepcell/applications/application_test.py
@@ -29,12 +29,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import numpy as np
-
-from tensorflow.keras.layers import Input
-from tensorflow.python.platform import test
-from unittest.mock import Mock
 from itertools import product
+import numpy as np
+from unittest.mock import Mock
+
+from tensorflow.python.platform import test
 
 from deepcell.applications import Application
 

--- a/deepcell/applications/application_test.py
+++ b/deepcell/applications/application_test.py
@@ -30,8 +30,9 @@ from __future__ import division
 from __future__ import print_function
 
 from itertools import product
-import numpy as np
 from unittest.mock import Mock
+
+import numpy as np
 
 from tensorflow.python.platform import test
 

--- a/deepcell/applications/application_test.py
+++ b/deepcell/applications/application_test.py
@@ -243,13 +243,27 @@ class TestApplication(test.TestCase):
         y = app._format_model_output(x)
         self.assertAllEqual(x, y['inner-distance'])
 
+    def test_batch_predict(self):
+        for num_images in [4, 8, 10]:
+            for num_pred_heads in [1, 2]:
+                model = DummyModel(n_out=num_pred_heads)
+                app = Application(model)
+
+                x = np.random.rand(num_images, 128, 128, 1)
+                y = app._batch_predict(x, batch_size=4)
+                self.assertEqual(x.shape, y[0].shape)
+
+                if num_pred_heads == 2:
+                    self.assertEqual(x.shape, y[1].shape)
+
     def test_run_model(self):
-        model = DummyModel()
+        model = DummyModel(n_out=2)
         app = Application(model)
 
         x = np.random.rand(1, 128, 128, 1)
         y = app._run_model(x)
         self.assertEqual(x.shape, y[0].shape)
+        self.assertEqual(x.shape, y[1].shape)
 
     def test_predict_segmentation(self):
         model = DummyModel()


### PR DESCRIPTION
## What
Modifies the applications to use internal batch prediction function rather than the default model.predict batching functionality. Closes #538 

## Why
The default model.predict batch function creates a tf.dataset object with all images, not just the specified batch size. This leads to memory issues on the GPU when batch processing tiles from large images. 
