### PR TITLE
DOC: Update application examples with from_version

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -119,6 +119,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Attempt to free up space in workflow container
+    - name: Delete tools folder
+      run: rm -rf /opt/hostedtoolcache
+
     - uses: actions/checkout@v4
 
     - name: Set up QEMU

--- a/docs/source/applications/caliban.py
+++ b/docs/source/applications/caliban.py
@@ -51,8 +51,8 @@ def plot(im):
     plt.title('Raw Image Data')
 
     fig.canvas.draw()  # draw the canvas, cache the renderer
-    image = np.frombuffer(fig.canvas.tostring_rgb(), dtype='uint8')
-    image = image.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+    image = np.frombuffer(fig.canvas.buffer_rgba(), dtype='uint8')
+    image = image.reshape(fig.canvas.get_width_height()[::-1] + (4,))
 
     plt.close(fig)
 
@@ -126,8 +126,8 @@ def plot(x, y):
     ax[1].axis('off')
 
     fig.canvas.draw()  # draw the canvas, cache the renderer
-    image = np.frombuffer(fig.canvas.tostring_rgb(), dtype='uint8')
-    image = image.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+    image = np.frombuffer(fig.canvas.buffer_rgba(), dtype='uint8')
+    image = image.reshape(fig.canvas.get_width_height()[::-1] + (4,))
     plt.close(fig)
 
     return image
@@ -195,8 +195,8 @@ def plot(x, y):
     ax[1].axis('off')
 
     fig.canvas.draw()  # draw the canvas, cache the renderer
-    image = np.frombuffer(fig.canvas.tostring_rgb(), dtype='uint8')
-    image = image.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+    image = np.frombuffer(fig.canvas.buffer_rgba(), dtype='uint8')
+    image = image.reshape(fig.canvas.get_width_height()[::-1] + (4,))
     plt.close(fig)
 
     return image

--- a/docs/source/applications/caliban.py
+++ b/docs/source/applications/caliban.py
@@ -80,7 +80,7 @@ imageio.mimsave('caliban-raw.gif', [plot(x[i, ..., 0]) for i in range(x.shape[0]
 # `documentation <https://deepcell.readthedocs.io/en/master/API/deepcell.applications.html>`_.
 
 # %%
-app = NuclearSegmentation()
+app = NuclearSegmentation.from_version("1.1")
 
 # %% [markdown] raw_mimetype="text/restructuredtext"
 # Use the application to generate labeled images
@@ -164,7 +164,7 @@ imageio.mimsave(
 # Create an instance of ``deepcell.applications.CellTracking``.
 
 # %%
-tracker = CellTracking()
+tracker = CellTracking.from_version("1.1")
 
 # %% [markdown]
 # Track the cells

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,15 @@ requires = [
 ]
 
 [tool.ruff]
-lint.select = ["E", "F", "UP"]
 line-length = 99
-
 target-version="py37"
 
+
+[tool.ruff.lint]
+exclude = ["*.ipynb"]
+select = ["E", "F", "UP"]
 # Suppress ruff warnings
-lint.ignore = [
+ignore = [
     "E731",  # Unbound lambda
     "UP031",  # Use f-string instead of % formating
     "UP032",  # Use f-string instead of .format


### PR DESCRIPTION
## What
* #721 modified the interface for model loading to account for the existence of multiple versions. This PR updates the cell tracking gallery example to use the new API.

## Why
* Fix (at least a portion) of the docs
* Also replaces deprecated matplotlib API with recommended alternative.

Addresses #728 

--- Additional updates

This PR also includes a couple maintenance updates - namely improvements to the linter configuration and making the docker testing workflow more robust by freeing up virtual diskspace.