### PR TITLE
General maintenance to make CI happy

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,4 +15,4 @@ jobs:
           python -m pip install ruff
           python -m pip list
       - name: Run ruff
-        run: ruff --output-format=github .
+        run: ruff check --output-format=github .

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -92,9 +92,7 @@ jobs:
 
       - name: List dependencies
         run: |
-          # TODO: The numpy upgrade can be removed when transitive deps all
-          # support 1.24
-          python -m pip install --upgrade numpy
+          python -m pip install --upgrade numpy\<2
           python -m pip list
       
       - name: Run tests

--- a/deepcell/datasets/dynamic_nuclear_net.py
+++ b/deepcell/datasets/dynamic_nuclear_net.py
@@ -62,8 +62,8 @@ class DynamicNuclearNetSegmentation(SegmentationDataset):
             version (str, optional): Default 1.0
 
         Example:
-            >>>dnn_seg = DynamicNuclearNetSegmentation(version='1.0')
-            >>>X_val, y_val, meta_val = dnn_seg.load_data(split='val')
+            >>> dnn_seg = DynamicNuclearNetSegmentation(version='1.0')  # doctest: +SKIP
+            >>> X_val, y_val, meta_val = dnn_seg.load_data(split='val')  # doctest: +SKIP
 
         Raises:
             ValueError: Requested version is not included in available versions
@@ -102,9 +102,9 @@ class DynamicNuclearNetTracking(TrackingDataset):
             version (str, optional): Default 1.0
 
         Example:
-            >>>dnn_trk = DynamicNuclearNetTracking(version='1.0')
-            >>>X_val, y_val, lineage_val = dnn_trk.load_data(split='val')
-            >>>data_source = dnn_trk.load_source_metadata()
+            >>> dnn_trk = DynamicNuclearNetTracking(version='1.0')  # doctest: +SKIP
+            >>> X_val, y_val, lineage_val = dnn_trk.load_data(split='val')  # doctest: +SKIP
+            >>> data_source = dnn_trk.load_source_metadata()  # doctest: +SKIP
 
         Raises:
             ValueError: Requested version is not included in available versions

--- a/deepcell/datasets/spot_net.py
+++ b/deepcell/datasets/spot_net.py
@@ -65,8 +65,8 @@ class SpotNet(SpotsDataset):
             version (str, optional): Defaults to 1.0
 
         Example:
-            >>>spotnet = SpotNet(version='1.0')
-            >>>X_val, y_val = spotnet.load_data(split='val')
+            >>> spotnet = SpotNet(version='1.0')  # doctest: +SKIP
+            >>> X_val, y_val = spotnet.load_data(split='val')  # doctest: +SKIP
 
         Raises:
             ValueError: Requested version is not included in available versions

--- a/deepcell/datasets/tissue_net.py
+++ b/deepcell/datasets/tissue_net.py
@@ -74,8 +74,8 @@ class TissueNet(SegmentationDataset):
             version (:obj:`str`, optional): Default 1.1
 
         Example:
-            >>>tissuenet = TissueNet(version='1.1')
-            >>>X_val, y_val, meta_val = tissuenet.load_data(split='val')
+            >>> tissuenet = TissueNet(version='1.1')  # doctest: +SKIP
+            >>> X_val, y_val, meta_val = tissuenet.load_data(split='val')  # doctest: +SKIP
 
         Raises:
             ValueError: Requested version is not included in available versions

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -6,6 +6,7 @@ docutils
 ipython
 nbsphinx
 nbsphinx-link
+lxml_html_clean  # Required for nbsphinx
 sphinx-rtd-theme>=0.5.2
 sphinx-gallery
 pillow

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,7 +94,7 @@ source_suffix = ['.rst', '.md']
 # source_suffix = '.rst'
 
 # Ignore warning:
-suppress_warnings = ['autosectionlabel.*']
+suppress_warnings = ['autosectionlabel.*', "config.cache"]
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -224,7 +224,6 @@ autodoc_mock_imports = [
     'keras',
     'spektral',
     'scipy',
-    'numpy',
     'sklearn',
     'skimage',
     'cython',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,15 +7,15 @@ requires = [
 ]
 
 [tool.ruff]
-select = ["E", "F", "UP"]
+lint.select = ["E", "F", "UP"]
 line-length = 99
 
 target-version="py37"
 
 # Suppress remaining bound lambda warnings
-ignore = ["E731"]
+lint.ignore = ["E731"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]
 "docs/source/conf.py" = ["E402", "E501"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,11 @@ line-length = 99
 
 target-version="py37"
 
-# Suppress remaining bound lambda warnings
-lint.ignore = ["E731"]
+# Suppress ruff warnings
+lint.ignore = [
+    "E731",  # Unbound lambda
+    "UP032",  # Use f-string instead of .format
+]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ target-version="py37"
 # Suppress ruff warnings
 lint.ignore = [
     "E731",  # Unbound lambda
+    "UP031",  # Use f-string instead of % formating
     "UP032",  # Use f-string instead of .format
 ]
 


### PR DESCRIPTION
## What
Some general maintenance to deal with failures cropping up from dependencies either updating or falling out-of-sync with one another

### Documentation

- Force suppression of warnings from `nbsphinx` which break doc tests. Note: nbsphinx breaks sphinx caching (hence the warning)
- Add doc dependencies that nbsphinx needs but are not specified in their deps list
- Modify mocking to fix broken access of numpy features during doc build. This means the docs will no longer build without numpy installed

### Linting

The newest version of ruff has checks for non-f-string based string formatting. I've silenced these for now - there are much more important issues than string formatting.

- Updated ruff configuration and invocation to match latest release.

## Why
* General maintenance, keep CI green
