### PR TITLE
Rm pins from doc dependencies.

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,11 +1,11 @@
-m2r2<0.3.3 # Pinned to avoid docutils conflict with sphinx-rtd-theme
-docutils~=0.16.0
+m2r2
+docutils
 mock
-Sphinx<6
+Sphinx
 docutils
 ipython
 nbsphinx
 nbsphinx-link
-sphinx-rtd-theme>=0.5.2 # Pinned to fix list rendering issue
+sphinx-rtd-theme>=0.5.2
 sphinx-gallery
 pillow


### PR DESCRIPTION
@msschwartz21 IIRC the motivation for many of the pins was issues with list rendering in the datasets and applications galleries. They seem to be resolved locally, if you could double-check the dock preview below and confirm these look as expected then I think we're good to go!

## What
* Moving to latest versions of doc deps seems to resolve the issues that motivated the pins in the first place.

## Why
* Software maintenance best-practices
