### PR TITLE
Update models after retraining on deepcell 0.12.0rc

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker run --gpus '"device=0"' -it --rm \
     -p 8888:8888 \
     -v $PWD/notebooks:/notebooks \
     -v $PWD/data:/data \
-    vanvalenlab/deepcell-tf:0.11.1-gpu
+    vanvalenlab/deepcell-tf:0.12.0-gpu
 ```
 
 This will start a Docker container with `deepcell-tf` installed and start a jupyter session using the default port 8888. This command also mounts a data folder (`$PWD/data`) and a notebooks folder (`$PWD/notebooks`) to the docker container so it can access data and Juyter notebooks stored on the host workstation. Data and models must be saved in these mounted directories to persist them outside of the running container. The default port can be changed to any non-reserved port by updating `-p 8888:8888` to, e.g., `-p 8080:8888`. If you run across any errors getting started, you should either refer to the `deepcell-tf` for developers section or raise an issue on GitHub.
@@ -93,7 +93,7 @@ For examples of how to train models with the `deepcell-tf` library, check out th
 ```bash
 git clone https://github.com/vanvalenlab/deepcell-tf.git
 cd deepcell-tf
-docker build --build-arg TF_VERSION=2.5.1-gpu -t $USER/deepcell-tf .
+docker build --build-arg TF_VERSION=2.8.0-gpu -t $USER/deepcell-tf .
 ```
 
 ### Run the new docker image

--- a/deepcell/_version.py
+++ b/deepcell/_version.py
@@ -27,7 +27,7 @@
 __title__ = 'DeepCell'
 __description__ = 'Deep learning for single cell image segmentation'
 __url__ = 'https://github.com/vanvalenlab/deepcell-tf'
-__version__ = '0.12.0rc2'
+__version__ = '0.12.0'
 __download_url__ = '{}/tarball/{}'.format(__url__, __version__)
 __author__ = 'The Van Valen Lab'
 __author_email__ = 'vanvalen@caltech.edu'

--- a/deepcell/applications/cell_tracking.py
+++ b/deepcell/applications/cell_tracking.py
@@ -40,11 +40,13 @@ from deepcell.applications import Application
 
 
 MODEL_PATH = ('https://deepcell-data.s3-us-west-1.amazonaws.com/'
-              'saved-models/TrackingModel-7.tar.gz')
+              'saved-models/NuclearTrackingInf-6.tar.gz')
+MODEL_HASH = 'ac1323bfc331979464c8fbabaf6d55b2'
 
 
 ENCODER_PATH = ('https://deepcell-data.s3-us-west-1.amazonaws.com/'
-                'saved-models/TrackingModelNE-5.tar.gz')
+                'saved-models/NuclearTrackingNE-6.tar.gz')
+ENCODER_HASH = '29f668823680d10ac0af5c559b5174f1'
 
 
 class CellTracking(Application):
@@ -101,7 +103,7 @@ class CellTracking(Application):
         if self.neighborhood_encoder is None:
             archive_path = tf.keras.utils.get_file(
                 'NuclearTrackingNE.tgz', ENCODER_PATH,
-                file_hash='7d6636838e138bd31124bf76d462630d',
+                file_hash=ENCODER_HASH,
                 extract=True, cache_subdir='models')
             model_path = os.path.splitext(archive_path)[0]
             self.neighborhood_encoder = tf.keras.models.load_model(model_path)
@@ -109,7 +111,7 @@ class CellTracking(Application):
         if model is None:
             archive_path = tf.keras.utils.get_file(
                 'NuclearTrackingInf.tgz', MODEL_PATH,
-                file_hash='47a198b2aa1cbfd438e04f6c76a2ad02',
+                file_hash=MODEL_HASH,
                 extract=True, cache_subdir='models')
             model_path = os.path.splitext(archive_path)[0]
             model = tf.keras.models.load_model(model_path)

--- a/deepcell/applications/cytoplasm_segmentation.py
+++ b/deepcell/applications/cytoplasm_segmentation.py
@@ -40,8 +40,8 @@ from deepcell.applications import Application
 
 
 MODEL_PATH = ('https://deepcell-data.s3-us-west-1.amazonaws.com/'
-              'saved-models/CytoplasmSegmentation-3.tar.gz')
-MODEL_HASH = '6a244f561b4d37169cb1a58b6029910f'
+              'saved-models/CytoplasmSegmentation-5.tar.gz')
+MODEL_HASH = '97334472f59e6d85697c563ed65969ff'
 
 
 class CytoplasmSegmentation(Application):

--- a/deepcell/applications/mesmer.py
+++ b/deepcell/applications/mesmer.py
@@ -42,8 +42,8 @@ from deepcell.applications import Application
 
 
 MODEL_PATH = ('https://deepcell-data.s3-us-west-1.amazonaws.com/'
-              'saved-models/MultiplexSegmentation-8.tar.gz')
-MODEL_HASH = 'a685c80a1cb7cc36969afa7b99ec0005'
+              'saved-models/MultiplexSegmentation-9.tar.gz')
+MODEL_HASH = 'a1dfbce2594f927b9112f23a0a1739e0'
 
 
 # pre- and post-processing functions

--- a/deepcell/applications/nuclear_segmentation.py
+++ b/deepcell/applications/nuclear_segmentation.py
@@ -40,8 +40,8 @@ from deepcell.applications import Application
 
 
 MODEL_PATH = ('https://deepcell-data.s3-us-west-1.amazonaws.com/'
-              'saved-models/NuclearSegmentation-5.tar.gz')
-MODEL_HASH = 'c3667ffbe08035c9cb69ed882e4a49d7'
+              'saved-models/NuclearSegmentation-6.tar.gz')
+MODEL_HASH = 'aa7dbb2b324de6a74ebe8d8cf6630db9'
 
 
 class NuclearSegmentation(Application):


### PR DESCRIPTION
## What
* Update models with versions that were trained on tensorflow 2.8 (https://github.com/vanvalenlab/model-registry/pull/17)

## Why
* Models should use the same version of tensorflow for predictions as they were trained on 
