### PR TITLE
Pin `jinja2<3.1` to restore functional docs builds

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -6,3 +6,5 @@ ipython
 nbsphinx
 nbsphinx-link
 sphinx-rtd-theme
+# Jinja2 imports for sphinx are deprecated over 3.1
+Jinja2<3.1


### PR DESCRIPTION
## What
* Pins `jinja2<3.1` in `docs/requirements-docs.txt`

## Why
* The new `jinja2` release deprecates functions that are required for `sphinx`.