### PR TITLE
Fix scikit-image dependency specification

### DIFF
--- a/deepcell/image_generators/semantic.py
+++ b/deepcell/image_generators/semantic.py
@@ -1040,14 +1040,14 @@ class Semantic3DIterator(Iterator):
                     rescaled = rescale(batch, scale,
                                        order=order,
                                        preserve_range=True,
-                                       multichannel=True)
+                                       channel_axis=-1)
                     rescaled = np.moveaxis(rescaled, -1, 0)
 
                 else:
                     rescaled = rescale(batch, scale,
                                        order=order,
                                        preserve_range=True,
-                                       multichannel=True)
+                                       channel_axis=-1)
 
                 batch_list.append(rescaled)
             return np.stack(batch_list, axis=0).astype(dtype)

--- a/deepcell/utils/transform_utils.py
+++ b/deepcell/utils/transform_utils.py
@@ -81,7 +81,7 @@ def pixelwise_transform(mask, dilation_radius=None, data_format=None,
         if dilation_radius:
             dil_strel = ball(dilation_radius) if mask.ndim > 2 else disk(dilation_radius)
             # Thicken cell edges to be more pronounced
-            edge = binary_dilation(edge, selem=dil_strel)
+            edge = binary_dilation(edge, footprint=dil_strel)
 
             # Thin the augmented edges by subtracting the interior features.
             edge = (edge - interior > 0).astype('int')
@@ -109,8 +109,8 @@ def pixelwise_transform(mask, dilation_radius=None, data_format=None,
     if dilation_radius:
         dil_strel = ball(dilation_radius) if mask.ndim > 2 else disk(dilation_radius)
         # Thicken cell edges to be more pronounced
-        interior_edge = binary_dilation(interior_edge, selem=dil_strel)
-        background_edge = binary_dilation(background_edge, selem=dil_strel)
+        interior_edge = binary_dilation(interior_edge, footprint=dil_strel)
+        background_edge = binary_dilation(background_edge, footprint=dil_strel)
 
         # Thin the augmented edges by subtracting the interior features.
         interior_edge = (interior_edge - interior > 0).astype('int')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.16.6
 scipy>=1.2.3,<2
-scikit-image>=0.14.5,<0.20
+scikit-image>=0.19.3
 scikit-learn>=0.20.4
 tensorflow~=2.8.0
 tensorflow_addons~=0.16.1

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         'numpy>=1.16.6',
         'pydot>=1.4.2,<2',  # for keras.utils.plot_model
         'scipy>=1.2.3,<2',
-        'scikit-image>=0.14.5,<0.20',
+        'scikit-image>=0.19.3',
         'scikit-learn>=0.20.4',
         'tensorflow~=2.8.0',
         'tensorflow_addons~=0.16.1',


### PR DESCRIPTION
## What

There have been several deprecations and expirations of deprecations in `scikit-image` as of v0.18 that have affected the codebase. We caught most of these usages in vanvalenlab/deepcell-toolbox#131. Unfortunately, due to internal usage of `functools.wraps`, the stacklevel of some of the calls containing deprecated kwargs had changed, which prevented the DeprecationWarnings from being visible within `deepcell-tf` itself. This leads to all-out failures if scikit-image v0.21 is installed.

This PR fixes the situation by:
 - Pinning the lower-bound of scikit-image to 0.19, which is now the minimum version that supports the new keyword argument names. Fixes #670.
 - Updating internal usages of scikit-image functions that had relied on kwargs that have now been expired. Fixes #655.

### Additional context

This should fix the situation for those who are just installing `deepcell`. Things get more complicated if e.g. a user has installed `deepcell-toolbox` separately. There will likely need to be changes along the lines of `vanvalenlab/deepcell-toolbox#136 as well for better coverage of different installation orders, etc.

## Why
Without the lower-bound pin, it is possible to install `deepcell` with a non-functional environment (i.e. if `scikit-image` is installed as a transitive dependency by some other package in the environment).
