### PR TITLE
Remove fully convolutional layers from the GNNTrackingModel.

### DIFF
--- a/deepcell/_version.py
+++ b/deepcell/_version.py
@@ -27,7 +27,7 @@
 __title__ = 'DeepCell'
 __description__ = 'Deep learning for single cell image segmentation'
 __url__ = 'https://github.com/vanvalenlab/deepcell-tf'
-__version__ = '0.10.0-rc.2'
+__version__ = '0.10.0-rc.3'
 __download_url__ = '{}/tarball/{}'.format(__url__, __version__)
 __author__ = 'The Van Valen Lab'
 __author_email__ = 'vanvalen@caltech.edu'

--- a/deepcell/applications/cell_tracking.py
+++ b/deepcell/applications/cell_tracking.py
@@ -37,7 +37,6 @@ import deepcell_tracking
 from deepcell_toolbox.processing import normalize
 
 from deepcell.applications import Application
-from deepcell.model_zoo.tracking import GNNTrackingModel
 
 
 MODEL_PATH = ('https://deepcell-data.s3-us-west-1.amazonaws.com/'
@@ -97,8 +96,6 @@ class CellTracking(Application):
         self.division = division
         self.track_length = track_length
         self.embedding_axis = embedding_axis
-
-        tm = GNNTrackingModel()
 
         if self.neighborhood_encoder is None:
             archive_path = tf.keras.utils.get_file(

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -43,13 +43,12 @@ from tensorflow.keras.layers import Add, Subtract, Dense, Reshape
 from tensorflow.keras.layers import MaxPool3D
 from tensorflow.keras.layers import Activation, Softmax
 from tensorflow.keras.layers import BatchNormalization, Lambda
-
 from tensorflow.keras.regularizers import l2
+
+from spektral.layers import GCSConv, GCNConv
 
 from deepcell.layers import ImageNormalization2D
 from deepcell.layers import Comparison, DeltaReshape, Unmerge, TemporalMerge
-
-from spektral.layers import GCSConv, GCNConv
 
 
 def siamese_model(input_shape=None,

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -549,12 +549,6 @@ class GNNTrackingModel(object):
         embedding = BatchNormalization(axis=-1, name='bn_td0')(embedding)
         embedding = Activation('relu', name='relu_td0')(embedding)
 
-        for i in range(self.n_layers):
-            res = Dense(self.n_filters, name='dense_td{}'.format(i + 1))(embedding)
-            res = BatchNormalization(axis=-1, name='bn_td{}'.format(i + 1))(res)
-            res = Activation('relu', name='relu_td{}'.format(i + 1))(res)
-            embedding = Add()([embedding, res])
-
         # TODO: set to n_classes
         embedding = Dense(3, name='dense_outembed')(embedding)
 


### PR DESCRIPTION
## What
* Remove the Fully Connected layers from the tracking decoder
* Enable multiple graph convolutional layer types with new `graph_layer` argument, currently supports GCN and GCS.

## Why
* Improve model performance and ease of use.
