### PR TITLE
Modify testing workflow allow manual dispatch of workflow with different operating systems

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,11 +9,12 @@ jobs:
 
   tests:
 
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,14 @@
 
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      operating_system:
+        description: 'Operating system of the runner'
+        required: true
 
 jobs:
 
@@ -12,9 +19,8 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        os: [macos-latest, ubuntu-latest, windows-latest]
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ github.event.inputs.operating_system || 'ubuntu-latest' }}
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## What
* Adds a workflow dispatch trigger to our testing workflow that allows a user to run the workflow with a different runner operating system
* The default operating system for tests triggered by a push or pull_request is ubuntu-latest

## Why
* Users have reported issues installing deepcell on particular operating systems. This modification to the workflow allows us to test operating systems as needed, but will not clutter our usage of github actions with testing all possible operating systems every time we run tests.

## Note
* Workflow_dispatch events usually don't work until they are merged into the default branch so although the manual dispatch is not visible now it should appear after merging.
