### PR TITLE
Add option for either batch or layer norm in tracking model

### DIFF
--- a/deepcell/_version.py
+++ b/deepcell/_version.py
@@ -27,7 +27,7 @@
 __title__ = 'DeepCell'
 __description__ = 'Deep learning for single cell image segmentation'
 __url__ = 'https://github.com/vanvalenlab/deepcell-tf'
-__version__ = '0.12.0rc1'
+__version__ = '0.12.0rc2'
 __download_url__ = '{}/tarball/{}'.format(__url__, __version__)
 __author__ = 'The Van Valen Lab'
 __author_email__ = 'vanvalen@caltech.edu'

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -387,7 +387,8 @@ class GNNTrackingModel(object):
         # Concatenate features
         node_features = Concatenate(axis=-1)([app_features, morph_features, centroid_features])
         node_features = Dense(self.n_filters, name='dense_ne0')(node_features)
-        node_features = self.norm_layer(axis=-1, name='{}_ne0'.format(self.norm_layer_prefix))(node_features)
+        node_features = self.norm_layer(axis=-1, name='{}_ne0'.format(self.norm_layer_prefix)
+                                        )(node_features)
         node_features = Activation('relu', name='relu_ne0')(node_features)
 
         # Apply graph convolution


### PR DESCRIPTION
## What
* Provide the option to select either `BatchNormalization` or `LayerNormalization` in `GNNTrackingModel`

## Why
* This option makes it possible to train the model with a batch size of 1 when layer normalization is enabled.
