### PR TITLE
Update nuclear and cytoplasm segmentation models from the data-registry

### DIFF
--- a/deepcell/applications/cytoplasm_segmentation.py
+++ b/deepcell/applications/cytoplasm_segmentation.py
@@ -41,6 +41,7 @@ from deepcell.applications import Application
 
 MODEL_PATH = ('https://deepcell-data.s3-us-west-1.amazonaws.com/'
               'saved-models/CytoplasmSegmentation-3.tar.gz')
+MODEL_HASH = '6a244f561b4d37169cb1a58b6029910f'
 
 
 class CytoplasmSegmentation(Application):
@@ -99,7 +100,7 @@ class CytoplasmSegmentation(Application):
         if model is None:
             archive_path = tf.keras.utils.get_file(
                 'CytoplasmSegmentation.tgz', MODEL_PATH,
-                file_hash='3a44131177f2c66457bad444d8973708',
+                file_hash=MODEL_HASH,
                 extract=True, cache_subdir='models'
             )
             model_path = os.path.splitext(archive_path)[0]

--- a/deepcell/applications/nuclear_segmentation.py
+++ b/deepcell/applications/nuclear_segmentation.py
@@ -40,8 +40,8 @@ from deepcell.applications import Application
 
 
 MODEL_PATH = ('https://deepcell-data.s3-us-west-1.amazonaws.com/'
-              'saved-models/NuclearSegmentation-4.tar.gz')
-
+              'saved-models/NuclearSegmentation-5.tar.gz')
+MODEL_HASH = 'c3667ffbe08035c9cb69ed882e4a49d7'
 
 class NuclearSegmentation(Application):
     """Loads a :mod:`deepcell.model_zoo.panopticnet.PanopticNet` model
@@ -99,7 +99,7 @@ class NuclearSegmentation(Application):
         if model is None:
             archive_path = tf.keras.utils.get_file(
                 'NuclearSegmentation.tgz', MODEL_PATH,
-                file_hash='99ea4fe44cd8c20eb224565ee7a242b4',
+                file_hash=MODEL_HASH,
                 extract=True, cache_subdir='models'
             )
             model_path = os.path.splitext(archive_path)[0]

--- a/deepcell/applications/nuclear_segmentation.py
+++ b/deepcell/applications/nuclear_segmentation.py
@@ -43,6 +43,7 @@ MODEL_PATH = ('https://deepcell-data.s3-us-west-1.amazonaws.com/'
               'saved-models/NuclearSegmentation-5.tar.gz')
 MODEL_HASH = 'c3667ffbe08035c9cb69ed882e4a49d7'
 
+
 class NuclearSegmentation(Application):
     """Loads a :mod:`deepcell.model_zoo.panopticnet.PanopticNet` model
     for nuclear segmentation with pretrained weights.


### PR DESCRIPTION
* Updates nuclear segmentation model with the version created by https://github.com/vanvalenlab/data-registry/pull/188
* Update cytoplasm segmentation model with the version created by https://github.com/vanvalenlab/data-registry/pull/164

The same models have been uploaded to the deepcell-models bucket in GCP for deployment through the kiosk.