### PR TITLE
Deprecate entire `export_utils` module

### DIFF
--- a/deepcell/utils/__init__.py
+++ b/deepcell/utils/__init__.py
@@ -29,26 +29,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-
-def __getattr__(name):
-    if name in {"export_model", "export_utils"}:
-        import warnings
-        import importlib
-
-        warnings.warn(
-            f"\n\n{name} is deprecated, use tf.keras.models.save_model directly.\n",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        export_utils = importlib.import_module("deepcell.utils.export_utils")
-        if name == "export_model":
-            return getattr(export_utils, name)
-        if name == "export_utils":
-            return export_utils
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
 # compute_overlap has been moved to deepcell_toolbox
 # leaving here for backwards compatibility
 from deepcell_toolbox import compute_overlap
@@ -74,6 +54,25 @@ from deepcell.utils.transform_utils import inner_distance_transform_2d
 from deepcell.utils.transform_utils import inner_distance_transform_3d
 from deepcell.utils.transform_utils import inner_distance_transform_movie
 from deepcell.utils.transform_utils import pixelwise_transform
+
+
+def __getattr__(name):
+    if name in {"export_model", "export_utils"}:
+        import warnings
+        import importlib
+
+        warnings.warn(
+            f"\n\n{name} is deprecated, use tf.keras.models.save_model directly.\n",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        export_utils = importlib.import_module("deepcell.utils.export_utils")
+        if name == "export_model":
+            return getattr(export_utils, name)
+        if name == "export_utils":
+            return export_utils
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 del absolute_import
 del division

--- a/deepcell/utils/__init__.py
+++ b/deepcell/utils/__init__.py
@@ -29,7 +29,25 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import warnings
+
+def __getattr__(name):
+    if name in {"export_model", "export_utils"}:
+        import warnings
+        import importlib
+
+        warnings.warn(
+            f"\n\n{name} is deprecated, use tf.keras.models.save_model directly.\n",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        export_utils = importlib.import_module("deepcell.utils.export_utils")
+        if name == "export_model":
+            return getattr(export_utils, name)
+        if name == "export_utils":
+            return export_utils
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # compute_overlap has been moved to deepcell_toolbox
 # leaving here for backwards compatibility
@@ -37,7 +55,6 @@ from deepcell_toolbox import compute_overlap
 
 from deepcell.utils import backbone_utils
 from deepcell.utils import data_utils
-from deepcell.utils import export_utils
 from deepcell.utils import io_utils
 from deepcell.utils import misc_utils
 from deepcell.utils import plot_utils
@@ -48,7 +65,6 @@ from deepcell.utils import tfrecord_utils
 
 # Globally-importable utils.
 from deepcell.utils.data_utils import get_data
-from deepcell.utils.export_utils import export_model
 from deepcell.utils.misc_utils import sorted_nicely
 from deepcell.utils.train_utils import rate_scheduler
 from deepcell.utils.transform_utils import outer_distance_transform_2d
@@ -58,8 +74,6 @@ from deepcell.utils.transform_utils import inner_distance_transform_2d
 from deepcell.utils.transform_utils import inner_distance_transform_3d
 from deepcell.utils.transform_utils import inner_distance_transform_movie
 from deepcell.utils.transform_utils import pixelwise_transform
-
-del warnings
 
 del absolute_import
 del division


### PR DESCRIPTION
## What
A followup to #648. With the deprecation of `export_model_to_tflite`, it is now the case that every function in the `export_utils` module has been deprecated. Therefore I propose to deprecate the entire module. We can do this using the module `getattr` to emit warnings if a user ever tries to access the two public names (i.e. `export_model` or `export_utils`).

In practice this means import patterns like:

```python
>>> from deepcell.utils import export_model  # or export utils
```

will now raise a deprecation warning as well.

The module `getattr` was added in Python 3.7 - see [PEP 562](https://peps.python.org/pep-0562/) for details.

## Why
Further cleanup related to the `export_model` functions, all of which are deprecated in favor of using `tf.keras.models.save_model` directly.
