### PR TITLE
Fix untiling corner-case when no padding in one dimension

### DIFF
--- a/deepcell/applications/application.py
+++ b/deepcell/applications/application.py
@@ -238,9 +238,13 @@ class Application:
         # If padding was used, remove padding
         if tiles_info.get('padding', False):
             def _process(im, tiles_info):
-                x_pad, y_pad = tiles_info['x_pad'], tiles_info['y_pad']
-                out = im[:, x_pad[0]:-x_pad[1], y_pad[0]:-y_pad[1], :]
-                return out
+                ((xl, xh), (yl, yh)) = tiles_info['x_pad'], tiles_info['y_pad']
+                # Edge-case: upper-bound == 0 - this can occur when only one of
+                # either X or Y is smaller than model_img_shape while the other
+                # is equal to model_image_shape.
+                xh = -xh if xh != 0 else None
+                yh = -yh if yh != 0 else None
+                return im[:, xl:xh, yl:yh, :]
         # Otherwise untile
         else:
             def _process(im, tiles_info):

--- a/deepcell/applications/application_test.py
+++ b/deepcell/applications/application_test.py
@@ -29,6 +29,7 @@
 from itertools import product
 from unittest.mock import Mock
 
+import pytest
 import numpy as np
 
 from tensorflow.python.platform import test
@@ -301,22 +302,27 @@ class TestApplication(test.TestCase):
         self.assertEqual(x.shape, y.shape)
 
 
-def test_untile_non_empty_slices():
+@pytest.mark.parametrize(
+    "orig_img_shape",
+    (
+        (1, 216, 256, 1),  # x < model_img_shape
+        (1, 256, 64, 1),  # y < model_img_shape
+    ),
+)
+def test_untile_non_empty_slices(orig_img_shape):
     """Test corner cases when tile_info["padding"] is True, but the padding in
     at least one of the dimensions is (0, 0). See gh-665."""
     # Padding is "activated" whenever either of the input image dimensions is
     # smaller than app.model_image_shape
     app = Application(DummyModel, model_image_shape=(256, 256, 1))
 
-    # Case 1: y-dim has zero padding
-    orig_img_shp = (1, 216, 256, 1)
-    img = np.ones(orig_img_shp)
+    img = np.ones(orig_img_shape)
     # Use _tile_input to generate a valid tile_info object
     tiles, tile_info = app._tile_input(img)
     # Input validation - tile_info should have a "padding" key and one of the
-    # two pads should be (0, 0)
+    # two pads should be (0, 0).
     assert tile_info.get("padding") and (
         tile_info["x_pad"] == (0, 0) or tile_info["y_pad"] == (0, 0)
     )
     untiled = app._untile_output(tiles, tile_info)
-    assert untiled.shape == orig_img_shp
+    assert untiled.shape == orig_img_shape


### PR DESCRIPTION
## What
Closes #665. As noted there, the issue arises from pads of `(0, 0)` which subsequently lead to `0:0` slices in untiling, giving arrays with shape 0 for that dimension.

AFAICT, the only way to hit this corner case is when one of the dimensions is smaller than `model_image_shape`, but the other is exactly `model_image_shape`. If both dimensions are `>= model_image_shape`, then `padding` should be `False` if I'm following the logic correctly.

## Why
Bugfix