### PR TITLE
Fix `sed` commands to only replace `tensorflow` not `tensorflow-addons`.

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -44,7 +44,11 @@ jobs:
 
     - name: Build a source distribution
       run: |
-        sed -i "s/tensorflow/tensorflow-cpu/g" setup.py
+        sed -i "s/tensorflow~=/tensorflow-cpu~=/g" setup.py
+        sed -i "s/tensorflow==/tensorflow-cpu==/g" setup.py
+        sed -i "s/tensorflow>=/tensorflow-cpu>=/g" setup.py
+        sed -i "s/tensorflow<=/tensorflow-cpu<=/g" setup.py
+        sed -i "s/tensorflow!=/tensorflow-cpu!=/g" setup.py
         sed -i -e "/__title__ =/ s/= .*/= 'DeepCell-CPU'/" deepcell/_version.py
         python setup.py sdist
 

--- a/deepcell/_version.py
+++ b/deepcell/_version.py
@@ -27,7 +27,7 @@
 __title__ = 'DeepCell'
 __description__ = 'Deep learning for single cell image segmentation'
 __url__ = 'https://github.com/vanvalenlab/deepcell-tf'
-__version__ = '0.10.0-rc.1'
+__version__ = '0.10.0-rc.2'
 __download_url__ = '{}/tarball/{}'.format(__url__, __version__)
 __author__ = 'The Van Valen Lab'
 __author_email__ = 'vanvalen@caltech.edu'


### PR DESCRIPTION
## What
* Use `sed` to replace `tensorflow~=` with `tensorflow-cpu~=`. Including the `~` prevents other deps that start with the word `tensorflow` from getting replaced.
* Bump version to 0.10.0-rc.2

## Why
* Fixes #547 
