### PR TITLE
Swap m2r with m2r2 and update version number to 0.12.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker run --gpus '"device=0"' -it --rm \
     -p 8888:8888 \
     -v $PWD/notebooks:/notebooks \
     -v $PWD/data:/data \
-    vanvalenlab/deepcell-tf:0.12.1-gpu
+    vanvalenlab/deepcell-tf:latest-gpu
 ```
 
 This will start a Docker container with `deepcell-tf` installed and start a jupyter session using the default port 8888. This command also mounts a data folder (`$PWD/data`) and a notebooks folder (`$PWD/notebooks`) to the docker container so it can access data and Juyter notebooks stored on the host workstation. Data and models must be saved in these mounted directories to persist them outside of the running container. The default port can be changed to any non-reserved port by updating `-p 8888:8888` to, e.g., `-p 8080:8888`. If you run across any errors getting started, you should either refer to the `deepcell-tf` for developers section or raise an issue on GitHub.

--- a/deepcell/_version.py
+++ b/deepcell/_version.py
@@ -27,7 +27,7 @@
 __title__ = 'DeepCell'
 __description__ = 'Deep learning for single cell image segmentation'
 __url__ = 'https://github.com/vanvalenlab/deepcell-tf'
-__version__ = '0.12.2'
+__version__ = '0.12.3'
 __download_url__ = '{}/tarball/{}'.format(__url__, __version__)
 __author__ = 'The Van Valen Lab'
 __author_email__ = 'vanvalen@caltech.edu'

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,4 @@
-m2r
+m2r2
 mock==3.0.5
 Sphinx==2.3.1
 docutils==0.16

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,7 @@ extensions = [
     'sphinx.ext.githubpages',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
-    'm2r',
+    'm2r2',
     'IPython.sphinxext.ipython_console_highlighting',
     'nbsphinx',
     'nbsphinx_link',


### PR DESCRIPTION
Bump version number for new release

Also includes a change from `m2r` to `m2r2` for our documentation pipeline. `m2r` is no longer being maintained so it has been replaced with a fork with more active maintenance. https://github.com/CrossNox/m2r2