### PR TITLE
Bump copyright year to 2024.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ docker run --gpus '"device=0"' -it \
 
 ## Copyright
 
-Copyright © 2016-2023 [The Van Valen Lab](http://www.vanvalen.caltech.edu/) at the California Institute of Technology (Caltech), with support from the Shurl and Kay Curci Foundation, Google Research Cloud, the Paul Allen Family Foundation, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+Copyright © 2016-2024 [The Van Valen Lab](http://www.vanvalen.caltech.edu/) at the California Institute of Technology (Caltech), with support from the Shurl and Kay Curci Foundation, Google Research Cloud, the Paul Allen Family Foundation, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 All rights reserved.
 
 ## License

--- a/deepcell/__init__.py
+++ b/deepcell/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/_version.py
+++ b/deepcell/_version.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.
@@ -32,5 +32,5 @@ __download_url__ = f'{__url__}/tarball/{__version__}'
 __author__ = 'The Van Valen Lab'
 __author_email__ = 'vanvalen@caltech.edu'
 __license__ = 'LICENSE'
-__copyright__ = 'Copyright 2016-2023 The Van Valen Lab at the ' \
+__copyright__ = 'Copyright 2016-2024 The Van Valen Lab at the ' \
     'California Institute of Technology (Caltech)'

--- a/deepcell/applications/__init__.py
+++ b/deepcell/applications/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/applications/application.py
+++ b/deepcell/applications/application.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/applications/application_test.py
+++ b/deepcell/applications/application_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/applications/cell_tracking.py
+++ b/deepcell/applications/cell_tracking.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/applications/cell_tracking_test.py
+++ b/deepcell/applications/cell_tracking_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/applications/cytoplasm_segmentation.py
+++ b/deepcell/applications/cytoplasm_segmentation.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/applications/cytoplasm_segmentation_test.py
+++ b/deepcell/applications/cytoplasm_segmentation_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/applications/label_detection.py
+++ b/deepcell/applications/label_detection.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/applications/label_detection_test.py
+++ b/deepcell/applications/label_detection_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/applications/mesmer.py
+++ b/deepcell/applications/mesmer.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/applications/mesmer_test.py
+++ b/deepcell/applications/mesmer_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/applications/multiplex_segmentation.py
+++ b/deepcell/applications/multiplex_segmentation.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/applications/nuclear_segmentation.py
+++ b/deepcell/applications/nuclear_segmentation.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/applications/nuclear_segmentation_test.py
+++ b/deepcell/applications/nuclear_segmentation_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/applications/scale_detection.py
+++ b/deepcell/applications/scale_detection.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/applications/scale_detection_test.py
+++ b/deepcell/applications/scale_detection_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/callbacks.py
+++ b/deepcell/callbacks.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/callbacks_test.py
+++ b/deepcell/callbacks_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/data/__init__.py
+++ b/deepcell/data/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/data/tracking.py
+++ b/deepcell/data/tracking.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/data/tracking_test.py
+++ b/deepcell/data/tracking_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/datasets/__init__.py
+++ b/deepcell/datasets/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/datasets/dataset.py
+++ b/deepcell/datasets/dataset.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/datasets/dataset_test.py
+++ b/deepcell/datasets/dataset_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/datasets/dynamic_nuclear_net.py
+++ b/deepcell/datasets/dynamic_nuclear_net.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/datasets/spot_net.py
+++ b/deepcell/datasets/spot_net.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/datasets/tissue_net.py
+++ b/deepcell/datasets/tissue_net.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/image_generators/__init__.py
+++ b/deepcell/image_generators/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/image_generators/cropping.py
+++ b/deepcell/image_generators/cropping.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/image_generators/fully_convolutional.py
+++ b/deepcell/image_generators/fully_convolutional.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/image_generators/image_generators_test.py
+++ b/deepcell/image_generators/image_generators_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/image_generators/sample.py
+++ b/deepcell/image_generators/sample.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/image_generators/scale.py
+++ b/deepcell/image_generators/scale.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/image_generators/semantic.py
+++ b/deepcell/image_generators/semantic.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/image_generators/tracking.py
+++ b/deepcell/image_generators/tracking.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/layers/__init__.py
+++ b/deepcell/layers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/layers/location.py
+++ b/deepcell/layers/location.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/layers/location_test.py
+++ b/deepcell/layers/location_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/layers/normalization.py
+++ b/deepcell/layers/normalization.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/layers/normalization_test.py
+++ b/deepcell/layers/normalization_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/layers/padding.py
+++ b/deepcell/layers/padding.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/layers/padding_test.py
+++ b/deepcell/layers/padding_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/layers/pooling.py
+++ b/deepcell/layers/pooling.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/layers/pooling_test.py
+++ b/deepcell/layers/pooling_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/layers/temporal.py
+++ b/deepcell/layers/temporal.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/layers/temporal_test.py
+++ b/deepcell/layers/temporal_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/layers/tensor_product.py
+++ b/deepcell/layers/tensor_product.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/layers/tensor_product_test.py
+++ b/deepcell/layers/tensor_product_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/layers/upsample.py
+++ b/deepcell/layers/upsample.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/layers/upsample_test.py
+++ b/deepcell/layers/upsample_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/losses.py
+++ b/deepcell/losses.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/losses_test.py
+++ b/deepcell/losses_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/metrics.py
+++ b/deepcell/metrics.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/model_zoo/__init__.py
+++ b/deepcell/model_zoo/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/model_zoo/featurenet.py
+++ b/deepcell/model_zoo/featurenet.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/model_zoo/featurenet_test.py
+++ b/deepcell/model_zoo/featurenet_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/model_zoo/fpn.py
+++ b/deepcell/model_zoo/fpn.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/model_zoo/panopticnet.py
+++ b/deepcell/model_zoo/panopticnet.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/model_zoo/panopticnet_test.py
+++ b/deepcell/model_zoo/panopticnet_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/model_zoo/tracking.py
+++ b/deepcell/model_zoo/tracking.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/model_zoo/tracking_test.py
+++ b/deepcell/model_zoo/tracking_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/running.py
+++ b/deepcell/running.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/running_test.py
+++ b/deepcell/running_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/tracking.py
+++ b/deepcell/tracking.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/training.py
+++ b/deepcell/training.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/__init__.py
+++ b/deepcell/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/backbone_utils.py
+++ b/deepcell/utils/backbone_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/backbone_utils_test.py
+++ b/deepcell/utils/backbone_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/data_utils.py
+++ b/deepcell/utils/data_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/data_utils_test.py
+++ b/deepcell/utils/data_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/export_utils.py
+++ b/deepcell/utils/export_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/io_utils.py
+++ b/deepcell/utils/io_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/io_utils_test.py
+++ b/deepcell/utils/io_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/misc_utils.py
+++ b/deepcell/utils/misc_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/misc_utils_test.py
+++ b/deepcell/utils/misc_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/plot_utils.py
+++ b/deepcell/utils/plot_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/plot_utils_test.py
+++ b/deepcell/utils/plot_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/tfrecord_utils.py
+++ b/deepcell/utils/tfrecord_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/tfrecord_utils_test.py
+++ b/deepcell/utils/tfrecord_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/tracking_utils.py
+++ b/deepcell/utils/tracking_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 David Van Valen at California Institute of Technology
+# Copyright 2016-2024 David Van Valen at California Institute of Technology
 # (Caltech), with support from the Paul Allen Family Foundation, Google,
 # & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/train_utils.py
+++ b/deepcell/utils/train_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/train_utils_test.py
+++ b/deepcell/utils/train_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/transform_utils.py
+++ b/deepcell/utils/transform_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/deepcell/utils/transform_utils_test.py
+++ b/deepcell/utils/transform_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Van Valen Lab at the California Institute of
+# Copyright 2016-2024 The Van Valen Lab at the California Institute of
 # Technology (Caltech), with support from the Paul Allen Family Foundation,
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.


### PR DESCRIPTION
Bumps copyright from 2023->2024

Done in its own PR so that the commit sha can be added to .git-blame-ignore-revs after squash-merging.