### PR TITLE
Update the docstring for `format_output_mesmer`

### DIFF
--- a/deepcell/applications/mesmer.py
+++ b/deepcell/applications/mesmer.py
@@ -84,7 +84,7 @@ def format_output_mesmer(output_list):
         dict: Dict of predictions for whole cell and nuclear.
 
     Raises:
-        ValueError: if model output list is not len(8)
+        ValueError: if model output list is not len(4)
     """
     expected_length = 4
     if len(output_list) != expected_length:


### PR DESCRIPTION
## What
Doc-string for `format_output_mesmer` is now correctly saying "ValueError: if model output list is not len(4)" 

## Why
Because `format_output_mesmer` code diverged from the doc in what is expected length of model output list