### PR TITLE
Expose option for fixed crops in the Track data object

### DIFF
--- a/deepcell/data/tracking.py
+++ b/deepcell/data/tracking.py
@@ -53,7 +53,8 @@ from deepcell.data import split_dataset
 class Track(object):  # pylint: disable=useless-object-inheritance
 
     def __init__(self, path=None, tracked_data=None,
-                 appearance_dim=32, distance_threshold=64):
+                 appearance_dim=32, distance_threshold=64,
+                 **kwargs):
         if tracked_data:
             training_data = tracked_data
         elif path:
@@ -69,6 +70,8 @@ class Track(object):  # pylint: disable=useless-object-inheritance
                 'Please make sure you are using a valid .trks file')
         self.appearance_dim = appearance_dim
         self.distance_threshold = distance_threshold
+        self.crop_mode = kwargs.get('crop_mode', 'resize')
+        self.norm = kwargs.get('norm', True)
 
         # Correct lineages and remove bad batches
         self._correct_lineages()
@@ -155,7 +158,8 @@ class Track(object):  # pylint: disable=useless-object-inheritance
 
                 frame_features = get_image_features(
                     self.X[batch, frame], self.y[batch, frame],
-                    appearance_dim=self.appearance_dim)
+                    appearance_dim=self.appearance_dim,
+                    crop_mode=self.crop_mode, norm=self.norm)
 
                 track_ids = frame_features['labels'] - 1
                 centroids[batch, frame, track_ids] = frame_features['centroids']

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -540,12 +540,12 @@ class GNNTrackingModel(object):
 
     def get_inference_branch(self):
         # batch size, tracks
-        current_embedding = Input(shape=(None, None, self.encoder_dim),
+        current_embedding = Input(shape=(None, None, self.embedding_dim),
                                   name='current_embeddings')
         current_centroids = Input(shape=(None, None, self.centroid_shape[-1]),
                                   name='current_centroids')
 
-        future_embedding = Input(shape=(1, None, self.encoder_dim),
+        future_embedding = Input(shape=(1, None, self.embedding_dim),
                                  name='future_embeddings')
         future_centroids = Input(shape=(1, None, self.centroid_shape[-1]),
                                  name='future_centroids')

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -293,10 +293,10 @@ class GNNTrackingModel(object):
         self.training_model, self.inference_model = self.get_models()
 
     def get_embedding_temporal_merge_model(self):
-        inputs = Input(shape=(None, None, self.encoder_dim),
+        inputs = Input(shape=(None, None, self.embedding_dim),
                        name='embedding_temporal_merge_input')
 
-        x = TemporalMerge(self.encoder_dim, name='emb_tm')(inputs)
+        x = TemporalMerge(self.embedding_dim, name='emb_tm')(inputs)
         return Model(inputs=inputs, outputs=x, name='embedding_temporal_merge')
 
     def get_delta_temporal_merge_model(self):
@@ -355,7 +355,7 @@ class GNNTrackingModel(object):
         inputs_across_frames = Input(shape=(None, None, None, self.centroid_shape[-1]),
                                      name='encoder_delta_across_frames_input')
 
-        d = Dense(self.n_filters, name='dense_des')
+        d = Dense(self.encoder_dim, name='dense_des')
         a = Activation('relu', name='relu_des')
 
         x_0 = d(inputs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ tensorflow_addons~=0.16.1
 spektral~=1.0.4
 jupyter>=1.0.0,<2
 matplotlib
-deepcell-tracking~=0.5.7
+deepcell-tracking~=0.6.1
 deepcell-toolbox~=0.11.2

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'spektral~=1.0.4',
         'jupyter>=1.0.0,<2',
         'opencv-python-headless<5',
-        'deepcell-tracking~=0.5.7',
+        'deepcell-tracking~=0.6.1',
         'deepcell-toolbox~=0.11.2'
     ],
     extras_require={


### PR DESCRIPTION
## What
* Modify the Track class so that it allows hooks into get_image_features for crop_mode and norm

## Why
* Creating the appearance image feature by cropping and resizing removes information about cell size that the model can use to make more accurate tracking predictions. A previous update to deepcell-tracking (https://github.com/vanvalenlab/deepcell-tracking/pull/98) introduced the crop_mode (either 'fixed' or 'resize') and norm flags to get_image_features. This pull request exposes these flags to the Track class.
