### PR TITLE
MAINT: Pin numpy to avoid errors due to expired scalar deprecations

### DIFF
--- a/deepcell/_version.py
+++ b/deepcell/_version.py
@@ -27,7 +27,7 @@
 __title__ = 'DeepCell'
 __description__ = 'Deep learning for single cell image segmentation'
 __url__ = 'https://github.com/vanvalenlab/deepcell-tf'
-__version__ = '0.12.3'
+__version__ = '0.12.4'
 __download_url__ = '{}/tarball/{}'.format(__url__, __version__)
 __author__ = 'The Van Valen Lab'
 __author_email__ = 'vanvalen@caltech.edu'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,5 @@
 requires = [
     "wheel",
     "setuptools>=40.8.0",
-    "numpy>=1.16.6"
+    "numpy>=1.16.6,<1.24"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.16.6
+numpy>=1.16.6,<1.24
 pydot>=1.4.2,<2
 scipy>=1.2.3,<2
 scikit-image>=0.14.5

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     install_requires=[
-        'numpy>=1.16.6',
+        'numpy>=1.16.6,<1.24',
         'pydot>=1.4.2,<2',
         'scipy>=1.2.3,<2',
         'scikit-image>=0.14.5',
@@ -69,7 +69,7 @@ setup(
         'matplotlib',
         'opencv-python-headless<5',
         'deepcell-tracking~=0.6.1',
-        'deepcell-toolbox~=0.11.2'
+        'deepcell-toolbox~=0.12.0'
     ],
     extras_require={
         'tests': [


### PR DESCRIPTION
## What

Pinning numpy and creating a patch release to avoid errors related to the latest updates in numpy v1.24

## Why

Resolve failures in deepcell due to code that depends on numpy features that were removed in 1.24. This affects the entire deepcell ecosystem of libraries; see also: vanvalenlab/deepcell-toolbox#131 and vanvalenlab/deepcell-tracking#110
