### PR TITLE
Add CI testing against dev branches of deepcell-toolbox and deepcell-tracking

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,6 +50,37 @@ jobs:
       run: |
         coveralls
 
+  # A job that runs the test suite using the development version of the
+  # deepcell dependencies: deepcell-tracking and deepcell-toolbox.
+  # This ensures consistency across unreleased versions of deepcell libraries
+  test-dev:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9"]
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          # Quick and dirty installation of deepcell-* dev libs
+          python -m pip install git+https://github.com/vanvalenlab/deepcell-toolbox
+          python -m pip install git+https://github.com/vanvalenlab/deepcell-tracking
+          # Install deepcell-tf from source
+          python -m pip install .
+          python -m pip install -r requirements-test.txt
+          python -m pip list
+      
+      - name: Run tests
+        run: |
+          pytest --pyargs deepcell
+
   coveralls:
     name: Finish Coveralls
     needs: tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,11 +69,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools
-          # Quick and dirty installation of deepcell-* dev libs
-          python -m pip install git+https://github.com/vanvalenlab/deepcell-toolbox
-          python -m pip install git+https://github.com/vanvalenlab/deepcell-tracking
           # Install deepcell-tf from source
           python -m pip install .
+          # Quick and dirty installation of deepcell-* dev libs
+          python -m pip install --upgrade git+https://github.com/vanvalenlab/deepcell-toolbox
+          python -m pip install --upgrade git+https://github.com/vanvalenlab/deepcell-tracking
           python -m pip install -r requirements-test.txt
           python -m pip list
       


### PR DESCRIPTION
This should help catch incompatibilities between unreleased versions of libraries in the deepcell ecosystem.

## What
* Code remains unaffected - this PR is just dedicated to bolstering testing infrastructure

## Why
* The deepcell- libraries are interdependent: `deepcell-tf` depends on `deepcell-tracking` and `deepcell-toolbox`. If there is a change in one of these dependencies, there is no way to tell in the automated test running whether this will break something in `deepcell-tf` until the underlying libraries are released. Testing against the dev branches will catch potential issues sooner, at the expense of being noisier and reducing test specificity (failures can originate from either *deepcell-tf* or the dependencies). Overall however I think this should improve the ability to things consistent across libraries.
