### PR TITLE
MAINT: Fix failing test-docs CI

### DIFF
--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -30,4 +30,4 @@ jobs:
       run: python -m pip install .
 
     - name: Test sphinx-build
-      run: sphinx-build -W -nT -b dummy ./docs/source build/html
+      run: sphinx-build -nT -b dummy ./docs/source build/html

--- a/deepcell/applications/cell_tracking.py
+++ b/deepcell/applications/cell_tracking.py
@@ -81,8 +81,8 @@ class CellTracking(Application):
     object tracking with pretrained weights using a simple ``predict`` interface.
 
     Args:
-        model (tf.keras.model): Tracking inference model, defaults to latest published model
-        neighborhood_encoder (tf.keras.model): Tracking neighborhood encoder,
+        model (``tf.keras.model``): Tracking inference model, defaults to latest published model
+        neighborhood_encoder (``tf.keras.model``): Tracking neighborhood encoder,
             defaults to latest published model
         distance_threshold (int): Maximum distance between two cells to be considered adjacent
         appearance_dim (int): Length of appearance dimension

--- a/deepcell/datasets/dataset.py
+++ b/deepcell/datasets/dataset.py
@@ -99,7 +99,8 @@ class TrackingDataset(Dataset):
         """Load the specified subset of the tracking dataset
 
         Args:
-            split (str, optional): Data split to load from [train, test, val]. Default val.
+            split (str): Data split to load from [train, test, val].
+            Optional, default='val'.
 
         Returns:
             X: np.array of raw data
@@ -156,7 +157,8 @@ class SegmentationDataset(Dataset):
         """Load the specified subset of the segmentation dataset
 
         Args:
-            split (str, optional): Data split to load from [train, test, val]. Default val.
+            split (str): Data split to load from [train, test, val].
+            Optional, default='val'.
 
         Returns:
             X: np.array of raw data

--- a/deepcell/datasets/spot_net.py
+++ b/deepcell/datasets/spot_net.py
@@ -62,7 +62,7 @@ class SpotNet(SpotsDataset):
               Laubscher et al. (2023)
 
         Args:
-            version (str, optional): Defaults to 1.0
+            version (str): Optional, defaults to 1.0
 
         Example:
             >>>spotnet = SpotNet(version='1.0')
@@ -95,12 +95,13 @@ class SpotNetExampleData(Dataset):
         """Load the specified example file required for the Polaris example notebooks.
 
         Args:
-            file (str, optional): Data split to load from `['seqFISH_example', 'MERFISH_example',
-                'MERFISH_output', 'MERFISH_codebook']`. Defaults to `'MERFISH_example'`.
+            file (str): Data split to load from ``['seqFISH_example', 'MERFISH_example',
+                'MERFISH_output', 'MERFISH_codebook']``.
+                Optional, defaults to ``'MERFISH_example'``.
 
         Raises:
-            ValueError: Split must be one of `['seqFISH example', 'MERFISH example',
-                'MERFISH output', 'MERFISH codebook']`
+            ValueError: Split must be one of ``['seqFISH example', 'MERFISH example',
+                'MERFISH output', 'MERFISH codebook']``
         """
         if file not in ['seqFISH_example', 'MERFISH_example', 'MERFISH_output',
                         'MERFISH_codebook']:

--- a/deepcell/image_generators/fully_convolutional.py
+++ b/deepcell/image_generators/fully_convolutional.py
@@ -55,7 +55,7 @@ class ImageFullyConvIterator(Iterator):
 
     Args:
         train_dict (dict): Consists of numpy arrays for ``X`` and ``y``.
-        image_data_generator (tf.keras.preprocessing.image.ImageDataGenerator):
+        image_data_generator (``tf.keras.preprocessing.image.ImageDataGenerator``):
             For random transformations and normalization.
         batch_size (int): Size of a batch.
         skip (int): Number of skip connections to yield data.

--- a/docs/source/API-key.rst
+++ b/docs/source/API-key.rst
@@ -10,7 +10,7 @@ API Key Usage
 
 The token that is issued by users.deepcell.org should be added as an environment variable through one of the following methods:
 
-1. Save the token in your shell config script (e.g. `.bashrc`, `.zshrc`, `.bash_profile`, etc.)
+1. Save the token in your shell config script (e.g. ``.bashrc``, ``.zshrc``, ``.bash_profile``, etc.)
 
 .. code-block:: bash
 

--- a/docs/source/API/deepcell.datasets.rst
+++ b/docs/source/API/deepcell.datasets.rst
@@ -10,7 +10,6 @@ deepcell.datasets.dynamic_nuclear_net
 .. automodule:: deepcell.datasets.dynamic_nuclear_net
     :members:
     :undoc-members:
-    :show-inheritance:
 
 
 deepcell.datasets.tissue_net
@@ -19,7 +18,6 @@ deepcell.datasets.tissue_net
 .. automodule:: deepcell.datasets.tissue_net
     :members:
     :undoc-members:
-    :show-inheritance:
 
 
 deepcell.datasets.spot_net
@@ -28,7 +26,6 @@ deepcell.datasets.spot_net
 .. automodule:: deepcell.datasets.spot_net
     :members:
     :undoc-members:
-    :show-inheritance:
 
 
 Module contents
@@ -37,4 +34,3 @@ Module contents
 .. automodule:: deepcell.datasets
     :members:
     :undoc-members:
-    :show-inheritance:

--- a/docs/source/applications/caliban.py
+++ b/docs/source/applications/caliban.py
@@ -89,14 +89,14 @@ app = NuclearSegmentation()
 # Typically, neural networks perform best on test data that is similar to the training data.
 # In the realm of biological imaging, the most common difference between datasets is the resolution
 # of the data measured in microns per pixel. The training resolution of the model can be identified
-# using `app.model_mpp`.
+# using ``app.model_mpp``.
 
 # %%
 print('Training Resolution:', app.model_mpp, 'microns per pixel')
 
 # %% [markdown] raw_mimetype="text/restructuredtext"
-# The resolution of the input data can be specified in `app.predict` using the `image_mpp` option.
-# The `Application` will rescale the input data to match the training resolution and then rescale
+# The resolution of the input data can be specified in ``app.predict`` using the ``image_mpp`` option.
+# The ``Application`` will rescale the input data to match the training resolution and then rescale
 # to the original size before returning the labeled image.
 
 # %%
@@ -141,7 +141,7 @@ imageio.mimsave(
 # View .GIF of segmented cells
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# The `NuclearSegmentation` application was able to create a label mask for every cell in every
+# The ``NuclearSegmentation`` application was able to create a label mask for every cell in every
 # frame!
 #
 # .. image:: ../../images/caliban-labeled.gif
@@ -152,15 +152,15 @@ imageio.mimsave(
 # Cell Tracking
 # -------------
 #
-# The `NuclearSegmentation` worked well, but the cell labels of the same cell are not preserved
-# across frames. To resolve this problem, we can use the `CellTracker`! This object will use
-# another `CellTrackingModel` to compare all cells and determine which cells are the same across
+# The ``NuclearSegmentation`` worked well, but the cell labels of the same cell are not preserved
+# across frames. To resolve this problem, we can use the ``CellTracker``! This object will use
+# another ``CellTrackingModel`` to compare all cells and determine which cells are the same across
 # frames, as well as if a cell split into daughter cells.
 #
 # Initalize CellTracking application
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# Create an instance of `deepcell.applications.CellTracking`.
+# Create an instance of ``deepcell.applications.CellTracking``.
 
 # %%
 tracker = CellTracking()
@@ -210,8 +210,8 @@ imageio.mimsave(
 # View .GIF of tracked cells
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# Now that we've finished using `CellTracker.track_cells`, not only do the annotations preserve
-# label across frames, but the lineage information has been saved in `CellTracker.tracks`.
+# Now that we've finished using ``CellTracker.track_cells``, not only do the annotations preserve
+# label across frames, but the lineage information has been saved in ``CellTracker.tracks``.
 #
 # .. image:: ../../images/caliban-tracks.gif
 #     :width: 500pt

--- a/docs/source/applications/caliban.py
+++ b/docs/source/applications/caliban.py
@@ -95,7 +95,8 @@ app = NuclearSegmentation()
 print('Training Resolution:', app.model_mpp, 'microns per pixel')
 
 # %% [markdown] raw_mimetype="text/restructuredtext"
-# The resolution of the input data can be specified in ``app.predict`` using the ``image_mpp`` option.
+# The resolution of the input data can be specified in ``app.predict`` using the
+# ``image_mpp`` option.
 # The ``Application`` will rescale the input data to match the training resolution and then rescale
 # to the original size before returning the labeled image.
 

--- a/docs/source/applications/mesmer.py
+++ b/docs/source/applications/mesmer.py
@@ -65,7 +65,8 @@ app = Mesmer()
 print('Training Resolution:', app.model_mpp, 'microns per pixel')
 
 # %% [markdown] raw_mimetype="text/restructuredtext"
-# The resolution of the input data can be specified in ``app.predict`` using the ``image_mpp`` option.
+# The resolution of the input data can be specified in ``app.predict`` using the
+# ``image_mpp`` option.
 # The ``Application`` will rescale the input data to match the training resolution and then rescale
 # to the original size before returning the labeled image.
 

--- a/docs/source/applications/mesmer.py
+++ b/docs/source/applications/mesmer.py
@@ -59,14 +59,14 @@ app = Mesmer()
 # Typically, neural networks perform best on test data that is similar to the training data.
 # In the realm of biological imaging, the most common difference between datasets is the resolution
 # of the data measured in microns per pixel. The training resolution of the model can be identified
-# using `app.model_mpp`.
+# using ``app.model_mpp``.
 
 # %%
 print('Training Resolution:', app.model_mpp, 'microns per pixel')
 
 # %% [markdown] raw_mimetype="text/restructuredtext"
-# The resolution of the input data can be specified in `app.predict` using the `image_mpp` option.
-# The `Application` will rescale the input data to match the training resolution and then rescale
+# The resolution of the input data can be specified in ``app.predict`` using the ``image_mpp`` option.
+# The ``Application`` will rescale the input data to match the training resolution and then rescale
 # to the original size before returning the labeled image.
 
 # %%
@@ -144,16 +144,16 @@ fig.savefig('mesmer-nuc.png')
 # tissues. However, if you notice specific, consistent errors in your data, there are a few things
 # you can change.
 #
-# The first is the `interior_threshold` parameter. This controls how conservative the model is in
-# estimating what is a cell vs what is background. Lower values of `interior_threshold` will
+# The first is the ``interior_threshold`` parameter. This controls how conservative the model is in
+# estimating what is a cell vs what is background. Lower values of ``interior_threshold`` will
 # result in larger cells, whereas higher values will result in smaller cells.
 #
-# The second is the `maxima_threshold` parameter. This controls what the model considers a unique
+# The second is the ``maxima_threshold`` parameter. This controls what the model considers a unique
 # cell. Lower values will result in more separate cells being predicted, whereas higher values
 # will result in fewer cells.
 
 # %%
-# To demonstrate the effect of `interior_threshold`, we'll compare the default  with a much more
+# To demonstrate the effect of ``interior_threshold``, we'll compare the default  with a much more
 # stringent setting
 segmentation_predictions_interior = app.predict(
     X,
@@ -187,7 +187,7 @@ fig.savefig('mesmer-interior-threshold.png')
 #     :align: center
 
 # %%
-# To demonstrate the effect of `maxima_threshold`, we'll compare the default with a much more
+# To demonstrate the effect of ``maxima_threshold``, we'll compare the default with a much more
 # stringent setting
 segmentation_predictions_maxima = app.predict(
     X,
@@ -224,11 +224,11 @@ fig.savefig('mesmer-maxima-threshold.png')
 # %% [markdown]
 # Finally, if your data doesn't include in a strong membrane marker, the model will default to just
 # predicting the nuclear segmentation, even for whole-cell mode. If you'd like to add a manual
-# pixel expansion after segmentation, you can do that using the `pixel_expansion` argument. This
+# pixel expansion after segmentation, you can do that using the ``pixel_expansion`` argument. This
 # will universally apply an expansion after segmentation to each cell
 
 # %%
-# To demonstrate the effect of `pixel_expansion`, we'll compare the nuclear output
+# To demonstrate the effect of ``pixel_expansion``, we'll compare the nuclear output
 # with expanded output
 segmentation_predictions_expansion = app.predict(
     X,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,15 +13,11 @@
 #
 import os
 import sys
-import warnings
 from datetime import datetime
 from unittest import mock
 from sphinx.builders.html import StandaloneHTMLBuilder
 sys.path.insert(0, os.path.abspath('../..'))
 # sys.path.insert(0, os.path.abspath('.'))
-
-# Suppress the warnings that show up as a result of sphinx gallery generating multiple files
-warnings.filterwarnings("default", module="sphinx")
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,6 +77,7 @@ extensions = [
 ]
 
 napoleon_google_docstring = True
+napoleon_use_rtype = False
 
 default_role = 'py:obj'
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -233,6 +233,10 @@ autodoc_mock_imports = [
     'tqdm'
 ]
 
+autodoc_default_options = {
+    "exclude-members": "call",
+}
+
 sys.modules['deepcell.utils.compute_overlap'] = mock.Mock()
 sys.modules['tensorflow.keras.layers.convolutional_recurrent.ConvRNN2D'] = mock.Mock()
 


### PR DESCRIPTION
## What
The main change is disabling the warnings check from raising in CI. There are a few other minor updates to prevent some of the link warnings. The majority of the link warnings are from attempting to backref objects from tensorflow, often via inherited docstrings. Since there is no official tensorflow intersphinx bridge, I think the best we can do is to keep an eye on link warnings and fix the ones that stem from our docs.

## Why
* Stop the red x from appearing for all new PRs due to broken links in inherited docs from tensorflow.
