### PR TITLE
Move tracking data preprocessing into `deepcell.data.tracking`

### DIFF
--- a/deepcell/data/tracking.py
+++ b/deepcell/data/tracking.py
@@ -31,11 +31,271 @@ from __future__ import print_function
 
 import math
 
+from scipy.spatial.distance import cdist
+
 import numpy as np
+import tqdm
+
 import tensorflow as tf
 import tensorflow_addons as tfa
 
+from deepcell_tracking.utils import load_trks
+from deepcell_tracking.utils import get_max_cells
+from deepcell_tracking.utils import get_image_features
+from deepcell_tracking.utils import is_valid_lineage
+from deepcell_tracking.utils import normalize_adj_matrix
+from deepcell_tracking.utils import relabel_sequential_lineage
+
 from deepcell.data import split_dataset
+
+
+class Track(object):  # pylint: disable=useless-object-inheritance
+
+    def __init__(self, path=None, tracked_data=None,
+                 appearance_dim=32, distance_threshold=64):
+        if tracked_data:
+            training_data = tracked_data
+        elif path:
+            training_data = load_trks(path)
+        else:
+            raise ValueError('One of `tracked_data` or `path` is required')
+        self.X = training_data['X'].astype('float32')
+        self.y = training_data['y'].astype('int32')
+        self.lineages = training_data['lineages']
+        self.appearance_dim = appearance_dim
+        self.distance_threshold = distance_threshold
+
+        # Correct lineages and remove bad batches
+        self._correct_lineages()
+
+        # Create feature dictionaries
+        features_dict = self._get_features()
+
+        self.appearances = features_dict['appearances']
+        self.morphologies = features_dict['morphologies']
+        self.centroids = features_dict['centroids']
+
+        # Convert adj matrices to sparse
+        self.adj_matrices = self._get_sparse(
+            features_dict['adj_matrix'])
+        self.norm_adj_matrices = self._get_sparse(
+            normalize_adj_matrix(features_dict['adj_matrix']))
+        self.temporal_adj_matrices = self._get_sparse(
+            features_dict['temporal_adj_matrix'])
+
+        self.mask = features_dict['mask']
+        self.track_length = features_dict['track_length']
+
+    def _correct_lineages(self):
+        """Ensure valid lineages and sequential labels for all batches"""
+        new_X = []
+        new_y = []
+        new_lineages = []
+        for batch in tqdm.tqdm(range(self.y.shape[0])):
+            if is_valid_lineage(self.y[batch], self.lineages[batch]):
+
+                y_relabel, new_lineage = relabel_sequential_lineage(
+                    self.y[batch], self.lineages[batch])
+
+                new_X.append(self.X[batch])
+                new_y.append(y_relabel)
+                new_lineages.append(new_lineage)
+
+        self.X = np.stack(new_X, axis=0)
+        self.y = np.stack(new_y, axis=0)
+        self.lineages = new_lineages
+
+    def _get_sparse(self, arr):
+        # tf.sparse.from_dense causes memory issues for large arrays
+        indices = np.nonzero(arr)
+        indices_array = np.stack(indices, axis=-1)
+        values = arr[indices]
+        shape = arr.shape
+        return tf.sparse.SparseTensor(indices_array, values, shape)
+
+    def _get_features(self):
+        """
+        Extract the relevant features from the label movie
+        Appearance, morphologies, centroids, and adjacency matrices
+        """
+        max_tracks = get_max_cells(self.y)
+        n_batches = self.X.shape[0]
+        n_frames = self.X.shape[1]
+        n_channels = self.X.shape[-1]
+
+        batch_shape = (n_batches, n_frames, max_tracks)
+
+        appearance_shape = (self.appearance_dim, self.appearance_dim, n_channels)
+
+        appearances = np.zeros(batch_shape + appearance_shape, dtype='float32')
+
+        morphologies = np.zeros(batch_shape + (3,), dtype='float32')
+
+        centroids = np.zeros(batch_shape + (2,), dtype='float32')
+
+        adj_matrix = np.zeros(batch_shape + (max_tracks,), dtype='float32')
+
+        temporal_adj_matrix = np.zeros((n_batches,
+                                        n_frames - 1,
+                                        max_tracks,
+                                        max_tracks,
+                                        3), dtype='float32')
+
+        mask = np.zeros(batch_shape, dtype='float32')
+
+        track_length = np.zeros((n_batches, max_tracks, 2), dtype='int32')
+
+        for batch in tqdm.tqdm(range(n_batches)):
+            for frame in range(n_frames):
+
+                frame_features = get_image_features(
+                    self.X[batch, frame], self.y[batch, frame],
+                    appearance_dim=self.appearance_dim)
+
+                track_ids = frame_features['labels'] - 1
+                centroids[batch, frame, track_ids] = frame_features['centroids']
+                morphologies[batch, frame, track_ids] = frame_features['morphologies']
+                appearances[batch, frame, track_ids] = frame_features['appearances']
+                mask[batch, frame, track_ids] = 1
+
+                # Get adjacency matrix, cannot filter on track ids.
+                cent = centroids[batch, frame]
+                distance = cdist(cent, cent, metric='euclidean')
+                distance = distance < self.distance_threshold
+
+                # Disconnect the padded nodes
+                morphs = morphologies[batch, frame]
+                is_pad = np.matmul(morphs, morphs.T) == 0
+
+                adj = distance * (1 - is_pad)
+                adj_matrix[batch, frame] = adj.astype(np.float32)
+
+            # Get track length and temporal adjacency matrix
+            for label in self.lineages[batch]:
+                # Get track length
+                start_frame = self.lineages[batch][label]['frames'][0]
+                end_frame = self.lineages[batch][label]['frames'][-1]
+
+                track_id = label - 1
+                track_length[batch, track_id, 0] = start_frame
+                track_length[batch, track_id, 1] = end_frame
+
+                # Get temporal adjacency matrix
+                frames = self.lineages[batch][label]['frames']
+
+                # Assign same
+                for f0, f1 in zip(frames[0:-1], frames[1:]):
+                    if f1 - f0 == 1:
+                        temporal_adj_matrix[batch, f0, track_id, track_id, 0] = 1
+
+                # Assign daughter
+                # WARNING: This wont work if there's a time gap between mother
+                # cell disappearing and daughter cells appearing
+                last_frame = frames[-1]
+                daughters = self.lineages[batch][label]['daughters']
+                for daughter in daughters:
+                    daughter_id = daughter - 1
+                    temporal_adj_matrix[batch, last_frame, track_id, daughter_id, 2] = 1
+
+            # Assign different
+            same_prob = temporal_adj_matrix[batch, ..., 0]
+            daughter_prob = temporal_adj_matrix[batch, ..., 2]
+            temporal_adj_matrix[batch, ..., 1] = 1 - same_prob - daughter_prob
+
+            # Identify cell padding
+            for i in range(temporal_adj_matrix.shape[2]):
+                # index + 1 is the cell label
+                if i + 1 not in self.lineages[batch]:
+                    temporal_adj_matrix[batch, :, i] = 0
+                    temporal_adj_matrix[batch, :, :, i] = 0
+
+            # Identify temporal padding
+            for b in range(temporal_adj_matrix.shape[0]):
+                sames = temporal_adj_matrix[b, ..., 0]
+                sames = np.sum(sames, axis=(1, 2))
+                temporal_adj_matrix[b, sames == 0] = 0
+
+        features = {
+            'adj_matrix': adj_matrix,
+            'appearances': appearances,
+            'morphologies': morphologies,
+            'centroids': centroids,
+            'temporal_adj_matrix': temporal_adj_matrix,
+            'mask': mask,
+            'track_length': track_length,
+        }
+
+        return features
+
+
+def concat_tracks(tracks):
+    """Join an iterable of Track objects into a single dictionary of features.
+    Args:
+        tracks (iterable): Iterable of tracks.
+    Returns:
+        dict: A dictionary of tracked features.
+    Raises:
+        TypeError: ``tracks`` is not iterable.
+    """
+    try:
+        list(tracks)  # check if iterable
+    except TypeError:
+        raise TypeError('concatenate_tracks requires an iterable input.')
+
+    def get_array_of_max_shape(lst):
+        # find max dimensions of all arrs in lst.
+        shape = None
+        size = 0
+        for arr in lst:
+            if shape is None:
+                shape = [0] * len(arr.shape[1:])
+            for i, dim in enumerate(arr.shape[1:]):
+                if dim > shape[i]:
+                    shape[i] = dim
+            size += arr.shape[0]
+        # add batch dimension
+        shape = [size] + shape
+        return np.zeros(shape, dtype='float32')
+
+    # insert small array into larger array
+    # https://stackoverflow.com/a/50692782
+    def paste_slices(tup):
+        pos, w, max_w = tup
+        wall_min = max(pos, 0)
+        wall_max = min(pos + w, max_w)
+        block_min = -min(pos, 0)
+        block_max = max_w - max(pos + w, max_w)
+        block_max = block_max if block_max != 0 else None
+        return slice(wall_min, wall_max), slice(block_min, block_max)
+
+    def paste(wall, block, loc):
+        loc_zip = zip(loc, block.shape, wall.shape)
+        wall_slices, block_slices = zip(*map(paste_slices, loc_zip))
+        wall[wall_slices] = block[block_slices]
+
+    def concat_adj_matrices(tracks, matrix_name):
+        adj_list = [getattr(t, matrix_name) for t in tracks]
+        return tf.sparse.concat(0, adj_list,
+                                expand_nonconcat_dims=True)
+
+    # TODO: these keys must match the Track attributes.
+    data_dict = {
+        'appearances': get_array_of_max_shape((t.appearances for t in tracks)),
+        'centroids': get_array_of_max_shape((t.centroids for t in tracks)),
+        'morphologies': get_array_of_max_shape((t.morphologies for t in tracks)),
+    }
+
+    for track in tracks:
+        for k in data_dict:
+            feature = getattr(track, k)
+            paste(data_dict[k], feature, (0,) * len(feature.shape))
+
+    # handle adj matrices differently as they can be directly concatenated.
+    adj_matrix_names = ('adj_matrices', 'norm_adj_matrices', 'temporal_adj_matrices')
+    for matrix_name in adj_matrix_names:
+        data_dict[matrix_name] = concat_adj_matrices(tracks, matrix_name)
+
+    return data_dict
 
 
 def temporal_slice(X, y, track_length=8):
@@ -51,17 +311,17 @@ def temporal_slice(X, y, track_length=8):
     """
     temporal_adj_matrices = y['temporal_adj_matrices']
 
-    temporal_adj_matrices = tf.dtypes.cast(temporal_adj_matrices, dtype=tf.dtypes.int32)
+    temporal_adj_matrices = tf.cast(temporal_adj_matrices, tf.int32)
 
     # Identify max time, accounting for padding
     # Padding frames have zero value accross all channels - look for these
-    tam_reduce_sum = tf.sparse.reduce_sum(temporal_adj_matrices, axis=[1,2,3])
+    tam_reduce_sum = tf.sparse.reduce_sum(temporal_adj_matrices, axis=[1, 2, 3])
     non_pad_indices = tf.where(tam_reduce_sum != 0)
-    max_time = tf.reduce_max(non_pad_indices) - track_length
+    max_time = tf.reduce_max(non_pad_indices)
 
-    max_time = tf.cond(max_time > 0,
-                       lambda: tf.dtypes.cast(max_time, dtype=tf.int32),
-                       lambda: tf.dtypes.cast(1, dtype=tf.int32))
+    max_time = tf.cond(max_time > track_length,
+                       lambda: tf.cast(max_time - track_length, tf.int32),
+                       lambda: tf.cast(1, tf.int32))
 
     t_start = tf.random.uniform(shape=[], minval=0,
                                 maxval=max_time,
@@ -74,7 +334,7 @@ def temporal_slice(X, y, track_length=8):
         n_dim = len(shape)
         start = [t_start] + [0] * (n_dim - 1)
         size = [t_length] + shape[1:]
-        sp_slice = tf.sparse.slice(sp, start, size)
+        sp_slice = tf.sparse.slice(sp, start=start, size=size)
         return tf.sparse.to_dense(sp_slice)
 
     for key, data in X.items():
@@ -139,13 +399,17 @@ def random_translate(X, y, range=512):
     return X, y
 
 
-def prepare_dataset(track_info, batch_size=32, buffer_size=256,
+def prepare_dataset(tracked_data=None, path=None,
+                    batch_size=32, buffer_size=256,
                     seed=None, track_length=8, rotation_range=0,
                     translation_range=0, val_size=0.2, test_size=0):
     """Build and prepare the tracking dataset.
 
     Args:
-        track_info (dict): A dictionary of all input and output features
+        tracked_data (dict): A dictionary of data from a trks file.
+            Only one of ``tracked_data`` and ``path`` can be used.
+        path (str): A filepath to a .trks file.
+            Only one of ``tracked_data`` and ``path`` can be used.
         batch_size (int): number of examples per batch
         buffer_size (int): number of samples to buffer
         seed (int): Random seed
@@ -159,6 +423,9 @@ def prepare_dataset(track_info, batch_size=32, buffer_size=256,
     Returns:
         tf.data.Dataset: A ``tf.data.Dataset`` object ready for training.
     """
+
+    track_info = concat_tracks([Track(path=path, tracked_data=tracked_data)])
+
     input_dict = {
         'appearances': track_info['appearances'],
         'centroids': track_info['centroids'],

--- a/deepcell/data/tracking_test.py
+++ b/deepcell/data/tracking_test.py
@@ -31,12 +31,121 @@ from __future__ import print_function
 
 from absl.testing import parameterized
 
+import pytest
+
 import numpy as np
 import tensorflow as tf
 
 from tensorflow.python.platform import test
 
+from deepcell_tracking.test_utils import get_annotated_movie
+
 from deepcell.data import tracking
+
+
+def get_dummy_data(num_labels=3, batches=2):
+    num_labels = 3
+    movies = []
+    for _ in range(batches):
+        movies.append(get_annotated_movie(labels_per_frame=num_labels))
+
+    y = np.stack(movies, axis=0)
+    X = np.random.random(y.shape)
+
+    # create dummy lineage
+    lineages = {}
+    for b in range(X.shape[0]):
+        lineages[b] = {}
+        for frame in range(X.shape[1]):
+            unique_labels = np.unique(y[b, frame])
+            unique_labels = unique_labels[unique_labels != 0]
+            for unique_label in unique_labels:
+                if unique_label not in lineages[b]:
+                    lineages[b][unique_label] = {
+                        'frames': [frame],
+                        'parent': None,
+                        'daughters': [],
+                        'label': unique_label,
+                    }
+                else:
+                    lineages[b][unique_label]['frames'].append(frame)
+
+    # tracks expect batched data
+    data = {'X': X, 'y': y, 'lineages': lineages}
+    return data
+
+
+class TestTrack(object):
+
+    def test_init(self, mocker):
+        num_labels = 3
+
+        data = get_dummy_data(num_labels)
+
+        # mock reading from disk to return the expected data
+        mocker.patch('deepcell.data.tracking.load_trks',
+                     lambda x: data)
+
+        track1 = tracking.Track(tracked_data=data)
+        track2 = tracking.Track(path='path/to/data')
+
+        np.testing.assert_array_equal(track1.appearances, track2.appearances)
+        np.testing.assert_array_equal(
+            tf.sparse.to_dense(track1.temporal_adj_matrices),
+            tf.sparse.to_dense(track2.temporal_adj_matrices))
+
+        with pytest.raises(ValueError):
+            tracking.Track()
+
+    def test_x_y_padding(self):
+        num_labels = 3
+
+        data = get_dummy_data(num_labels)
+
+        pads = [(0, 5) if i in {2, 3} else (0, 0) for i in range(data['y'].ndim)]
+
+        padded_data = {
+            'X': np.pad(data['X'], pads, mode='constant'),
+            'y': np.pad(data['y'], pads, mode='constant'),
+            'lineages': data['lineages'],
+        }
+
+        unpadded = tracking.Track(tracked_data=data)
+        padded = tracking.Track(tracked_data=padded_data)
+
+        np.testing.assert_array_equal(unpadded.appearances, padded.appearances)
+        np.testing.assert_array_equal(
+            tf.sparse.to_dense(unpadded.temporal_adj_matrices),
+            tf.sparse.to_dense(padded.temporal_adj_matrices))
+
+    def test_concat_tracks(self):
+        num_labels = 3
+
+        data = get_dummy_data(num_labels)
+        track_1 = tracking.Track(tracked_data=data)
+        track_2 = tracking.Track(tracked_data=data)
+
+        data = tracking.concat_tracks([track_1, track_2])
+
+        for k, v in data.items():
+            starting_batch = 0
+            for t in (track_1, track_2):
+                assert hasattr(t, k)
+                w = getattr(t, k)
+                if not isinstance(w, tf.sparse.SparseTensor):
+                    # data is put into top left corner of array
+                    v_sub = v[
+                        starting_batch:starting_batch + w.shape[0],
+                        0:w.shape[1],
+                        0:w.shape[2],
+                        0:w.shape[3]
+                    ]
+                    np.testing.assert_array_equal(v_sub, w)
+                # TODO: how to test the sparse tensors?
+
+        # test that input must be iterable
+        with pytest.raises(TypeError):
+            tracking.concat_tracks(track_1)
 
 
 @parameterized.named_parameters([
@@ -128,14 +237,16 @@ class TrackingTests(test.TestCase, parameterized.TestCase):
                              batch_size, seed, track_length,
                              val_size, test_size):
         # Create track_info and prepare the dataset
-        track_info = self.create_track_info(226, time, max_cells, crop_size)
-        train_data, val_data, test_data = tracking.prepare_dataset(track_info,
-                                                                   rotation_range=180,
-                                                                   batch_size=batch_size,
-                                                                   seed=seed,
-                                                                   track_length=track_length,
-                                                                   val_size=val_size,
-                                                                   test_size=test_size)
+        tracked_data = get_dummy_data(num_labels=3, batches=batch_size * 2)
+        train_data, val_data, test_data = tracking.prepare_dataset(
+            tracked_data,
+            rotation_range=180,
+            batch_size=batch_size,
+            seed=seed,
+            track_length=track_length,
+            val_size=val_size,
+            test_size=test_size)
+
         # Test data correctly batched
         for X, y in train_data.take(1):
             self.assertEqual((X['appearances'].shape)[0], batch_size)
@@ -151,26 +262,13 @@ class TrackingTests(test.TestCase, parameterized.TestCase):
         y = {}
         X['appearances'] = tf.random.uniform([time, max_cells, crop_size, crop_size, 1], 0, 1)
         X['centroids'] = tf.random.uniform([time, max_cells, 2], 0, 512)
-        X['morphologies'] = tf.random.uniform([time, max_cells, 3], 0, 1)
-        X['adj_matrices'] = tf.random.uniform([time, max_cells, max_cells], 0, 1)
-        y['temporal_adj_matrices'] = tf.random.uniform([time - 1, max_cells, max_cells, 3], 0, 1)
+        X['morphologies'] = tf.sparse.from_dense(
+            tf.random.uniform([time, max_cells, 3], 0, 1))
+        X['adj_matrices'] = tf.sparse.from_dense(
+            tf.random.uniform([time, max_cells, max_cells], 0, 1))
+        y['temporal_adj_matrices'] = tf.sparse.from_dense(
+            tf.random.uniform([time - 1, max_cells, max_cells, 3], 0, 1))
         return X, y
-
-    def create_track_info(self, n_batches, time, max_cells, crop_size):
-        # Create track_info input (dictionary of all input and output features) with correct
-        # dimensions for prepare_dataset function.
-        track_info = {}
-        track_info['appearances'] = tf.random.uniform([n_batches, time, max_cells,
-                                                       crop_size, crop_size, 1], 0, 1)
-        track_info['centroids'] = tf.random.uniform([n_batches, time, max_cells, 2], 0, 512)
-        track_info['morphologies'] = tf.random.uniform([n_batches, time, max_cells, 3], 0, 1)
-        track_info['adj_matrices'] = tf.random.uniform([n_batches, time, max_cells, max_cells],
-                                                       0, 1)
-        track_info['norm_adj_matrices'] = tf.random.uniform([n_batches, time, max_cells,
-                                                            max_cells], 0, 1)
-        track_info['temporal_adj_matrices'] = tf.random.uniform([n_batches, time - 1, max_cells,
-                                                                max_cells, 3], 0, 1)
-        return track_info
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ tensorflow~=2.5.1
 tensorflow_addons~=0.13.0
 spektral~=1.0.4
 jupyter>=1.0.0,<2
-deepcell-tracking~=0.4.4
+deepcell-tracking~=0.5.0rc3
 deepcell-toolbox~=0.10.0

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'spektral~=1.0.4',
         'jupyter>=1.0.0,<2',
         'opencv-python-headless<5',
-        'deepcell-tracking~=0.4.4',
+        'deepcell-tracking~=0.5.0rc3',
         'deepcell-toolbox~=0.10.0'
     ],
     extras_require={


### PR DESCRIPTION
## What
* Update the adjacency matrix data from to a sparse tensor to significantly reduce memory footprint.
* Move `Track` and `concat_tracks` functions from `deepcell-tracking` to `deepcell.data.tracking`. They are really just `.trk` preprocessing and are unnecessary outside of `prepare_data`.
* Update `temporal_slice` to not slice into padded frames.
* Bump `deepcell-tracking` to 0.5.0rc3. This should be a major release before this PR is merged.

## Why
* Continue to upgrade the tracking model to make it more usable.
* The `temporal_slice` fix should improve the precision metrics of the model by not training on padded data.
