### PR TITLE
Update Tensorflow to 2.8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 # Use tensorflow/tensorflow as the base image
 # Change the build arg to edit the tensorflow version.
 # Only supporting python3.
-ARG TF_VERSION=2.5.1-gpu
+ARG TF_VERSION=2.8.0-gpu
 
 FROM tensorflow/tensorflow:${TF_VERSION}
 
+# https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 # System maintenance
 RUN apt-get update && apt-get install -y  \
-    graphviz && \
+    graphviz git && \
     rm -rf /var/lib/apt/lists/* && \
     /usr/bin/python3 -m pip install --no-cache-dir --upgrade pip
 

--- a/deepcell/callbacks_test.py
+++ b/deepcell/callbacks_test.py
@@ -32,8 +32,8 @@ from __future__ import division
 import sys
 
 import tensorflow as tf
-from tensorflow.python.keras import keras_parameterized
-from tensorflow.python.keras import testing_utils
+from tensorflow.keras import keras_parameterized
+from tensorflow.keras import testing_utils
 from tensorflow.python.framework import test_util as tf_test_util
 
 from deepcell import callbacks

--- a/deepcell/callbacks_test.py
+++ b/deepcell/callbacks_test.py
@@ -32,8 +32,8 @@ from __future__ import division
 import sys
 
 import tensorflow as tf
-from tensorflow.keras import keras_parameterized
-from tensorflow.keras import testing_utils
+from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.keras import testing_utils
 from tensorflow.python.framework import test_util as tf_test_util
 
 from deepcell import callbacks

--- a/deepcell/image_generators/cropping.py
+++ b/deepcell/image_generators/cropping.py
@@ -34,7 +34,7 @@ import warnings
 
 import numpy as np
 
-from tensorflow.keras.preprocessing.image import array_to_img
+from tensorflow.python.keras.preprocessing.image import array_to_img
 
 from deepcell.image_generators import SemanticDataGenerator, SemanticIterator
 

--- a/deepcell/image_generators/cropping.py
+++ b/deepcell/image_generators/cropping.py
@@ -34,7 +34,7 @@ import warnings
 
 import numpy as np
 
-from tensorflow.python.keras.preprocessing.image import array_to_img
+from tensorflow.keras.preprocessing.image import array_to_img
 
 from deepcell.image_generators import SemanticDataGenerator, SemanticIterator
 

--- a/deepcell/image_generators/sample.py
+++ b/deepcell/image_generators/sample.py
@@ -43,7 +43,7 @@ from tensorflow.keras.utils import to_categorical
 from tensorflow.keras.preprocessing.image import array_to_img
 from tensorflow.keras.preprocessing.image import Iterator
 from tensorflow.keras.preprocessing.image import ImageDataGenerator
-from tensorflow.python.keras.utils import conv_utils
+from tensorflow.keras.utils import conv_utils
 
 from deepcell.image_generators import _transform_masks
 

--- a/deepcell/image_generators/sample.py
+++ b/deepcell/image_generators/sample.py
@@ -43,7 +43,7 @@ from tensorflow.keras.utils import to_categorical
 from tensorflow.keras.preprocessing.image import array_to_img
 from tensorflow.keras.preprocessing.image import Iterator
 from tensorflow.keras.preprocessing.image import ImageDataGenerator
-from tensorflow.keras.utils import conv_utils
+from keras.utils import conv_utils
 
 from deepcell.image_generators import _transform_masks
 

--- a/deepcell/image_generators/sample.py
+++ b/deepcell/image_generators/sample.py
@@ -43,7 +43,7 @@ from tensorflow.keras.utils import to_categorical
 from tensorflow.keras.preprocessing.image import array_to_img
 from tensorflow.keras.preprocessing.image import Iterator
 from tensorflow.keras.preprocessing.image import ImageDataGenerator
-from tensorflow.keras.utils import conv_utils
+from tensorflow.python.keras.utils import conv_utils
 
 from deepcell.image_generators import _transform_masks
 

--- a/deepcell/layers/convolutional_recurrent.py
+++ b/deepcell/layers/convolutional_recurrent.py
@@ -44,9 +44,9 @@ from tensorflow.keras import constraints
 from tensorflow.keras import initializers
 from tensorflow.keras import regularizers
 from tensorflow.keras.layers import Layer
-from tensorflow.keras.layers.recurrent import DropoutRNNCellMixin
-from tensorflow.keras.layers.convolutional_recurrent import ConvRNN2D
-from tensorflow.keras.utils import conv_utils
+from tensorflow.python.keras.layers.recurrent import DropoutRNNCellMixin
+from tensorflow.python.keras.layers.convolutional_recurrent import ConvRNN2D
+from tensorflow.python.keras.utils import conv_utils
 
 
 class ConvGRU2DCell(DropoutRNNCellMixin, Layer):

--- a/deepcell/layers/convolutional_recurrent.py
+++ b/deepcell/layers/convolutional_recurrent.py
@@ -44,9 +44,9 @@ from tensorflow.keras import constraints
 from tensorflow.keras import initializers
 from tensorflow.keras import regularizers
 from tensorflow.keras.layers import Layer
-from tensorflow.python.keras.layers.recurrent import DropoutRNNCellMixin
-from tensorflow.python.keras.layers.convolutional_recurrent import ConvRNN2D
-from tensorflow.python.keras.utils import conv_utils
+from tensorflow.keras.layers.recurrent import DropoutRNNCellMixin
+from tensorflow.keras.layers.convolutional_recurrent import ConvRNN2D
+from tensorflow.keras.utils import conv_utils
 
 
 class ConvGRU2DCell(DropoutRNNCellMixin, Layer):

--- a/deepcell/layers/convolutional_recurrent_test.py
+++ b/deepcell/layers/convolutional_recurrent_test.py
@@ -9,8 +9,8 @@ from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf
 
-from tensorflow.keras import keras_parameterized
-from tensorflow.keras import testing_utils
+from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.keras import testing_utils
 from tensorflow.python.framework import test_util as tf_test_util
 
 from deepcell import layers

--- a/deepcell/layers/convolutional_recurrent_test.py
+++ b/deepcell/layers/convolutional_recurrent_test.py
@@ -9,8 +9,8 @@ from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf
 
-from tensorflow.python.keras import keras_parameterized
-from tensorflow.python.keras import testing_utils
+from tensorflow.keras import keras_parameterized
+from tensorflow.keras import testing_utils
 from tensorflow.python.framework import test_util as tf_test_util
 
 from deepcell import layers

--- a/deepcell/layers/location.py
+++ b/deepcell/layers/location.py
@@ -32,7 +32,7 @@ from __future__ import division
 import tensorflow as tf
 from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Layer
-from tensorflow.keras.utils import conv_utils
+from tensorflow.python.keras.utils import conv_utils
 from tensorflow.python.framework import tensor_shape
 
 

--- a/deepcell/layers/location.py
+++ b/deepcell/layers/location.py
@@ -32,7 +32,7 @@ from __future__ import division
 import tensorflow as tf
 from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Layer
-from tensorflow.python.keras.utils import conv_utils
+from tensorflow.keras.utils import conv_utils
 from tensorflow.python.framework import tensor_shape
 
 

--- a/deepcell/layers/location.py
+++ b/deepcell/layers/location.py
@@ -32,7 +32,7 @@ from __future__ import division
 import tensorflow as tf
 from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Layer
-from tensorflow.keras.utils import conv_utils
+from keras.utils import conv_utils
 from tensorflow.python.framework import tensor_shape
 
 

--- a/deepcell/layers/location_test.py
+++ b/deepcell/layers/location_test.py
@@ -28,8 +28,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
-from tensorflow.python.keras import testing_utils
-from tensorflow.python.keras import keras_parameterized
+from tensorflow.keras import testing_utils
+from tensorflow.keras import keras_parameterized
 from tensorflow.keras.utils import custom_object_scope
 from tensorflow.python.platform import test
 

--- a/deepcell/layers/location_test.py
+++ b/deepcell/layers/location_test.py
@@ -28,8 +28,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
-from tensorflow.keras import testing_utils
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import testing_utils
+from tensorflow.python.keras import keras_parameterized
 from tensorflow.keras.utils import custom_object_scope
 from tensorflow.python.platform import test
 

--- a/deepcell/layers/normalization.py
+++ b/deepcell/layers/normalization.py
@@ -37,7 +37,7 @@ from tensorflow.keras import constraints
 from tensorflow.keras import initializers
 from tensorflow.keras import regularizers
 from tensorflow.keras.layers import Layer, InputSpec
-from tensorflow.python.keras.utils import conv_utils
+from tensorflow.keras.utils import conv_utils
 
 
 class ImageNormalization2D(Layer):

--- a/deepcell/layers/normalization.py
+++ b/deepcell/layers/normalization.py
@@ -37,7 +37,7 @@ from tensorflow.keras import constraints
 from tensorflow.keras import initializers
 from tensorflow.keras import regularizers
 from tensorflow.keras.layers import Layer, InputSpec
-from tensorflow.keras.utils import conv_utils
+from tensorflow.python.keras.utils import conv_utils
 
 
 class ImageNormalization2D(Layer):

--- a/deepcell/layers/normalization.py
+++ b/deepcell/layers/normalization.py
@@ -37,7 +37,7 @@ from tensorflow.keras import constraints
 from tensorflow.keras import initializers
 from tensorflow.keras import regularizers
 from tensorflow.keras.layers import Layer, InputSpec
-from tensorflow.keras.utils import conv_utils
+from keras.utils import conv_utils
 
 
 class ImageNormalization2D(Layer):

--- a/deepcell/layers/normalization_test.py
+++ b/deepcell/layers/normalization_test.py
@@ -33,8 +33,8 @@ from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf
 
-from tensorflow.keras import keras_parameterized
-from tensorflow.keras import testing_utils
+from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.keras import testing_utils
 from tensorflow.python.framework import test_util as tf_test_util
 from tensorflow.python.platform import test
 

--- a/deepcell/layers/normalization_test.py
+++ b/deepcell/layers/normalization_test.py
@@ -33,8 +33,8 @@ from absl.testing import parameterized
 import numpy as np
 import tensorflow as tf
 
-from tensorflow.python.keras import keras_parameterized
-from tensorflow.python.keras import testing_utils
+from tensorflow.keras import keras_parameterized
+from tensorflow.keras import testing_utils
 from tensorflow.python.framework import test_util as tf_test_util
 from tensorflow.python.platform import test
 

--- a/deepcell/layers/padding_test.py
+++ b/deepcell/layers/padding_test.py
@@ -36,8 +36,8 @@ from absl.testing import parameterized
 
 from tensorflow.python import keras
 # from tensorflow.python.eager import context
-from tensorflow.keras import keras_parameterized
-from tensorflow.keras import testing_utils
+from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.keras import testing_utils
 from tensorflow.python.platform import test
 
 from deepcell import layers

--- a/deepcell/layers/padding_test.py
+++ b/deepcell/layers/padding_test.py
@@ -36,8 +36,8 @@ from absl.testing import parameterized
 
 from tensorflow.python import keras
 # from tensorflow.python.eager import context
-from tensorflow.python.keras import keras_parameterized
-from tensorflow.python.keras import testing_utils
+from tensorflow.keras import keras_parameterized
+from tensorflow.keras import testing_utils
 from tensorflow.python.platform import test
 
 from deepcell import layers

--- a/deepcell/layers/pooling.py
+++ b/deepcell/layers/pooling.py
@@ -34,7 +34,7 @@ from tensorflow.python.framework import tensor_shape
 from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Layer
 from tensorflow.keras.layers import InputSpec
-from tensorflow.keras.utils import conv_utils
+from tensorflow.python.keras.utils import conv_utils
 
 
 class DilatedMaxPool2D(Layer):

--- a/deepcell/layers/pooling.py
+++ b/deepcell/layers/pooling.py
@@ -34,7 +34,7 @@ from tensorflow.python.framework import tensor_shape
 from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Layer
 from tensorflow.keras.layers import InputSpec
-from tensorflow.python.keras.utils import conv_utils
+from tensorflow.keras.utils import conv_utils
 
 
 class DilatedMaxPool2D(Layer):

--- a/deepcell/layers/pooling.py
+++ b/deepcell/layers/pooling.py
@@ -34,7 +34,7 @@ from tensorflow.python.framework import tensor_shape
 from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Layer
 from tensorflow.keras.layers import InputSpec
-from tensorflow.keras.utils import conv_utils
+from keras.utils import conv_utils
 
 
 class DilatedMaxPool2D(Layer):

--- a/deepcell/layers/pooling_test.py
+++ b/deepcell/layers/pooling_test.py
@@ -30,8 +30,8 @@ from __future__ import division
 
 from absl.testing import parameterized
 
-from tensorflow.keras import keras_parameterized
-from tensorflow.keras import testing_utils
+from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.keras import testing_utils
 from tensorflow.keras.utils import custom_object_scope
 from tensorflow.python.framework import test_util as tf_test_util
 from tensorflow.python.platform import test

--- a/deepcell/layers/pooling_test.py
+++ b/deepcell/layers/pooling_test.py
@@ -30,8 +30,8 @@ from __future__ import division
 
 from absl.testing import parameterized
 
-from tensorflow.python.keras import keras_parameterized
-from tensorflow.python.keras import testing_utils
+from tensorflow.keras import keras_parameterized
+from tensorflow.keras import testing_utils
 from tensorflow.keras.utils import custom_object_scope
 from tensorflow.python.framework import test_util as tf_test_util
 from tensorflow.python.platform import test

--- a/deepcell/layers/temporal_test.py
+++ b/deepcell/layers/temporal_test.py
@@ -30,8 +30,8 @@ from __future__ import division
 
 import numpy as np
 from tensorflow.keras import backend as K
-from tensorflow.python.keras import keras_parameterized
-from tensorflow.python.keras import testing_utils
+from tensorflow.keras import keras_parameterized
+from tensorflow.keras import testing_utils
 from tensorflow.keras.utils import custom_object_scope
 from tensorflow.python.platform import test
 

--- a/deepcell/layers/temporal_test.py
+++ b/deepcell/layers/temporal_test.py
@@ -30,8 +30,8 @@ from __future__ import division
 
 import numpy as np
 from tensorflow.keras import backend as K
-from tensorflow.keras import keras_parameterized
-from tensorflow.keras import testing_utils
+from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.keras import testing_utils
 from tensorflow.keras.utils import custom_object_scope
 from tensorflow.python.platform import test
 

--- a/deepcell/layers/tensor_product.py
+++ b/deepcell/layers/tensor_product.py
@@ -34,7 +34,7 @@ from tensorflow.python.framework import tensor_shape
 from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Layer
 from tensorflow.keras.layers import InputSpec
-from tensorflow.keras.utils import conv_utils
+from keras.utils import conv_utils
 
 
 class TensorProduct(Layer):

--- a/deepcell/layers/tensor_product.py
+++ b/deepcell/layers/tensor_product.py
@@ -34,7 +34,7 @@ from tensorflow.python.framework import tensor_shape
 from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Layer
 from tensorflow.keras.layers import InputSpec
-from tensorflow.python.keras.utils import conv_utils
+from tensorflow.keras.utils import conv_utils
 
 
 class TensorProduct(Layer):

--- a/deepcell/layers/tensor_product.py
+++ b/deepcell/layers/tensor_product.py
@@ -34,7 +34,7 @@ from tensorflow.python.framework import tensor_shape
 from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Layer
 from tensorflow.keras.layers import InputSpec
-from tensorflow.keras.utils import conv_utils
+from tensorflow.python.keras.utils import conv_utils
 
 
 class TensorProduct(Layer):

--- a/deepcell/layers/tensor_product_test.py
+++ b/deepcell/layers/tensor_product_test.py
@@ -32,8 +32,8 @@ import numpy as np
 import tensorflow as tf
 
 from tensorflow.python import keras
-from tensorflow.keras import keras_parameterized
-from tensorflow.keras import testing_utils
+from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.keras import testing_utils
 from tensorflow.python.platform import test
 
 from deepcell import layers

--- a/deepcell/layers/tensor_product_test.py
+++ b/deepcell/layers/tensor_product_test.py
@@ -32,8 +32,8 @@ import numpy as np
 import tensorflow as tf
 
 from tensorflow.python import keras
-from tensorflow.python.keras import keras_parameterized
-from tensorflow.python.keras import testing_utils
+from tensorflow.keras import keras_parameterized
+from tensorflow.keras import testing_utils
 from tensorflow.python.platform import test
 
 from deepcell import layers

--- a/deepcell/layers/upsample.py
+++ b/deepcell/layers/upsample.py
@@ -32,7 +32,7 @@ import tensorflow as tf
 from tensorflow.python.framework import tensor_shape
 from tensorflow.keras.layers import Layer
 from tensorflow.keras import backend as K
-from tensorflow.keras.utils import conv_utils
+from keras.utils import conv_utils
 
 
 class UpsampleLike(Layer):

--- a/deepcell/layers/upsample.py
+++ b/deepcell/layers/upsample.py
@@ -32,7 +32,7 @@ import tensorflow as tf
 from tensorflow.python.framework import tensor_shape
 from tensorflow.keras.layers import Layer
 from tensorflow.keras import backend as K
-from tensorflow.python.keras.utils import conv_utils
+from tensorflow.keras.utils import conv_utils
 
 
 class UpsampleLike(Layer):

--- a/deepcell/layers/upsample.py
+++ b/deepcell/layers/upsample.py
@@ -32,7 +32,7 @@ import tensorflow as tf
 from tensorflow.python.framework import tensor_shape
 from tensorflow.keras.layers import Layer
 from tensorflow.keras import backend as K
-from tensorflow.keras.utils import conv_utils
+from tensorflow.python.keras.utils import conv_utils
 
 
 class UpsampleLike(Layer):

--- a/deepcell/layers/upsample_test.py
+++ b/deepcell/layers/upsample_test.py
@@ -30,8 +30,8 @@ from __future__ import division
 
 import numpy as np
 from tensorflow.keras import backend as K
-from tensorflow.python.keras import keras_parameterized
-from tensorflow.python.keras import testing_utils
+from tensorflow.keras import keras_parameterized
+from tensorflow.keras import testing_utils
 from tensorflow.keras.utils import custom_object_scope
 from tensorflow.python.platform import test
 

--- a/deepcell/layers/upsample_test.py
+++ b/deepcell/layers/upsample_test.py
@@ -30,8 +30,8 @@ from __future__ import division
 
 import numpy as np
 from tensorflow.keras import backend as K
-from tensorflow.keras import keras_parameterized
-from tensorflow.keras import testing_utils
+from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.keras import testing_utils
 from tensorflow.keras.utils import custom_object_scope
 from tensorflow.python.platform import test
 

--- a/deepcell/model_zoo/featurenet_test.py
+++ b/deepcell/model_zoo/featurenet_test.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 from absl.testing import parameterized
 
 from tensorflow.python.framework import test_util as tf_test_util
-from tensorflow.python.keras import keras_parameterized
+from tensorflow.keras import keras_parameterized
 
 from tensorflow.keras import backend as K
 

--- a/deepcell/model_zoo/featurenet_test.py
+++ b/deepcell/model_zoo/featurenet_test.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 from absl.testing import parameterized
 
 from tensorflow.python.framework import test_util as tf_test_util
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 
 from tensorflow.keras import backend as K
 

--- a/deepcell/model_zoo/panopticnet_test.py
+++ b/deepcell/model_zoo/panopticnet_test.py
@@ -33,7 +33,7 @@ from absl.testing import parameterized
 
 from tensorflow.test import assert_equal_graph_def
 from tensorflow.keras import backend as K
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.model_zoo import PanopticNet
 

--- a/deepcell/model_zoo/panopticnet_test.py
+++ b/deepcell/model_zoo/panopticnet_test.py
@@ -33,7 +33,7 @@ from absl.testing import parameterized
 
 from tensorflow.test import assert_equal_graph_def
 from tensorflow.keras import backend as K
-from tensorflow.python.keras import keras_parameterized
+from tensorflow.keras import keras_parameterized
 
 from deepcell.model_zoo import PanopticNet
 

--- a/deepcell/model_zoo/tracking_test.py
+++ b/deepcell/model_zoo/tracking_test.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 from absl.testing import parameterized
 
 from tensorflow.python.framework import test_util as tf_test_util
-from tensorflow.python.keras import keras_parameterized
+from tensorflow.keras import keras_parameterized
 
 from tensorflow.keras import backend as K
 

--- a/deepcell/model_zoo/tracking_test.py
+++ b/deepcell/model_zoo/tracking_test.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 from absl.testing import parameterized
 
 from tensorflow.python.framework import test_util as tf_test_util
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 
 from tensorflow.keras import backend as K
 

--- a/deepcell/utils/backbone_utils_test.py
+++ b/deepcell/utils/backbone_utils_test.py
@@ -37,7 +37,7 @@ from tensorflow.python.platform import test
 from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Input
 from tensorflow.keras.models import Model
-from tensorflow.keras import keras_parameterized
+from tensorflow.python.keras import keras_parameterized
 
 from deepcell.utils import backbone_utils
 

--- a/deepcell/utils/backbone_utils_test.py
+++ b/deepcell/utils/backbone_utils_test.py
@@ -37,7 +37,7 @@ from tensorflow.python.platform import test
 from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Input
 from tensorflow.keras.models import Model
-from tensorflow.python.keras import keras_parameterized
+from tensorflow.keras import keras_parameterized
 
 from deepcell.utils import backbone_utils
 

--- a/deepcell/utils/data_utils.py
+++ b/deepcell/utils/data_utils.py
@@ -32,7 +32,7 @@ from __future__ import division
 import numpy as np
 from sklearn.model_selection import train_test_split
 from tensorflow.keras import backend as K
-from tensorflow.keras.utils import conv_utils
+from keras.utils import conv_utils
 
 from deepcell.utils.tracking_utils import load_trks
 

--- a/deepcell/utils/data_utils.py
+++ b/deepcell/utils/data_utils.py
@@ -32,7 +32,7 @@ from __future__ import division
 import numpy as np
 from sklearn.model_selection import train_test_split
 from tensorflow.keras import backend as K
-from tensorflow.python.keras.utils import conv_utils
+from tensorflow.keras.utils import conv_utils
 
 from deepcell.utils.tracking_utils import load_trks
 

--- a/deepcell/utils/data_utils.py
+++ b/deepcell/utils/data_utils.py
@@ -32,7 +32,7 @@ from __future__ import division
 import numpy as np
 from sklearn.model_selection import train_test_split
 from tensorflow.keras import backend as K
-from tensorflow.keras.utils import conv_utils
+from tensorflow.python.keras.utils import conv_utils
 
 from deepcell.utils.tracking_utils import load_trks
 

--- a/deepcell/utils/plot_utils.py
+++ b/deepcell/utils/plot_utils.py
@@ -35,7 +35,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from matplotlib import animation
-from tensorflow.python.keras import backend as K
+from tensorflow.keras import backend as K
 from skimage.exposure import rescale_intensity
 from skimage.segmentation import find_boundaries
 

--- a/deepcell/utils/plot_utils.py
+++ b/deepcell/utils/plot_utils.py
@@ -35,7 +35,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from matplotlib import animation
-from tensorflow.keras import backend as K
+from tensorflow.python.keras import backend as K
 from skimage.exposure import rescale_intensity
 from skimage.segmentation import find_boundaries
 

--- a/docs/source/.nitpick-ignore
+++ b/docs/source/.nitpick-ignore
@@ -20,8 +20,8 @@ py:class tensorflow.keras.Layer
 py:class tensorflow.keras.layers.Layer
 py:class tensorflow.keras.callbacks.Callback
 py:class tensorflow.keras.initializers.Initializer
-py:class tensorflow.python.keras.layers.recurrent.DropoutRNNCellMixin
-py:class tensorflow.python.keras.layers.convolutional_recurrent.ConvRNN2D
+py:class tensorflow.keras.layers.recurrent.DropoutRNNCellMixin
+py:class tensorflow.keras.layers.convolutional_recurrent.ConvRNN2D
 py:class tensorflow.keras.layers.ZeroPadding2D
 py:class tensorflow.keras.layers.ZeroPadding3D
 py:class tensorflow.keras.preprocessing.image.Iterator

--- a/docs/source/.nitpick-ignore
+++ b/docs/source/.nitpick-ignore
@@ -20,8 +20,8 @@ py:class tensorflow.keras.Layer
 py:class tensorflow.keras.layers.Layer
 py:class tensorflow.keras.callbacks.Callback
 py:class tensorflow.keras.initializers.Initializer
-py:class tensorflow.keras.layers.recurrent.DropoutRNNCellMixin
-py:class tensorflow.keras.layers.convolutional_recurrent.ConvRNN2D
+py:class tensorflow.python.keras.layers.recurrent.DropoutRNNCellMixin
+py:class tensorflow.python.keras.layers.convolutional_recurrent.ConvRNN2D
 py:class tensorflow.keras.layers.ZeroPadding2D
 py:class tensorflow.keras.layers.ZeroPadding3D
 py:class tensorflow.keras.preprocessing.image.Iterator

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -238,7 +238,7 @@ autodoc_mock_imports = [
 ]
 
 sys.modules['deepcell.utils.compute_overlap'] = mock.Mock()
-sys.modules['tensorflow.keras.layers.convolutional_recurrent.ConvRNN2D'] = mock.Mock()
+sys.modules['tensorflow.python.keras.layers.convolutional_recurrent.ConvRNN2D'] = mock.Mock()
 
 # Disable nbsphinx extension from running notebooks
 nbsphinx_execute = 'never'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -238,7 +238,7 @@ autodoc_mock_imports = [
 ]
 
 sys.modules['deepcell.utils.compute_overlap'] = mock.Mock()
-sys.modules['tensorflow.python.keras.layers.convolutional_recurrent.ConvRNN2D'] = mock.Mock()
+sys.modules['tensorflow.keras.layers.convolutional_recurrent.ConvRNN2D'] = mock.Mock()
 
 # Disable nbsphinx extension from running notebooks
 nbsphinx_execute = 'never'

--- a/notebooks/training/panopticnets/3D Nuclear Segmentation - Deep Watershed.ipynb
+++ b/notebooks/training/panopticnets/3D Nuclear Segmentation - Deep Watershed.ipynb
@@ -3893,7 +3893,7 @@
    "outputs": [],
    "source": [
     "# Create a dictionary of losses for each semantic head\n",
-    "from tensorflow.keras.losses import MSE\n",
+    "from tensorflow.python.keras.losses import MSE\n",
     "from deepcell import losses\n",
     "\n",
     "\n",

--- a/notebooks/training/panopticnets/3D Nuclear Segmentation - Deep Watershed.ipynb
+++ b/notebooks/training/panopticnets/3D Nuclear Segmentation - Deep Watershed.ipynb
@@ -3893,7 +3893,7 @@
    "outputs": [],
    "source": [
     "# Create a dictionary of losses for each semantic head\n",
-    "from tensorflow.python.keras.losses import MSE\n",
+    "from tensorflow.keras.losses import MSE\n",
     "from deepcell import losses\n",
     "\n",
     "\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
-numpy>=1.16.6,<1.20
+numpy>=1.16.6 #,<1.20
 pydot>=1.4.2,<2
 scipy>=1.2.3,<2
 scikit-image>=0.14.5
 scikit-learn>=0.20.4
-tensorflow~=2.5.1
-tensorflow_addons~=0.13.0
+tensorflow~=2.8.0
+tensorflow_addons #~=0.13.0
 spektral~=1.0.4
 jupyter>=1.0.0,<2
-deepcell-tracking~=0.5.0
-deepcell-toolbox~=0.10.0
+matplotlib
+git+https://github.com/vanvalenlab/deepcell-tracking.git@mrgn/tf2.8
+git+https://github.com/vanvalenlab/deepcell-toolbox.git@mrgn/tf2.8

--- a/setup.py
+++ b/setup.py
@@ -56,20 +56,20 @@ setup(
     license=about['__license__'],
     long_description=readme,
     long_description_content_type='text/markdown',
-    install_requires=[
-        'numpy>=1.16.6,<1.20.0',
-        'pydot>=1.4.2,<2',
-        'scipy>=1.2.3,<2',
-        'scikit-image>=0.14.5',
-        'scikit-learn>=0.20.4',
-        'tensorflow~=2.5.1',
-        'tensorflow_addons~=0.13.0',
-        'spektral~=1.0.4',
-        'jupyter>=1.0.0,<2',
-        'opencv-python-headless<5',
-        'deepcell-tracking~=0.5.0',
-        'deepcell-toolbox~=0.10.0'
-    ],
+    # install_requires=[
+    #     'numpy>=1.16.6,<1.20.0',
+    #     'pydot>=1.4.2,<2',
+    #     'scipy>=1.2.3,<2',
+    #     'scikit-image>=0.14.5',
+    #     'scikit-learn>=0.20.4',
+    #     'tensorflow~=2.5.1',
+    #     'tensorflow_addons~=0.13.0',
+    #     'spektral~=1.0.4',
+    #     'jupyter>=1.0.0,<2',
+    #     'opencv-python-headless<5',
+    #     'deepcell-tracking~=0.5.0',
+    #     'deepcell-toolbox~=0.10.0'
+    # ],
     extras_require={
         'tests': [
             'pytest<6',
@@ -78,7 +78,7 @@ setup(
         ],
     },
     packages=find_packages(),
-    python_requires='>=3.6, <3.10',
+    python_requires='>=3.7, <3.10',
     classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
This PR updates tensorflow to 2.8 and drops support for python 3.6. The following changes were necessary to make this upgrade possible:
- Change imports from `tensorflow.python.keras` to `tensorflow.keras` which was a change introduced with tensorflow 2.6
- Remove convolutional recurrent layers and their functionality from featurenet and panopticnet. Key functions that were used in the convolutional recurrent layer are no longer available in keras.
- Change imports from `tensorflow.keras` to `keras`: `keras_parameterized`, `conv_utils`, `test_utils`