### PR TITLE
Bump version to 0.10.0-rc.1

### DIFF
--- a/deepcell/_version.py
+++ b/deepcell/_version.py
@@ -27,7 +27,7 @@
 __title__ = 'DeepCell'
 __description__ = 'Deep learning for single cell image segmentation'
 __url__ = 'https://github.com/vanvalenlab/deepcell-tf'
-__version__ = '0.9.0'
+__version__ = '0.10.0-rc.1'
 __download_url__ = '{}/tarball/{}'.format(__url__, __version__)
 __author__ = 'The Van Valen Lab'
 __author_email__ = 'vanvalen@caltech.edu'


### PR DESCRIPTION
## What
* Bump version to `0.10.0-rc.1`, the first release candidate for the pending `0.10.0` release.

## Why
* #530 and #545 will be addressed before final release comes out, but pre-release will enable users to begin using the new functionality.
