### PR TITLE
Rm blurb about Python2/TensorFlow 1 from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Read the documentation at [deepcell.readthedocs.io](https://deepcell.readthedocs
 
 For more information on deploying models in the cloud refer to the [the Kiosk documentation](https://deepcell-kiosk.readthedocs.io).
 
-For TensorFlow 1.X or Python 2.7 support, please use deepcell [0.7.0](https://github.com/vanvalenlab/deepcell-tf/tree/0.7.0) or earlier.
-
 ## Examples
 
 <table width="700" border="1" cellpadding="5">


### PR DESCRIPTION
## What
Removing blurb from README about running with Python2/TensorFlow 1.

## Why
The chances of this working out of a containerized environment is practically nil and certainly not worth the effort for users.

I'm also using this change as a test for the RTD docs preview feature in CI.
