### PR TITLE
Update TensorFlow to 2.3.4.

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      TF_VERSION: 2.3.1
+      TF_VERSION: 2.3.4
 
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use tensorflow/tensorflow as the base image
 # Change the build arg to edit the tensorflow version.
 # Only supporting python3.
-ARG TF_VERSION=2.3.1-gpu
+ARG TF_VERSION=2.3.4-gpu
 
 FROM tensorflow/tensorflow:${TF_VERSION}
 

--- a/deepcell/_version.py
+++ b/deepcell/_version.py
@@ -27,7 +27,7 @@
 __title__ = 'DeepCell'
 __description__ = 'Deep learning for single cell image segmentation'
 __url__ = 'https://github.com/vanvalenlab/deepcell-tf'
-__version__ = '0.8.7'
+__version__ = '0.8.8'
 __download_url__ = '{}/tarball/{}'.format(__url__, __version__)
 __author__ = 'The Van Valen Lab'
 __author_email__ = 'vanvalen@caltech.edu'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.16.6,<1.20
 scipy>=1.1.0,<2
 scikit-image>=0.14.5,<0.17
 scikit-learn>=0.19.1,<1
-tensorflow==2.3.1
+tensorflow~=2.3.4
 jupyter>=1.0.0,<2
 opencv-python-headless<5
 deepcell-tracking>=0.3.1,<0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.16.6,<1.20
 scipy>=1.1.0,<2
 scikit-image>=0.14.5,<0.17
 scikit-learn>=0.19.1,<1
-tensorflow~=2.3.4
+tensorflow~=2.3.1
 jupyter>=1.0.0,<2
 opencv-python-headless<5
 deepcell-tracking>=0.3.1,<0.4.0

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'scipy>=1.1.0,<2',
         'scikit-image>=0.14.5,<=0.17',
         'scikit-learn>=0.19.1,<1',
-        'tensorflow~=2.3.4',
+        'tensorflow~=2.3.1',
         'jupyter>=1.0.0,<2',
         'opencv-python-headless<5',
         'deepcell-tracking>=0.3.1,<0.4.0',

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'scipy>=1.1.0,<2',
         'scikit-image>=0.14.5,<=0.17',
         'scikit-learn>=0.19.1,<1',
-        'tensorflow==2.3.1',
+        'tensorflow~=2.3.4',
         'jupyter>=1.0.0,<2',
         'opencv-python-headless<5',
         'deepcell-tracking>=0.3.1,<0.4.0',


### PR DESCRIPTION
## What
* Update TensorFlow to the latest 2.3.x release.
* Updates the compatible releases of TensorFlow 2.3.x to allow patch releases, as TensorFlow 2.3.1+ does not support Python 3.5.

## Why
* Fixes lots of [CVEs](https://github.com/tensorflow/tensorflow/releases/tag/v2.3.4)
