### PR TITLE
Minor modification of documentation build to get rid of warnings from inherited docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ instance/
 docs/_build/
 docs/source/data-gallery
 docs/source/app-gallery
+docs/source/API/_generated
 
 # PyBuilder
 target/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,3 +22,4 @@ clean:
 	rm -rf build
 	rm -rf source/data-gallery
 	rm -rf source/app-gallery
+	rm -rf source/API/_generated

--- a/docs/source/API-key.rst
+++ b/docs/source/API-key.rst
@@ -10,7 +10,7 @@ API Key Usage
 
 The token that is issued by users.deepcell.org should be added as an environment variable through one of the following methods:
 
-1. Save the token in your shell config script (e.g. `.bashrc`, `.zshrc`, `.bash_profile`, etc.)
+1. Save the token in your shell config script (e.g. ``.bashrc``, ``.zshrc``, ``.bash_profile``, etc.)
 
 .. code-block:: bash
 

--- a/docs/source/API/deepcell.layers.rst
+++ b/docs/source/API/deepcell.layers.rst
@@ -3,47 +3,56 @@ deepcell.layers
 
 .. automodule:: deepcell.layers
 
-.. contents:: Contents
-    :local:
+.. currentmodule:: deepcell.layers
 
 location
 --------
-.. automodule:: deepcell.layers.location
-    :members:
-    :undoc-members:
-    :show-inheritance:
+
+.. autosummary::
+   :toctree: _generated
+
+   Location2D
+   Location3D
 
 normalization
 -------------
-.. automodule:: deepcell.layers.normalization
-    :members:
-    :undoc-members:
-    :show-inheritance:
+
+.. autosummary::
+   :toctree: _generated
+
+   ImageNormalization2D
+   ImageNormalization3D
 
 padding
 -------
-.. automodule:: deepcell.layers.padding
-    :members:
-    :undoc-members:
-    :show-inheritance:
+
+.. autosummary::
+   :toctree: _generated
+
+   ReflectionPadding2D
+   ReflectionPadding3D
 
 pooling
 -------
-.. automodule:: deepcell.layers.pooling
-    :members:
-    :undoc-members:
-    :show-inheritance:
+
+.. autosummary::
+   :toctree: _generated
+
+   DilatedMaxPool2D
+   DilatedMaxPool3D
 
 tensor_product
 --------------
-.. automodule:: deepcell.layers.tensor_product
-    :members:
-    :undoc-members:
-    :show-inheritance:
+
+.. autosummary::
+   :toctree: _generated
+
+   TensorProduct
 
 upsample
 --------
-.. automodule:: deepcell.layers.upsample
-    :members:
-    :undoc-members:
-    :show-inheritance:
+
+.. autosummary::
+   :toctree: _generated
+
+   UpsampleLike

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,15 +13,11 @@
 #
 import os
 import sys
-import warnings
 from datetime import datetime
 from unittest import mock
 from sphinx.builders.html import StandaloneHTMLBuilder
 sys.path.insert(0, os.path.abspath('../..'))
 # sys.path.insert(0, os.path.abspath('.'))
-
-# Suppress the warnings that show up as a result of sphinx gallery generating multiple files
-warnings.filterwarnings("default", module="sphinx")
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,6 +65,7 @@ needs_sphinx = '2.3.1'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
     'sphinx.ext.coverage',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',


### PR DESCRIPTION
## What
* Adds `sphinx.ext.autosummary` and use the `.. autosummary` directed to auto-generate the docs for the custom `layers`.

## Why
* The default level of introspection prevents diving down into inherited members, where issues in the parent docstrings (from tensorflow) throw sphinx warnings/errors in this doc build.

Note - this is not the *only* solution for fixing this issue, but IMO is a relatively lightweight one that aligns with best-practices for reference docs. Note that this will turn the `deepcell.layers` page into more of a summary listing; though users can still click through to see the ref docs for each class.
