### PR TITLE
STY: ruff str.format -> f-strings.

### DIFF
--- a/deepcell/image_generators/cropping.py
+++ b/deepcell/image_generators/cropping.py
@@ -155,11 +155,7 @@ class CroppingIterator(SemanticIterator):
                 else:
                     img_x = np.expand_dims(batch_x[i, ..., 0], -1)
                 img = array_to_img(img_x, self.data_format, scale=True)
-                fname = '{prefix}_{index}_{hash}.{format}'.format(
-                    prefix=self.save_prefix,
-                    index=j,
-                    hash=np.random.randint(1e4),
-                    format=self.save_format)
+                fname = f'{self.save_prefix}_{j}_{np.random.randint(1e4)}.{self.save_format}'
                 img.save(os.path.join(self.save_to_dir, fname))
 
                 if self.y is not None:

--- a/deepcell/image_generators/fully_convolutional.py
+++ b/deepcell/image_generators/fully_convolutional.py
@@ -140,11 +140,7 @@ class ImageFullyConvIterator(Iterator):
                 else:
                     img_x = np.expand_dims(batch_x[i, ..., 0], -1)
                 img = array_to_img(img_x, self.data_format, scale=True)
-                fname = '{prefix}_{index}_{hash}.{format}'.format(
-                    prefix=self.save_prefix,
-                    index=j,
-                    hash=np.random.randint(1e4),
-                    format=self.save_format)
+                fname = f'{self.save_prefix}_{j}_{np.random.randint(1e4)}.{self.save_format}'
                 img.save(os.path.join(self.save_to_dir, fname))
 
                 if self.y is not None:
@@ -152,11 +148,7 @@ class ImageFullyConvIterator(Iterator):
                     img_y = np.argmax(batch_y[i], axis=self.channel_axis - 1)
                     img_y = np.expand_dims(img_y, axis=self.channel_axis - 1)
                     img = array_to_img(img_y, self.data_format, scale=True)
-                    fname = 'y_{prefix}_{index}_{hash}.{format}'.format(
-                        prefix=self.save_prefix,
-                        index=j,
-                        hash=np.random.randint(1e4),
-                        format=self.save_format)
+                    fname = f'y_{self.save_prefix}_{j}_{np.random.randint(1e4)}.{self.save_format}'
                     img.save(os.path.join(self.save_to_dir, fname))
 
         if self.y is None:
@@ -722,11 +714,7 @@ class MovieArrayIterator(Iterator):
                         img = array_to_img(batch_x[i, :, frame], self.data_format, scale=True)
                     else:
                         img = array_to_img(batch_x[i, frame], self.data_format, scale=True)
-                    fname = '{prefix}_{index}_{hash}.{format}'.format(
-                        prefix=self.save_prefix,
-                        index=j,
-                        hash=np.random.randint(1e4),
-                        format=self.save_format)
+                    fname = f'{self.save_prefix}_{j}_{np.random.randint(1e4)}.{self.save_format}'
                     img.save(os.path.join(self.save_to_dir, fname))
 
                     if self.y is not None:

--- a/deepcell/image_generators/sample.py
+++ b/deepcell/image_generators/sample.py
@@ -218,11 +218,7 @@ class ImageSampleArrayIterator(Iterator):
                 else:
                     img_x = np.expand_dims(batch_x[i, ..., 0], -1)
                 img = array_to_img(img_x, self.data_format, scale=True)
-                fname = '{prefix}_{index}_{hash}.{format}'.format(
-                    prefix=self.save_prefix,
-                    index=j,
-                    hash=np.random.randint(1e4),
-                    format=self.save_format)
+                fname = f'{self.save_prefix}_{j}_{np.random.randint(1e4)}.{self.save_format}'
                 img.save(os.path.join(self.save_to_dir, fname))
 
         if self.y is None:
@@ -550,11 +546,7 @@ class SampleMovieArrayIterator(Iterator):
                     else:
                         img = batch_x[i, frame]
                     img = array_to_img(img, self.data_format, scale=True)
-                    fname = '{prefix}_{index}_{hash}.{format}'.format(
-                        prefix=self.save_prefix,
-                        index=j,
-                        hash=np.random.randint(1e4),
-                        format=self.save_format)
+                    fname = f'{self.save_prefix}_{j}_{np.random.randint(1e4)}.{self.save_format}'
                     img.save(os.path.join(self.save_to_dir, fname))
 
         if self.y is None:

--- a/deepcell/image_generators/scale.py
+++ b/deepcell/image_generators/scale.py
@@ -125,11 +125,7 @@ class ScaleIterator(Iterator):
                 else:
                     img_x = np.expand_dims(batch_x[i, ..., 0], -1)
                 img = array_to_img(img_x, self.data_format, scale=True)
-                fname = '{prefix}_{index}_{hash}.{format}'.format(
-                    prefix=self.save_prefix,
-                    index=j,
-                    hash=np.random.randint(1e4),
-                    format=self.save_format)
+                fname = f'{self.save_prefix}_{j}_{np.random.randint(1e4)}.{self.save_format}'
                 img.save(os.path.join(self.save_to_dir, fname))
 
         return batch_x, batch_y

--- a/deepcell/image_generators/semantic.py
+++ b/deepcell/image_generators/semantic.py
@@ -196,11 +196,7 @@ class SemanticIterator(Iterator):
                 else:
                     img_x = np.expand_dims(batch_x[i, ..., 0], -1)
                 img = array_to_img(img_x, self.data_format, scale=True)
-                fname = '{prefix}_{index}_{hash}.{format}'.format(
-                    prefix=self.save_prefix,
-                    index=j,
-                    hash=np.random.randint(1e4),
-                    format=self.save_format)
+                fname = f'{self.save_prefix}_{j}_{np.random.randint(1e4)}.{self.save_format}'
                 img.save(os.path.join(self.save_to_dir, fname))
 
                 if self.y is not None:
@@ -587,11 +583,7 @@ class SemanticMovieIterator(Iterator):
                     else:
                         img = array_to_img(batch_x[i, frame],
                                            self.data_format, scale=True)
-                    fname = '{prefix}_{index}_{hash}.{format}'.format(
-                        prefix=self.save_prefix,
-                        index=j,
-                        hash=np.random.randint(1e4),
-                        format=self.save_format)
+                    fname = f'{self.save_prefix}_{j}_{np.random.randint(1e4)}.{self.save_format}'
                     img.save(os.path.join(self.save_to_dir, fname))
 
                     if self.y is not None:

--- a/deepcell/layers/normalization.py
+++ b/deepcell/layers/normalization.py
@@ -196,8 +196,7 @@ class ImageNormalization2D(Layer):
             outputs = outputs - self._average_filter(outputs)
 
         else:
-            raise NotImplementedError('"{}" is not a valid norm_method'.format(
-                self.norm_method))
+            raise NotImplementedError(f'"{self.norm_method}" is not a valid norm_method')
 
         return outputs
 
@@ -385,8 +384,7 @@ class ImageNormalization3D(Layer):
             outputs = outputs - self._average_filter(outputs)
 
         else:
-            raise NotImplementedError('"{}" is not a valid norm_method'.format(
-                self.norm_method))
+            raise NotImplementedError(f'"{self.norm_method}" is not a valid norm_method')
 
         return outputs
 

--- a/deepcell/model_zoo/fpn.py
+++ b/deepcell/model_zoo/fpn.py
@@ -372,12 +372,10 @@ def semantic_upsample(x,
     if n_upsample > 0:
         for i in range(n_upsample):
             x = conv(n_filters, conv_kernel, strides=1, padding='same',
-                     name='conv_{}_semantic_upsample_{}'.format(
-                         i, semantic_id))(x)
+                     name=f'conv_{i}_semantic_upsample_{semantic_id}')(x)
 
             # Define kwargs for upsampling layer
-            upsample_name = 'upsampling_{}_semantic_upsample_{}'.format(
-                i, semantic_id)
+            upsample_name = f'upsampling_{i}_semantic_upsample_{semantic_id}'
 
             if upsample_type == 'upsamplelike':
                 if i == n_upsample - 1 and target is not None:
@@ -397,8 +395,7 @@ def semantic_upsample(x,
                  name=f'conv_final_semantic_upsample_{semantic_id}')(x)
 
         if upsample_type == 'upsamplelike' and target is not None:
-            upsample_name = 'upsampling_{}_semanticupsample_{}'.format(
-                0, semantic_id)
+            upsample_name = f'upsampling_{0}_semanticupsample_{semantic_id}'
             x = UpsampleLike(name=upsample_name)([x, target])
 
     return x

--- a/deepcell/model_zoo/panopticnet.py
+++ b/deepcell/model_zoo/panopticnet.py
@@ -194,8 +194,7 @@ def PanopticNet(backbone,
     # What are the requirements for 3D data?
     img_shape = input_shape[1:] if channel_axis == 1 else input_shape[:-1]
     if img_shape[0] != img_shape[1]:
-        raise ValueError('Input data must be square, got dimensions {}'.format(
-            img_shape))
+        raise ValueError(f'Input data must be square, got dimensions {img_shape}')
 
     if not math.log(img_shape[0], 2).is_integer():
         raise ValueError('Input data dimensions must be a power of 2, '

--- a/deepcell/utils/io_utils.py
+++ b/deepcell/utils/io_utils.py
@@ -72,8 +72,7 @@ def save_model_output(output,
                          'channels. Got ', channel)
 
     if not os.path.isdir(output_dir):
-        raise OSError('{} is not a valid output_dir'.format(
-            output_dir))
+        raise OSError(f'{output_dir} is not a valid output_dir')
 
     for b in range(output.shape[0]):
         # If multiple batches of results, create a numbered subdirectory


### PR DESCRIPTION
## What
Ruff v0.278 was released yesterday (07/12) and added pyupgrade checks to use f-strings instead of the str.format method. I'm generally +1 for this, but if there are objections, we could ignore the rule instead.

This PR is the result of `ruff . --fix`

## Why
* Fix linting CI and ever-so-slightly modernize the codebase
