### PR TITLE
Add option for graph attention layer to tracking model

### DIFF
--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -378,21 +378,21 @@ class GNNTrackingModel(object):
         node_features = Activation('relu', name='relu_ne0')(node_features)
 
         # Apply graph convolution
+        # Extract and define layer name
+        graph_layer_name = str(self.graph_layer.split('-')[0]).lower()
+        # Extract layer kwargs
+        split = self.graph_layer.split('-')
+        layer_kwargs = {}
+        if len(split) > 1:
+            for item in split[1:]:
+                k, v = item.split(':')
+                # Cast value to correct type
+                try:
+                    layer_kwargs[k] = ast.literal_eval(v)
+                except ValueError:
+                    layer_kwargs[k] = v
         for i in range(self.n_layers):
-            # Extract and define layer name
-            graph_layer_name = str(self.graph_layer.split('-')[0]).lower()
             name = '{}{}'.format(graph_layer_name, i)
-            # Extract layer kwargs
-            split = self.graph_layer.split('-')
-            layer_kwargs = {}
-            if len(split) > 1:
-                for item in split[1:]:
-                    k, v = item.split(':')
-                    # Cast value to correct type
-                    try:
-                        layer_kwargs[k] = ast.literal_eval(v)
-                    except ValueError:
-                        layer_kwargs[k] = v
             if graph_layer_name == 'gcn':
                 graph_layer = GCNConv(self.n_filters, activation=None, name=name, **layer_kwargs)
             elif graph_layer_name == 'gcs':

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -45,7 +45,7 @@ from tensorflow.keras.layers import Activation, Softmax
 from tensorflow.keras.layers import BatchNormalization, Lambda
 from tensorflow.keras.regularizers import l2
 
-from spektral.layers import GCSConv, GCNConv
+from spektral.layers import GCSConv, GCNConv, GATConv
 
 from deepcell.layers import ImageNormalization2D
 from deepcell.layers import Comparison, DeltaReshape, Unmerge, TemporalMerge
@@ -245,7 +245,7 @@ class GNNTrackingModel(object):
                              'and each side should be a power of 2.')
 
         graph_layer = str(graph_layer).lower()
-        if graph_layer not in {'gcn', 'gcs'}:
+        if graph_layer not in {'gcn', 'gcs', 'gat'}:
             raise ValueError('Invalid graph_layer: {}'.format(graph_layer))
         self.graph_layer = graph_layer
 
@@ -380,6 +380,8 @@ class GNNTrackingModel(object):
                 graph_layer = GCNConv(self.n_filters, activation=None, name=name)
             elif self.graph_layer == 'gcs':
                 graph_layer = GCSConv(self.n_filters, activation=None, name=name)
+            elif self.graph_layer == 'gat':
+                graph_layer = GATConv(self.n_filters, activation=None, name=name, attn_heads=4)
             else:
                 raise ValueError('Unexpected graph_layer: {}'.format(self.graph_layer))
 


### PR DESCRIPTION
## What
* Exposes an option to use the graph attention layer `GATConv` from `spektral`

## Why
* Allows us to test the impact of different graph layers on the tracking model
