### PR TITLE
REL: Increment patch version for 0.12.7 release.

### DIFF
--- a/deepcell/_version.py
+++ b/deepcell/_version.py
@@ -27,7 +27,7 @@
 __title__ = 'DeepCell'
 __description__ = 'Deep learning for single cell image segmentation'
 __url__ = 'https://github.com/vanvalenlab/deepcell-tf'
-__version__ = '0.12.6'
+__version__ = '0.12.7'
 __download_url__ = f'{__url__}/tarball/{__version__}'
 __author__ = 'The Van Valen Lab'
 __author_email__ = 'vanvalen@caltech.edu'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ copyright = ('2016-{currentyear}, Van Valen Lab at the '
 author = 'Van Valen Lab at Caltech'
 
 # The short X.Y.Z version - overriden by rtd
-version = release = '0.12.6'
+version = release = '0.12.7'
 
 import subprocess
 try:


### PR DESCRIPTION
## What
* Prepare for 0.12.7 release

## Why
* Fix downstream problems related to Cython version used to build deepcell-toolbox
