### PR TITLE
Pin scikit-image to avoid expired deprecations.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.16.6
 pydot>=1.4.2,<2
 scipy>=1.2.3,<2
-scikit-image>=0.14.5
+scikit-image>=0.14.5,<0.20
 scikit-learn>=0.20.4
 tensorflow~=2.8.0
 tensorflow_addons~=0.16.1

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         'numpy>=1.16.6',
         'pydot>=1.4.2,<2',
         'scipy>=1.2.3,<2',
-        'scikit-image>=0.14.5',
+        'scikit-image>=0.14.5,<0.20',
         'scikit-learn>=0.20.4',
         'tensorflow~=2.8.0',
         'tensorflow_addons~=0.16.1',


### PR DESCRIPTION
## What
* Fix for #655 .

## Why
My vote is to pin scikit-image then do a patch release. For the next minor release the pin should be updated to >=0.19.
