### PR TITLE
MAINT: Require deepcell-toolbox 0.12.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ spektral~=1.0.4
 jupyterlab
 matplotlib
 deepcell-tracking~=0.6.1
-deepcell-toolbox~=0.12.0
+deepcell-toolbox>=0.12.1
 
 # Required for keras.utils.plot_model
 pydot>=1.4.2,<2

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'matplotlib',
         'opencv-python-headless<5',
         'deepcell-tracking~=0.6.1',
-        'deepcell-toolbox~=0.12.0'
+        'deepcell-toolbox>=0.12.1'
     ],
     extras_require={
         'tests': ['pytest', 'pytest-cov', 'ruff'],


### PR DESCRIPTION
Capped Cython in 0.12.1 build reqs to work around issue in deepcell-tf containers.

## What
* Bump `deepcell-toolbox` minimum version

## Why
* Fix broken docker containers
