### PR TITLE
A collection of minor documentation updates

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,6 +1,6 @@
 m2r2
 mock
-Sphinx
+Sphinx<6
 docutils
 ipython
 nbsphinx

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,10 +1,8 @@
 m2r2
-mock==3.0.5
-Sphinx==2.3.1
-docutils==0.16
+mock
+Sphinx
+docutils
 ipython
 nbsphinx
 nbsphinx-link
 sphinx-rtd-theme
-# Jinja2 imports for sphinx are deprecated over 3.1
-Jinja2<3.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -265,7 +265,7 @@ r"""
 # -- Options for intersphinx extension ---------------------------------------
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.7', None),
+    'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'kiosk': ('https://deepcell-kiosk.readthedocs.io/en/{}/'.format(rtd_version), None),
     'kiosk-redis-consumer': (('https://deepcell-kiosk.readthedocs.io/'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -105,7 +105,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,10 +30,8 @@ copyright = ('2016-{currentyear}, Van Valen Lab at the '
                  currentyear=datetime.now().year)
 author = 'Van Valen Lab at Caltech'
 
-# The short X.Y version
-version = '0.6.0'
-# The full version, including alpha/beta/rc tags
-release = '0.6.0'
+# The short X.Y.Z version - overriden by rtd
+version = release = '0.12.4'
 
 import subprocess
 try:

--- a/notebooks/training/tracking/Training and Tracking with GNNs.ipynb
+++ b/notebooks/training/tracking/Training and Tracking with GNNs.ipynb
@@ -30208,7 +30208,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Save the Output\n",
+    "## Save the Output\n",
     "\n",
     "If desired, save the results in our compressed format (.trk - with lineage information), as a movie (.gif - images only/no lineage information), or both"
    ]
@@ -30267,7 +30267,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Benchmark the Results\n",
+    "## Benchmark the Results\n",
     "\n",
     "N.B. Requires the result to be saved to .trk file"
    ]


### PR DESCRIPTION
## What
The major change is removing the pins to sphinx, docutils, etc. AFAICT the motivating factors for the pins are no longer relevant - see e.g. #320 and #526.

Some other minor changes include:
 - Minor configuration updates to get rid of warnings
 - Updating intersphinx to point to the stable Python docs instead of 3.7
 - Modifying the heading levels in one of the example notebooks to fix the toctree nav column

## Why
Sphinx 2.3.1 is 2 major releases behind stable - being pinned this far back will make it difficult to reliably change/update the docs.
