### PR TITLE
REL: bump patch for 0.12.9 release.

### DIFF
--- a/deepcell/_version.py
+++ b/deepcell/_version.py
@@ -27,7 +27,7 @@
 __title__ = 'DeepCell'
 __description__ = 'Deep learning for single cell image segmentation'
 __url__ = 'https://github.com/vanvalenlab/deepcell-tf'
-__version__ = '0.12.8'
+__version__ = '0.12.9'
 __download_url__ = f'{__url__}/tarball/{__version__}'
 __author__ = 'The Van Valen Lab'
 __author_email__ = 'vanvalen@caltech.edu'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,7 @@ copyright = (f'2016-{datetime.now().year}, Van Valen Lab at the '
 author = 'Van Valen Lab at Caltech'
 
 # The short X.Y.Z version - overriden by rtd
-version = release = '0.12.8'
+version = release = '0.12.9'
 
 import subprocess
 try:


### PR DESCRIPTION
0.12.9 release - bug fix for authenticated model downloads in fresh directory tree.
